### PR TITLE
chore: update global.json to target .NET 5

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "rollForward": "latestMajor",
-    "version": "5.0.301"
+    "rollForward": "latestFeature",
+    "version": "5.0.100"
   }
 }


### PR DESCRIPTION
`latestMajor` allowed newer versions, like .NET 6

<!--
Please read the contributing guide before raising a pull request.
https://github.com/octokit/webhooks.net/blob/main/CONTRIBUTING.md
-->
