### PR TITLE
chore: update all repository references

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
 <!--
 Please read the contributing guide before raising a pull request.
-https://github.com/octokit/Octokit.Webhooks/blob/main/CONTRIBUTING.md
+https://github.com/octokit/webhooks.net/blob/main/CONTRIBUTING.md
 -->

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,7 +59,7 @@ jobs:
     if: github.ref == 'refs/heads/main' || github.event_name == 'release'
     environment:
       name: 'GitHub Packages'
-      url: https://github.com/JamieMagee/Octokit.Webhooks/packages
+      url: https://github.com/octokit/webhooks.net/packages
     permissions:
       packages: write
     runs-on: windows-latest
@@ -69,7 +69,7 @@ jobs:
         with:
           name: 'windows-latest'
       - name: 'Dotnet NuGet Add Source'
-        run: dotnet nuget add source https://nuget.pkg.github.com/JamieMagee/index.json --name GitHub --username JamieMagee --password ${{secrets.GITHUB_TOKEN}}
+        run: dotnet nuget add source https://nuget.pkg.github.com/octokit/index.json --name GitHub --username octokit --password ${{secrets.GITHUB_TOKEN}}
         shell: pwsh
       - name: 'Dotnet NuGet Push'
         run: dotnet nuget push .\*.nupkg --api-key ${{ github.token }} --source GitHub --skip-duplicate

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ Thank you 💖
 
 Before you create a new Issue:
 
-1. Please make sure there is no [open issue](https://github.com/octokit/Octokit.Webhooks/issues) yet.
+1. Please make sure there is no [open issue](https://github.com/octokit/webhooks.net/issues) yet.
 2. If it is a bug report, include the steps to reproduce the issue, and please create a reproducible test case on [dotnetfiddle.com](https://dotnetfiddle.net/).
 3. If it is a feature request, please share the motivation for the new feature, what alternatives you tried, and how you would implement it.
 4. Please include links to the corresponding GitHub documentation.
@@ -23,8 +23,8 @@ First, fork the repository.
 Set up the repository locally. Replace `<your account name>` with the name of the account you forked to.
 
 ```shell
-git clone https://github.com/<your account name>/Octokit.Webhooks.git
-cd Octokit.Webhooks
+git clone https://github.com/<your account name>/webhooks.net.git
+cd webhooks.net
 dotnet tool restore
 dotnet cake --target=Build
 ```
@@ -39,5 +39,5 @@ dotnet cake --target=Test
 
 - Create a new branch locally.
 - Make your changes in that branch and push them to your fork
-- Submit a pull request from your topic branch to the main branch on the `octokit/Octokit.Webhooks` repository.
+- Submit a pull request from your topic branch to the main branch on the `octokit/webhooks.net` repository.
 - Be sure to tag any issues your pull request is taking care of / contributing to. Adding "Closes #123" to a pull request description will automatically close the issue once the pull request is merged in.

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -14,11 +14,11 @@
     <Copyright>Copyright © Octokit Contributors</Copyright>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <PackageProjectUrl>https://github.com/JamieMagee/Octokit.Webhooks</PackageProjectUrl>
+    <PackageProjectUrl>https://github.com/octokit/webhooks.net</PackageProjectUrl>
     <PackageIcon>Icon.png</PackageIcon>
-    <RepositoryUrl>https://github.com/JamieMagee/Octokit.Webhooks.git</RepositoryUrl>
+    <RepositoryUrl>https://github.com/octokit/webhooks.net.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <PackageReleaseNotes>https://github.com/JamieMagee/Octokit.Webhooks/releases</PackageReleaseNotes>
+    <PackageReleaseNotes>https://github.com/octokit/webhooks.net/releases</PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup Label="Package References">

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Octokit.Webhooks
 
-![GitHub Workflow Status](https://img.shields.io/github/workflow/status/JamieMagee/Octokit.Webhooks/Build?style=for-the-badge)
-![Octokit.Webhooks NuGet Package Version](https://img.shields.io/nuget/v/Octokit.Webhooks?style=for-the-badge)
-![Octokit.Webhooks NuGet Package Downloads](https://img.shields.io/nuget/dt/Octokit.Webhooks?style=for-the-badge)
+[![GitHub Workflow Status](https://img.shields.io/github/workflow/status/octokit/webhooks.net/Build?style=for-the-badge)](https://github.com/octokit/webhooks.net/actions/workflows/build.yml?query=branch%3Amain)
+[![Octokit.Webhooks NuGet Package Version](https://img.shields.io/nuget/v/Octokit.Webhooks?style=for-the-badge)](https://www.nuget.org/packages/Octokit.Webhooks/)
+[![Octokit.Webhooks NuGet Package Downloads](https://img.shields.io/nuget/dt/Octokit.Webhooks?style=for-the-badge)](https://www.nuget.org/packages/Octokit.Webhooks/)
 ![Stability - Experimental](https://img.shields.io/badge/stability-experimental-orange?style=for-the-badge)
 
 Libraries to handle GitHub Webhooks in .NET applications.


### PR DESCRIPTION
This repository previously lived under my personal GitHub account. Now that it is under to octokit organization all references need to be updated.

<!--
Please read the contributing guide before raising a pull request.
https://github.com/octokit/Octokit.Webhooks/blob/main/CONTRIBUTING.md
-->
