### PR TITLE
fix: migrate from int to long

### DIFF
--- a/src/Octokit.Webhooks/Events/MetaEvent.cs
+++ b/src/Octokit.Webhooks/Events/MetaEvent.cs
@@ -11,7 +11,7 @@
     public abstract record MetaEvent : WebhookEvent
     {
         [JsonPropertyName("hook_id")]
-        public int HookId { get; init; }
+        public long HookId { get; init; }
 
         [JsonPropertyName("hook")]
         public Hook Hook { get; init; } = null!;

--- a/src/Octokit.Webhooks/Events/PageBuildEvent.cs
+++ b/src/Octokit.Webhooks/Events/PageBuildEvent.cs
@@ -9,7 +9,7 @@
     public sealed record PageBuildEvent : WebhookEvent
     {
         [JsonPropertyName("id")]
-        public int Id { get; init; }
+        public long Id { get; init; }
 
         [JsonPropertyName("build")]
         public Build Build { get; init; } = null!;

--- a/src/Octokit.Webhooks/Events/PingEvent.cs
+++ b/src/Octokit.Webhooks/Events/PingEvent.cs
@@ -12,7 +12,7 @@ namespace Octokit.Webhooks.Events
         public string Zen { get; init; } = null!;
 
         [JsonPropertyName("hook_id")]
-        public int HookId { get; init; }
+        public long HookId { get; init; }
 
         [JsonPropertyName("hook")]
         public Hook Hook { get; init; } = null!;

--- a/src/Octokit.Webhooks/Events/PullRequestEvent.cs
+++ b/src/Octokit.Webhooks/Events/PullRequestEvent.cs
@@ -10,7 +10,7 @@
     public abstract record PullRequestEvent : WebhookEvent
     {
         [JsonPropertyName("number")]
-        public int Number { get; init; }
+        public long Number { get; init; }
 
         [JsonPropertyName("pull_request")]
         public Models.PullRequestEvent.PullRequest PullRequest { get; init; } = null!;

--- a/src/Octokit.Webhooks/Events/StatusEvent.cs
+++ b/src/Octokit.Webhooks/Events/StatusEvent.cs
@@ -10,7 +10,7 @@
     public sealed record StatusEvent : WebhookEvent
     {
         [JsonPropertyName("id")]
-        public int Id { get; init; }
+        public long Id { get; init; }
 
         [JsonPropertyName("sha")]
         public string Sha { get; init; } = null!;

--- a/src/Octokit.Webhooks/Models/App.cs
+++ b/src/Octokit.Webhooks/Models/App.cs
@@ -8,7 +8,7 @@
     public sealed record App
     {
         [JsonPropertyName("id")]
-        public int Id { get; init; }
+        public long Id { get; init; }
 
         [JsonPropertyName("slug")]
         public string? Slug { get; init; }

--- a/src/Octokit.Webhooks/Models/BranchProtectionRule.cs
+++ b/src/Octokit.Webhooks/Models/BranchProtectionRule.cs
@@ -8,10 +8,10 @@
     public sealed record BranchProtectionRule
     {
         [JsonPropertyName("id")]
-        public int Id { get; init; }
+        public long Id { get; init; }
 
         [JsonPropertyName("repository_id")]
-        public int RepositoryId { get; init; }
+        public long RepositoryId { get; init; }
 
         [JsonPropertyName("name")]
         public string Name { get; init; } = null!;
@@ -59,7 +59,7 @@
         public bool RequireCodeOwnerReview { get; init; }
 
         [JsonPropertyName("required_approving_review_count")]
-        public int RequiredApprovingReviewCount { get; init; }
+        public long RequiredApprovingReviewCount { get; init; }
 
         [JsonPropertyName("required_conversation_resolution_level")]
         public EnforcementLevel RequiredConversationResolutionLevel { get; init; }

--- a/src/Octokit.Webhooks/Models/CheckRunEvent/CheckRun.cs
+++ b/src/Octokit.Webhooks/Models/CheckRunEvent/CheckRun.cs
@@ -8,7 +8,7 @@
     public sealed record CheckRun
     {
         [JsonPropertyName("id")]
-        public int Id { get; init; }
+        public long Id { get; init; }
 
         [JsonPropertyName("node_id")]
         public string NodeId { get; init; } = null!;

--- a/src/Octokit.Webhooks/Models/CheckRunEvent/CheckRunOutput.cs
+++ b/src/Octokit.Webhooks/Models/CheckRunEvent/CheckRunOutput.cs
@@ -16,7 +16,7 @@
         public string? Text { get; init; }
 
         [JsonPropertyName("annotations_count")]
-        public int AnnotationsCount { get; init; }
+        public long AnnotationsCount { get; init; }
 
         [JsonPropertyName("annotations_url")]
         public string AnnotationsUrl { get; init; } = null!;

--- a/src/Octokit.Webhooks/Models/CheckRunEvent/CheckRunPullRequest.cs
+++ b/src/Octokit.Webhooks/Models/CheckRunEvent/CheckRunPullRequest.cs
@@ -10,10 +10,10 @@
         public string Url { get; init; } = null!;
 
         [JsonPropertyName("id")]
-        public int Id { get; init; }
+        public long Id { get; init; }
 
         [JsonPropertyName("number")]
-        public int Number { get; init; }
+        public long Number { get; init; }
 
         [JsonPropertyName("head")]
         public CheckRunPullRequestHead Head { get; init; } = null!;

--- a/src/Octokit.Webhooks/Models/CheckRunEvent/CheckSuite.cs
+++ b/src/Octokit.Webhooks/Models/CheckRunEvent/CheckSuite.cs
@@ -8,7 +8,7 @@
     public sealed record CheckSuite
     {
         [JsonPropertyName("id")]
-        public int Id { get; init; }
+        public long Id { get; init; }
 
         [JsonPropertyName("node_id")]
         public string? NodeId { get; init; }

--- a/src/Octokit.Webhooks/Models/CheckRunEvent/Deployment.cs
+++ b/src/Octokit.Webhooks/Models/CheckRunEvent/Deployment.cs
@@ -10,7 +10,7 @@
         public string Url { get; init; } = null!;
 
         [JsonPropertyName("id")]
-        public int Id { get; init; }
+        public long Id { get; init; }
 
         [JsonPropertyName("node_id")]
         public string NodeId { get; init; } = null!;

--- a/src/Octokit.Webhooks/Models/CheckSuiteEvent/CheckSuite.cs
+++ b/src/Octokit.Webhooks/Models/CheckSuiteEvent/CheckSuite.cs
@@ -9,7 +9,7 @@
     public sealed record CheckSuite
     {
         [JsonPropertyName("id")]
-        public int Id { get; init; }
+        public long Id { get; init; }
 
         [JsonPropertyName("node_id")]
         public string? NodeId { get; init; }
@@ -48,7 +48,7 @@
         public string UpdatedAt { get; init; } = null!;
 
         [JsonPropertyName("latest_check_runs_count")]
-        public int LatestCheckRunsCount { get; init; }
+        public long LatestCheckRunsCount { get; init; }
 
         [JsonPropertyName("check_runs_url")]
         public string CheckRunsUrl { get; init; } = null!;

--- a/src/Octokit.Webhooks/Models/CodeScanningAlertEvent/Alert.cs
+++ b/src/Octokit.Webhooks/Models/CodeScanningAlertEvent/Alert.cs
@@ -8,7 +8,7 @@
     public sealed record Alert
     {
         [JsonPropertyName("number")]
-        public int Number { get; init; }
+        public long Number { get; init; }
 
         [JsonPropertyName("created_at")]
         public string CreatedAt { get; init; } = null!;

--- a/src/Octokit.Webhooks/Models/CommitCommentEvent/Comment.cs
+++ b/src/Octokit.Webhooks/Models/CommitCommentEvent/Comment.cs
@@ -13,7 +13,7 @@
         public string HtmlUrl { get; init; } = null!;
 
         [JsonPropertyName("id")]
-        public int Id { get; init; }
+        public long Id { get; init; }
 
         [JsonPropertyName("node_id")]
         public string NodeId { get; init; } = null!;

--- a/src/Octokit.Webhooks/Models/ContentReferenceEvent/ContentReference.cs
+++ b/src/Octokit.Webhooks/Models/ContentReferenceEvent/ContentReference.cs
@@ -7,7 +7,7 @@
     public sealed record ContentReference
     {
         [JsonPropertyName("id")]
-        public int Id { get; init; }
+        public long Id { get; init; }
 
         [JsonPropertyName("node_id")]
         public string NodeId { get; init; } = null!;

--- a/src/Octokit.Webhooks/Models/DeployKeyEvent/DeployKey.cs
+++ b/src/Octokit.Webhooks/Models/DeployKeyEvent/DeployKey.cs
@@ -7,7 +7,7 @@
     public sealed record DeployKey
     {
         [JsonPropertyName("id")]
-        public int Id { get; init; }
+        public long Id { get; init; }
 
         [JsonPropertyName("key")]
         public string Key { get; init; } = null!;

--- a/src/Octokit.Webhooks/Models/DeploymentEvent/Deployment.cs
+++ b/src/Octokit.Webhooks/Models/DeploymentEvent/Deployment.cs
@@ -10,7 +10,7 @@
         public string Url { get; init; } = null!;
 
         [JsonPropertyName("id")]
-        public int Id { get; init; }
+        public long Id { get; init; }
 
         [JsonPropertyName("node_id")]
         public string NodeId { get; init; } = null!;

--- a/src/Octokit.Webhooks/Models/DeploymentStatusEvent/Deployment.cs
+++ b/src/Octokit.Webhooks/Models/DeploymentStatusEvent/Deployment.cs
@@ -10,7 +10,7 @@
         public string Url { get; init; } = null!;
 
         [JsonPropertyName("id")]
-        public int Id { get; init; }
+        public long Id { get; init; }
 
         [JsonPropertyName("node_id")]
         public string NodeId { get; init; } = null!;

--- a/src/Octokit.Webhooks/Models/DeploymentStatusEvent/DeploymentStatus.cs
+++ b/src/Octokit.Webhooks/Models/DeploymentStatusEvent/DeploymentStatus.cs
@@ -10,7 +10,7 @@
         public string Url { get; init; } = null!;
 
         [JsonPropertyName("id")]
-        public int Id { get; init; }
+        public long Id { get; init; }
 
         [JsonPropertyName("node_id")]
         public string NodeId { get; init; } = null!;

--- a/src/Octokit.Webhooks/Models/DiscussionCommentEvent/DiscussionComment.cs
+++ b/src/Octokit.Webhooks/Models/DiscussionCommentEvent/DiscussionComment.cs
@@ -7,7 +7,7 @@
     public sealed record DiscussionComment
     {
         [JsonPropertyName("id")]
-        public int Id { get; init; }
+        public long Id { get; init; }
 
         [JsonPropertyName("node_id")]
         public string NodeId { get; init; } = null!;
@@ -19,13 +19,13 @@
         public int? ParentId { get; init; }
 
         [JsonPropertyName("child_comment_count")]
-        public int ChildCommentCount { get; init; }
+        public long ChildCommentCount { get; init; }
 
         [JsonPropertyName("repository_url")]
         public string RepositoryUrl { get; init; } = null!;
 
         [JsonPropertyName("discussion_id")]
-        public int DiscussionId { get; init; }
+        public long DiscussionId { get; init; }
 
         [JsonPropertyName("author_association")]
         public AuthorAssociation AuthorAssociation { get; init; }

--- a/src/Octokit.Webhooks/Models/DiscussionEvent/Discussion.cs
+++ b/src/Octokit.Webhooks/Models/DiscussionEvent/Discussion.cs
@@ -25,13 +25,13 @@
         public string HtmlUrl { get; init; } = null!;
 
         [JsonPropertyName("id")]
-        public int Id { get; init; }
+        public long Id { get; init; }
 
         [JsonPropertyName("node_id")]
         public string NodeId { get; init; } = null!;
 
         [JsonPropertyName("number")]
-        public int Number { get; init; }
+        public long Number { get; init; }
 
         [JsonPropertyName("title")]
         public string Title { get; init; } = null!;
@@ -43,10 +43,10 @@
         public DiscussionState State { get; init; }
 
         [JsonPropertyName("locked")]
-        public int Locked { get; init; }
+        public long Locked { get; init; }
 
         [JsonPropertyName("comments")]
-        public int Comments { get; init; }
+        public long Comments { get; init; }
 
         [JsonPropertyName("created_at")]
         public string CreatedAt { get; init; } = null!;

--- a/src/Octokit.Webhooks/Models/DiscussionEvent/DiscussionAnswer.cs
+++ b/src/Octokit.Webhooks/Models/DiscussionEvent/DiscussionAnswer.cs
@@ -7,7 +7,7 @@
     public sealed record DiscussionAnswer
     {
         [JsonPropertyName("id")]
-        public int Id { get; init; }
+        public long Id { get; init; }
 
         [JsonPropertyName("node_id")]
         public string NodeId { get; init; } = null!;
@@ -19,13 +19,13 @@
         public int? ParentId { get; init; }
 
         [JsonPropertyName("child_comment_count")]
-        public int ChildCommentCount { get; init; }
+        public long ChildCommentCount { get; init; }
 
         [JsonPropertyName("repository_url")]
         public string RepositoryUrl { get; init; } = null!;
 
         [JsonPropertyName("discussion_id")]
-        public int DiscussionId { get; init; }
+        public long DiscussionId { get; init; }
 
         [JsonPropertyName("author_association")]
         public AuthorAssociation AuthorAssociation { get; init; }

--- a/src/Octokit.Webhooks/Models/DiscussionEvent/DiscussionCategory.cs
+++ b/src/Octokit.Webhooks/Models/DiscussionEvent/DiscussionCategory.cs
@@ -7,10 +7,10 @@
     public sealed record DiscussionCategory
     {
         [JsonPropertyName("id")]
-        public int Id { get; init; }
+        public long Id { get; init; }
 
         [JsonPropertyName("repository_id")]
-        public int RepositoryId { get; init; }
+        public long RepositoryId { get; init; }
 
         [JsonPropertyName("emoji")]
         public string Emoji { get; init; } = null!;
@@ -31,6 +31,6 @@
         public string Slug { get; init; } = null!;
 
         [JsonPropertyName("is_answerable")]
-        public int IsAnswerable { get; init; }
+        public long IsAnswerable { get; init; }
     }
 }

--- a/src/Octokit.Webhooks/Models/Installation.cs
+++ b/src/Octokit.Webhooks/Models/Installation.cs
@@ -8,7 +8,7 @@
     public sealed record Installation
     {
         [JsonPropertyName("id")]
-        public int Id { get; init; }
+        public long Id { get; init; }
 
         [JsonPropertyName("account")]
         public User Account { get; init; } = null!;
@@ -26,13 +26,13 @@
         public string HtmlUrl { get; init; } = null!;
 
         [JsonPropertyName("app_id")]
-        public int AppId { get; init; }
+        public long AppId { get; init; }
 
         [JsonPropertyName("app_slug")]
         public string? AppSlug { get; init; }
 
         [JsonPropertyName("target_id")]
-        public int TargetId { get; init; }
+        public long TargetId { get; init; }
 
         [JsonPropertyName("target_type")]
         public InstallationTargetType TargetType { get; init; }

--- a/src/Octokit.Webhooks/Models/InstallationEvent/Repository.cs
+++ b/src/Octokit.Webhooks/Models/InstallationEvent/Repository.cs
@@ -7,7 +7,7 @@
     public sealed record Repository
     {
         [JsonPropertyName("id")]
-        public int Id { get; init; }
+        public long Id { get; init; }
 
         [JsonPropertyName("node_id")]
         public string NodeId { get; init; } = null!;

--- a/src/Octokit.Webhooks/Models/InstallationLite.cs
+++ b/src/Octokit.Webhooks/Models/InstallationLite.cs
@@ -7,7 +7,7 @@
     public sealed record InstallationLite
     {
         [JsonPropertyName("id")]
-        public int Id { get; init; }
+        public long Id { get; init; }
 
         [JsonPropertyName("node_id")]
         public string NodeId { get; init; } = null!;

--- a/src/Octokit.Webhooks/Models/InstallationRepositoriesEvent/Repository.cs
+++ b/src/Octokit.Webhooks/Models/InstallationRepositoriesEvent/Repository.cs
@@ -7,7 +7,7 @@
     public sealed record Repository
     {
         [JsonPropertyName("id")]
-        public int Id { get; init; }
+        public long Id { get; init; }
 
         [JsonPropertyName("node_id")]
         public string NodeId { get; init; } = null!;

--- a/src/Octokit.Webhooks/Models/Issue.cs
+++ b/src/Octokit.Webhooks/Models/Issue.cs
@@ -26,13 +26,13 @@
         public string HtmlUrl { get; init; } = null!;
 
         [JsonPropertyName("id")]
-        public int Id { get; init; }
+        public long Id { get; init; }
 
         [JsonPropertyName("node_id")]
         public string NodeId { get; init; } = null!;
 
         [JsonPropertyName("number")]
-        public int Number { get; init; }
+        public long Number { get; init; }
 
         [JsonPropertyName("title")]
         public string Title { get; init; } = null!;
@@ -59,7 +59,7 @@
         public Milestone? Milestone { get; init; }
 
         [JsonPropertyName("comments")]
-        public int Comments { get; init; }
+        public long Comments { get; init; }
 
         [JsonPropertyName("created_at")]
         public string CreatedAt { get; init; } = null!;

--- a/src/Octokit.Webhooks/Models/IssueComment.cs
+++ b/src/Octokit.Webhooks/Models/IssueComment.cs
@@ -16,7 +16,7 @@
         public string IssueUrl { get; init; } = null!;
 
         [JsonPropertyName("id")]
-        public int Id { get; init; }
+        public long Id { get; init; }
 
         [JsonPropertyName("node_id")]
         public string NodeId { get; init; } = null!;

--- a/src/Octokit.Webhooks/Models/Label.cs
+++ b/src/Octokit.Webhooks/Models/Label.cs
@@ -7,7 +7,7 @@
     public sealed record Label
     {
         [JsonPropertyName("id")]
-        public int Id { get; init; }
+        public long Id { get; init; }
 
         [JsonPropertyName("node_id")]
         public string NodeId { get; init; } = null!;

--- a/src/Octokit.Webhooks/Models/MarketplacePurchase.cs
+++ b/src/Octokit.Webhooks/Models/MarketplacePurchase.cs
@@ -13,7 +13,7 @@
         public string BillingCycle { get; init; } = null!;
 
         [JsonPropertyName("unit_count")]
-        public int UnitCount { get; init; }
+        public long UnitCount { get; init; }
 
         [JsonPropertyName("on_free_trial")]
         public bool OnFreeTrial { get; init; }

--- a/src/Octokit.Webhooks/Models/MarkplacePurchaseAccount.cs
+++ b/src/Octokit.Webhooks/Models/MarkplacePurchaseAccount.cs
@@ -10,7 +10,7 @@
         public string Type { get; init; } = null!;
 
         [JsonPropertyName("id")]
-        public int Id { get; init; }
+        public long Id { get; init; }
 
         [JsonPropertyName("node_id")]
         public string NodeId { get; init; } = null!;

--- a/src/Octokit.Webhooks/Models/MarkplacePurchasePlan.cs
+++ b/src/Octokit.Webhooks/Models/MarkplacePurchasePlan.cs
@@ -8,7 +8,7 @@
     public sealed record MarkplacePurchasePlan
     {
         [JsonPropertyName("id")]
-        public int Id { get; init; }
+        public long Id { get; init; }
 
         [JsonPropertyName("name")]
         public string Name { get; init; } = null!;
@@ -17,10 +17,10 @@
         public string Description { get; init; } = null!;
 
         [JsonPropertyName("monthly_price_in_cents")]
-        public int MonthlyPriceInCents { get; init; }
+        public long MonthlyPriceInCents { get; init; }
 
         [JsonPropertyName("yearly_price_in_cents")]
-        public int YearlyPriceInCents { get; init; }
+        public long YearlyPriceInCents { get; init; }
 
         [JsonPropertyName("price_model")]
         public string PriceModel { get; init; } = null!;

--- a/src/Octokit.Webhooks/Models/MetaEvent/Hook.cs
+++ b/src/Octokit.Webhooks/Models/MetaEvent/Hook.cs
@@ -11,7 +11,7 @@
         public string Type { get; init; } = null!;
 
         [JsonPropertyName("id")]
-        public int Id { get; init; }
+        public long Id { get; init; }
 
         [JsonPropertyName("name")]
         public string Name { get; init; } = null!;

--- a/src/Octokit.Webhooks/Models/Milestone.cs
+++ b/src/Octokit.Webhooks/Models/Milestone.cs
@@ -16,13 +16,13 @@
         public string LabelsUrl { get; init; } = null!;
 
         [JsonPropertyName("id")]
-        public int Id { get; init; }
+        public long Id { get; init; }
 
         [JsonPropertyName("node_id")]
         public string NodeId { get; init; } = null!;
 
         [JsonPropertyName("number")]
-        public int Number { get; init; }
+        public long Number { get; init; }
 
         [JsonPropertyName("title")]
         public string Title { get; init; } = null!;
@@ -34,10 +34,10 @@
         public User Creator { get; init; } = null!;
 
         [JsonPropertyName("open_issues")]
-        public int OpenIssues { get; init; }
+        public long OpenIssues { get; init; }
 
         [JsonPropertyName("closed_issues")]
-        public int ClosedIssues { get; init; }
+        public long ClosedIssues { get; init; }
 
         [JsonPropertyName("state")]
         public MilestoneState State { get; init; }

--- a/src/Octokit.Webhooks/Models/Organization.cs
+++ b/src/Octokit.Webhooks/Models/Organization.cs
@@ -10,7 +10,7 @@
         public string Login { get; init; } = null!;
 
         [JsonPropertyName("id")]
-        public int Id { get; init; }
+        public long Id { get; init; }
 
         [JsonPropertyName("node_id")]
         public string NodeId { get; init; } = null!;

--- a/src/Octokit.Webhooks/Models/OrganizationEvent/Invitation.cs
+++ b/src/Octokit.Webhooks/Models/OrganizationEvent/Invitation.cs
@@ -7,7 +7,7 @@
     public sealed record Invitation
     {
         [JsonPropertyName("id")]
-        public int Id { get; init; }
+        public long Id { get; init; }
 
         [JsonPropertyName("node_id")]
         public string NodeId { get; init; } = null!;
@@ -34,7 +34,7 @@
         public User Inviter { get; init; } = null!;
 
         [JsonPropertyName("team_count")]
-        public int TeamCount { get; init; }
+        public long TeamCount { get; init; }
 
         [JsonPropertyName("invitation_teams_url")]
         public string InvitationTeamsUrl { get; init; } = null!;

--- a/src/Octokit.Webhooks/Models/Package.cs
+++ b/src/Octokit.Webhooks/Models/Package.cs
@@ -7,7 +7,7 @@
     public sealed record Package
     {
         [JsonPropertyName("id")]
-        public int Id { get; init; }
+        public long Id { get; init; }
 
         [JsonPropertyName("name")]
         public string Name { get; init; } = null!;

--- a/src/Octokit.Webhooks/Models/PackageVersion.cs
+++ b/src/Octokit.Webhooks/Models/PackageVersion.cs
@@ -8,7 +8,7 @@
     public sealed record PackageVersion
     {
         [JsonPropertyName("id")]
-        public int Id { get; init; }
+        public long Id { get; init; }
 
         [JsonPropertyName("version")]
         public string Version { get; init; } = null!;

--- a/src/Octokit.Webhooks/Models/PackageVersionPackageFile.cs
+++ b/src/Octokit.Webhooks/Models/PackageVersionPackageFile.cs
@@ -10,7 +10,7 @@
         public string DownloadUrl { get; init; } = null!;
 
         [JsonPropertyName("id")]
-        public int Id { get; init; }
+        public long Id { get; init; }
 
         [JsonPropertyName("name")]
         public string Name { get; init; } = null!;
@@ -31,7 +31,7 @@
         public string State { get; init; } = null!;
 
         [JsonPropertyName("size")]
-        public int Size { get; init; }
+        public long Size { get; init; }
 
         [JsonPropertyName("created_at")]
         public string CreatedAt { get; init; } = null!;

--- a/src/Octokit.Webhooks/Models/PackageVersionRelease.cs
+++ b/src/Octokit.Webhooks/Models/PackageVersionRelease.cs
@@ -13,7 +13,7 @@
         public string HtmlUrl { get; init; } = null!;
 
         [JsonPropertyName("id")]
-        public int Id { get; init; }
+        public long Id { get; init; }
 
         [JsonPropertyName("tag_name")]
         public string TagName { get; init; } = null!;

--- a/src/Octokit.Webhooks/Models/PageBuildEvent/Build.cs
+++ b/src/Octokit.Webhooks/Models/PageBuildEvent/Build.cs
@@ -22,7 +22,7 @@
         public string Commit { get; init; } = null!;
 
         [JsonPropertyName("duration")]
-        public int Duration { get; init; }
+        public long Duration { get; init; }
 
         [JsonPropertyName("created_at")]
         public string CreatedAt { get; init; } = null!;

--- a/src/Octokit.Webhooks/Models/PingEvent/Hook.cs
+++ b/src/Octokit.Webhooks/Models/PingEvent/Hook.cs
@@ -11,7 +11,7 @@
         public string Type { get; init; } = null!;
 
         [JsonPropertyName("id")]
-        public int Id { get; init; }
+        public long Id { get; init; }
 
         [JsonPropertyName("name")]
         public string Name { get; init; } = null!;

--- a/src/Octokit.Webhooks/Models/Project.cs
+++ b/src/Octokit.Webhooks/Models/Project.cs
@@ -19,7 +19,7 @@
         public string ColumnsUrl { get; init; } = null!;
 
         [JsonPropertyName("id")]
-        public int Id { get; init; }
+        public long Id { get; init; }
 
         [JsonPropertyName("node_id")]
         public string NodeId { get; init; } = null!;
@@ -31,7 +31,7 @@
         public string? Body { get; init; }
 
         [JsonPropertyName("number")]
-        public int Number { get; init; }
+        public long Number { get; init; }
 
         [JsonPropertyName("state")]
         public ProjectState State { get; init; }

--- a/src/Octokit.Webhooks/Models/ProjectCard.cs
+++ b/src/Octokit.Webhooks/Models/ProjectCard.cs
@@ -16,10 +16,10 @@
         public string ColumnUrl { get; init; } = null!;
 
         [JsonPropertyName("column_id")]
-        public int ColumnId { get; init; }
+        public long ColumnId { get; init; }
 
         [JsonPropertyName("id")]
-        public int Id { get; init; }
+        public long Id { get; init; }
 
         [JsonPropertyName("node_id")]
         public string NodeId { get; init; } = null!;
@@ -28,7 +28,7 @@
         public string? Note { get; init; }
 
         [JsonPropertyName("archived")]
-        public int Archived { get; init; }
+        public long Archived { get; init; }
 
         [JsonPropertyName("creator")]
         public User Creator { get; init; } = null!;
@@ -43,6 +43,6 @@
         public string? ContentUrl { get; init; }
 
         [JsonPropertyName("after_id")]
-        public int AfterId { get; init; }
+        public long AfterId { get; init; }
     }
 }

--- a/src/Octokit.Webhooks/Models/ProjectCardEvent/ChangesColumnId.cs
+++ b/src/Octokit.Webhooks/Models/ProjectCardEvent/ChangesColumnId.cs
@@ -7,6 +7,6 @@
     public sealed record ChangesColumnId
     {
         [JsonPropertyName("from")]
-        public int From { get; init; }
+        public long From { get; init; }
     }
 }

--- a/src/Octokit.Webhooks/Models/ProjectColumn.cs
+++ b/src/Octokit.Webhooks/Models/ProjectColumn.cs
@@ -16,7 +16,7 @@
         public string CardsUrl { get; init; } = null!;
 
         [JsonPropertyName("id")]
-        public int Id { get; init; }
+        public long Id { get; init; }
 
         [JsonPropertyName("node_id")]
         public string NodeId { get; init; } = null!;

--- a/src/Octokit.Webhooks/Models/PullRequestEvent/PullRequest.cs
+++ b/src/Octokit.Webhooks/Models/PullRequestEvent/PullRequest.cs
@@ -14,7 +14,7 @@
         public string Url { get; init; } = null!;
 
         [JsonPropertyName("id")]
-        public int Id { get; init; }
+        public long Id { get; init; }
 
         [JsonPropertyName("node_id")]
         public string NodeId { get; init; } = null!;
@@ -32,7 +32,7 @@
         public string IssueUrl { get; init; } = null!;
 
         [JsonPropertyName("number")]
-        public int Number { get; init; }
+        public long Number { get; init; }
 
         [JsonPropertyName("state")]
         public PullRequestState State { get; init; }
@@ -131,24 +131,24 @@
         public User? MergedBy { get; init; }
 
         [JsonPropertyName("comments")]
-        public int Comments { get; init; }
+        public long Comments { get; init; }
 
         [JsonPropertyName("review_comments")]
-        public int ReviewComments { get; init; }
+        public long ReviewComments { get; init; }
 
         [JsonPropertyName("maintainer_can_modify")]
         public bool MaintainerCanModify { get; init; }
 
         [JsonPropertyName("commits")]
-        public int Commits { get; init; }
+        public long Commits { get; init; }
 
         [JsonPropertyName("additions")]
-        public int Additions { get; init; }
+        public long Additions { get; init; }
 
         [JsonPropertyName("deletions")]
-        public int Deletions { get; init; }
+        public long Deletions { get; init; }
 
         [JsonPropertyName("changed_files")]
-        public int ChangedFiles { get; init; }
+        public long ChangedFiles { get; init; }
     }
 }

--- a/src/Octokit.Webhooks/Models/PullRequestReviewComment.cs
+++ b/src/Octokit.Webhooks/Models/PullRequestReviewComment.cs
@@ -10,10 +10,10 @@
         public string Url { get; init; } = null!;
 
         [JsonPropertyName("pull_request_review_id")]
-        public int PullRequestReviewId { get; init; }
+        public long PullRequestReviewId { get; init; }
 
         [JsonPropertyName("id")]
-        public int Id { get; init; }
+        public long Id { get; init; }
 
         [JsonPropertyName("node_id")]
         public string NodeId { get; init; } = null!;
@@ -28,7 +28,7 @@
         public int? Position { get; init; }
 
         [JsonPropertyName("original_position")]
-        public int OriginalPosition { get; init; }
+        public long OriginalPosition { get; init; }
 
         [JsonPropertyName("commit_id")]
         public string CommitId { get; init; } = null!;
@@ -73,7 +73,7 @@
         public int? Line { get; init; }
 
         [JsonPropertyName("original_line")]
-        public int OriginalLine { get; init; }
+        public long OriginalLine { get; init; }
 
         [JsonPropertyName("side")]
         public Side Side { get; init; }

--- a/src/Octokit.Webhooks/Models/PullRequestReviewEvent/Review.cs
+++ b/src/Octokit.Webhooks/Models/PullRequestReviewEvent/Review.cs
@@ -7,7 +7,7 @@
     public sealed record Review
     {
         [JsonPropertyName("id")]
-        public int Id { get; init; }
+        public long Id { get; init; }
 
         [JsonPropertyName("node_id")]
         public string NodeId { get; init; } = null!;

--- a/src/Octokit.Webhooks/Models/Release.cs
+++ b/src/Octokit.Webhooks/Models/Release.cs
@@ -20,7 +20,7 @@
         public string HtmlUrl { get; init; } = null!;
 
         [JsonPropertyName("id")]
-        public int Id { get; init; }
+        public long Id { get; init; }
 
         [JsonPropertyName("node_id")]
         public string NodeId { get; init; } = null!;

--- a/src/Octokit.Webhooks/Models/ReleaseAsset.cs
+++ b/src/Octokit.Webhooks/Models/ReleaseAsset.cs
@@ -13,7 +13,7 @@
         public string BrowserDownloadUrl { get; init; } = null!;
 
         [JsonPropertyName("id")]
-        public int Id { get; init; }
+        public long Id { get; init; }
 
         [JsonPropertyName("node_id")]
         public string NodeId { get; init; } = null!;
@@ -31,10 +31,10 @@
         public string ContentType { get; init; } = null!;
 
         [JsonPropertyName("size")]
-        public int Size { get; init; }
+        public long Size { get; init; }
 
         [JsonPropertyName("download_count")]
-        public int DownloadCount { get; init; }
+        public long DownloadCount { get; init; }
 
         [JsonPropertyName("created_at")]
         public string CreatedAt { get; init; } = null!;

--- a/src/Octokit.Webhooks/Models/RepoRef.cs
+++ b/src/Octokit.Webhooks/Models/RepoRef.cs
@@ -7,7 +7,7 @@
     public sealed record RepoRef
     {
         [JsonPropertyName("id")]
-        public int Id { get; init; }
+        public long Id { get; init; }
 
         [JsonPropertyName("url")]
         public string Url { get; init; } = null!;

--- a/src/Octokit.Webhooks/Models/Repository.cs
+++ b/src/Octokit.Webhooks/Models/Repository.cs
@@ -7,7 +7,7 @@
     public sealed record Repository
     {
         [JsonPropertyName("id")]
-        public int Id { get; init; }
+        public long Id { get; init; }
 
         [JsonPropertyName("node_id")]
         public string NodeId { get; init; } = null!;
@@ -169,13 +169,13 @@
         public string? Homepage { get; init; }
 
         [JsonPropertyName("size")]
-        public int Size { get; init; }
+        public long Size { get; init; }
 
         [JsonPropertyName("stargazers_count")]
-        public int StargazersCount { get; init; }
+        public long StargazersCount { get; init; }
 
         [JsonPropertyName("watchers_count")]
-        public int WatchersCount { get; init; }
+        public long WatchersCount { get; init; }
 
         [JsonPropertyName("language")]
         public string? Language { get; init; }
@@ -196,7 +196,7 @@
         public bool HasPages { get; init; }
 
         [JsonPropertyName("forks_count")]
-        public int ForksCount { get; init; }
+        public long ForksCount { get; init; }
 
         [JsonPropertyName("mirror_url")]
         public string? MirrorUrl { get; init; }
@@ -208,19 +208,19 @@
         public bool? Disabled { get; init; }
 
         [JsonPropertyName("open_issues_count")]
-        public int OpenIssuesCount { get; init; }
+        public long OpenIssuesCount { get; init; }
 
         [JsonPropertyName("license")]
         public License? License { get; init; }
 
         [JsonPropertyName("forks")]
-        public int Forks { get; init; }
+        public long Forks { get; init; }
 
         [JsonPropertyName("open_issues")]
-        public int OpenIssues { get; init; }
+        public long OpenIssues { get; init; }
 
         [JsonPropertyName("watchers")]
-        public int Watchers { get; init; }
+        public long Watchers { get; init; }
 
         [JsonPropertyName("stargazers")]
         public int? Stargazers { get; init; }

--- a/src/Octokit.Webhooks/Models/RepositoryLite.cs
+++ b/src/Octokit.Webhooks/Models/RepositoryLite.cs
@@ -73,7 +73,7 @@
         public string HtmlUrl { get; init; } = null!;
 
         [JsonPropertyName("id")]
-        public int Id { get; init; }
+        public long Id { get; init; }
 
         [JsonPropertyName("issue_comment_url")]
         public string IssueCommentUrl { get; init; } = null!;

--- a/src/Octokit.Webhooks/Models/RepositoryVulnerabilityAlertEvent/Alert.cs
+++ b/src/Octokit.Webhooks/Models/RepositoryVulnerabilityAlertEvent/Alert.cs
@@ -7,7 +7,7 @@
     public sealed record Alert
     {
         [JsonPropertyName("id")]
-        public int Id { get; init; }
+        public long Id { get; init; }
 
         [JsonPropertyName("affected_range")]
         public string AffectedRange { get; init; } = null!;

--- a/src/Octokit.Webhooks/Models/SecretScanningAlertEvent/Alert.cs
+++ b/src/Octokit.Webhooks/Models/SecretScanningAlertEvent/Alert.cs
@@ -7,7 +7,7 @@
     public sealed record Alert
     {
         [JsonPropertyName("number")]
-        public int Number { get; init; }
+        public long Number { get; init; }
 
         [JsonPropertyName("secret_type")]
         public string SecretType { get; init; } = null!;

--- a/src/Octokit.Webhooks/Models/SecurityAdvisoryEvent/SecurityAdvisoryCvss.cs
+++ b/src/Octokit.Webhooks/Models/SecurityAdvisoryEvent/SecurityAdvisoryCvss.cs
@@ -10,6 +10,6 @@
         public string? VectorString { get; init; }
 
         [JsonPropertyName("score")]
-        public int Score { get; init; }
+        public long Score { get; init; }
     }
 }

--- a/src/Octokit.Webhooks/Models/SimplePullRequest.cs
+++ b/src/Octokit.Webhooks/Models/SimplePullRequest.cs
@@ -11,7 +11,7 @@
         public string Url { get; init; } = null!;
 
         [JsonPropertyName("id")]
-        public int Id { get; init; }
+        public long Id { get; init; }
 
         [JsonPropertyName("node_id")]
         public string NodeId { get; init; } = null!;
@@ -29,7 +29,7 @@
         public string IssueUrl { get; init; } = null!;
 
         [JsonPropertyName("number")]
-        public int Number { get; init; }
+        public long Number { get; init; }
 
         [JsonPropertyName("state")]
         public SimplePullRequestState State { get; init; }

--- a/src/Octokit.Webhooks/Models/SponsorshipEvent/SponsorshipTier.cs
+++ b/src/Octokit.Webhooks/Models/SponsorshipEvent/SponsorshipTier.cs
@@ -16,10 +16,10 @@
         public string Description { get; init; } = null!;
 
         [JsonPropertyName("monthly_price_in_cents")]
-        public int MonthlyPriceInCents { get; init; }
+        public long MonthlyPriceInCents { get; init; }
 
         [JsonPropertyName("monthly_price_in_dollars")]
-        public int MonthlyPriceInDollars { get; init; }
+        public long MonthlyPriceInDollars { get; init; }
 
         [JsonPropertyName("name")]
         public string Name { get; init; } = null!;

--- a/src/Octokit.Webhooks/Models/StatusEvent/CommitDetails.cs
+++ b/src/Octokit.Webhooks/Models/StatusEvent/CommitDetails.cs
@@ -22,6 +22,6 @@
         public string Url { get; init; } = null!;
 
         [JsonPropertyName("comment_count")]
-        public int CommentCount { get; init; }
+        public long CommentCount { get; init; }
     }
 }

--- a/src/Octokit.Webhooks/Models/Team.cs
+++ b/src/Octokit.Webhooks/Models/Team.cs
@@ -10,7 +10,7 @@
         public string Name { get; init; } = null!;
 
         [JsonPropertyName("id")]
-        public int Id { get; init; }
+        public long Id { get; init; }
 
         [JsonPropertyName("node_id")]
         public string NodeId { get; init; } = null!;

--- a/src/Octokit.Webhooks/Models/TeamParent.cs
+++ b/src/Octokit.Webhooks/Models/TeamParent.cs
@@ -13,7 +13,7 @@
         public string Name { get; init; } = null!;
 
         [JsonPropertyName("id")]
-        public int Id { get; init; }
+        public long Id { get; init; }
 
         [JsonPropertyName("node_id")]
         public string NodeId { get; init; } = null!;

--- a/src/Octokit.Webhooks/Models/User.cs
+++ b/src/Octokit.Webhooks/Models/User.cs
@@ -10,7 +10,7 @@
         public string Login { get; init; } = null!;
 
         [JsonPropertyName("id")]
-        public int Id { get; init; }
+        public long Id { get; init; }
 
         [JsonPropertyName("node_id")]
         public string NodeId { get; init; } = null!;

--- a/src/Octokit.Webhooks/Models/Workflow.cs
+++ b/src/Octokit.Webhooks/Models/Workflow.cs
@@ -16,7 +16,7 @@
         public string HtmlUrl { get; init; } = null!;
 
         [JsonPropertyName("id")]
-        public int Id { get; init; }
+        public long Id { get; init; }
 
         [JsonPropertyName("name")]
         public string Name { get; init; } = null!;

--- a/src/Octokit.Webhooks/Models/WorkflowJobEvent/WorkflowJob.cs
+++ b/src/Octokit.Webhooks/Models/WorkflowJobEvent/WorkflowJob.cs
@@ -8,13 +8,13 @@ namespace Octokit.Webhooks.Models.WorkflowJobEvent
     public sealed record WorkflowJob
     {
         [JsonPropertyName("id")]
-        public int Id { get; init; }
+        public long Id { get; init; }
 
         [JsonPropertyName("run_id")]
-        public int RunId { get; init; }
+        public long RunId { get; init; }
 
         [JsonPropertyName("run_attempt")]
-        public int RunAttempt { get; init; }
+        public long RunAttempt { get; init; }
 
         [JsonPropertyName("run_url")]
         public string RunUrl { get; init; } = null!;

--- a/src/Octokit.Webhooks/Models/WorkflowJobEvent/WorkflowJobStep.cs
+++ b/src/Octokit.Webhooks/Models/WorkflowJobEvent/WorkflowJobStep.cs
@@ -16,7 +16,7 @@ namespace Octokit.Webhooks.Models.WorkflowJobEvent
         public WorkflowJobStepConclusion Conclusion { get; init; }
 
         [JsonPropertyName("number")]
-        public int Number { get; init; }
+        public long Number { get; init; }
 
         [JsonPropertyName("started_at")]
         public string StartedAt { get; init; } = null!;

--- a/src/Octokit.Webhooks/Models/WorkflowPullRequest.cs
+++ b/src/Octokit.Webhooks/Models/WorkflowPullRequest.cs
@@ -10,10 +10,10 @@
         public string Url { get; init; } = null!;
 
         [JsonPropertyName("id")]
-        public int Id { get; init; }
+        public long Id { get; init; }
 
         [JsonPropertyName("number")]
-        public int Number { get; init; }
+        public long Number { get; init; }
 
         [JsonPropertyName("head")]
         public WorkflowPullRequestHead Head { get; init; } = null!;

--- a/src/Octokit.Webhooks/Models/WorkflowRun.cs
+++ b/src/Octokit.Webhooks/Models/WorkflowRun.cs
@@ -17,7 +17,7 @@
         public string CheckSuiteUrl { get; init; } = null!;
 
         [JsonPropertyName("check_suite_id")]
-        public int CheckSuiteId { get; init; }
+        public long CheckSuiteId { get; init; }
 
         [JsonPropertyName("check_suite_node_id")]
         public string CheckSuiteNodeId { get; init; } = null!;
@@ -47,7 +47,7 @@
         public string HtmlUrl { get; init; } = null!;
 
         [JsonPropertyName("id")]
-        public int Id { get; init; }
+        public long Id { get; init; }
 
         [JsonPropertyName("jobs_url")]
         public string JobsUrl { get; init; } = null!;
@@ -71,7 +71,7 @@
         public string RerunUrl { get; init; } = null!;
 
         [JsonPropertyName("run_number")]
-        public int RunNumber { get; init; }
+        public long RunNumber { get; init; }
 
         [JsonPropertyName("status")]
         public WorkflowRunStatus Status { get; init; }
@@ -83,7 +83,7 @@
         public string Url { get; init; } = null!;
 
         [JsonPropertyName("workflow_id")]
-        public int WorkflowId { get; init; }
+        public long WorkflowId { get; init; }
 
         [JsonPropertyName("workflow_url")]
         public string WorkflowUrl { get; init; } = null!;


### PR DESCRIPTION
Migrates all integer types from `int` (32-bit) to `long` (64-bit).

Could I be a bit more directed with these changes? Probably. But the it's simpler and easier to migrate all `int`s to `long`s rather than debate how large a specific ID is going to be.

Closes #30

References:
  - https://github.com/octokit/webhooks.net/issues/30
  - https://github.com/octokit/octokit.net/issues/2351
  - https://github.com/octokit/octokit.net/pull/2352
  - https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/integral-numeric-types

<!--
Please read the contributing guide before raising a pull request.
https://github.com/octokit/webhooks.net/blob/main/CONTRIBUTING.md
-->
