### PR TITLE
Add logging to HTTP endpoint

### DIFF
--- a/src/Octokit.Webhooks.AspNetCore/GitHubWebhookExtensions.cs
+++ b/src/Octokit.Webhooks.AspNetCore/GitHubWebhookExtensions.cs
@@ -18,8 +18,7 @@
         public static void MapGitHubWebhooks(this IEndpointRouteBuilder endpoints, string path = "/api/github/webhooks", string secret = null!) =>
             endpoints.MapPost(path, async context =>
             {
-                var loggerFactory = context.RequestServices.GetRequiredService<ILoggerFactory>();
-                var logger = loggerFactory.CreateLogger("Octokit.Webhooks.AspNetCore");
+                var logger = context.RequestServices.GetRequiredService<ILogger<WebhookEventProcessor>>();
 
                 // Verify content type
                 if (!VerifyContentType(context, MediaTypeNames.Application.Json))


### PR DESCRIPTION
This afternoon I migrated from [Terrajobst.GitHubEvents.AspNetCore](https://www.nuget.org/packages/Terrajobst.GitHubEvents.AspNetCore/) to this library, and have since observed that my application is now failing to handle various webhooks with an HTTP 500 error. They seem to involve `check_run` and some `pull_request` events.

Unfortunately, I don't know _why_ they are failing because exceptions caught by the HTTP endpoint are not logged, they're just swallowed.

This PR adds equivalent logging to the endpoint as the endpoint in Terrajobst.GitHubEvents.AspNetCore has ([code](https://github.com/terrajobst/Terrajobst.GitHubEvents/blob/cb86100c783373e198cefb1ed7e92526a44833b0/src/Terrajobst.GitHubEvents.AspNetCore/GitHubEventsExtensions.cs#L20-L61)), making it easier to diagnose payloads that fail to be processed.
