### PR TITLE
fix: add waiting deployment status state

### DIFF
--- a/src/Octokit.Webhooks/Models/CheckRunEvent/CheckRunStatus.cs
+++ b/src/Octokit.Webhooks/Models/CheckRunEvent/CheckRunStatus.cs
@@ -14,5 +14,7 @@
         Completed,
         [EnumMember(Value = "queued")]
         Queued,
+        [EnumMember(Value = "waiting")]
+        Waiting,
     }
 }

--- a/src/Octokit.Webhooks/Models/DeploymentStatusEvent/DeploymentStatusState.cs
+++ b/src/Octokit.Webhooks/Models/DeploymentStatusEvent/DeploymentStatusState.cs
@@ -16,5 +16,7 @@
         Failure,
         [EnumMember(Value = "error")]
         Error,
+        [EnumMember(Value = "waiting")]
+        Waiting,
     }
 }

--- a/src/Octokit.Webhooks/Models/WorkflowRunStatus.cs
+++ b/src/Octokit.Webhooks/Models/WorkflowRunStatus.cs
@@ -14,5 +14,7 @@
         Completed,
         [EnumMember(Value = "queued")]
         Queued,
+        [EnumMember(Value = "waiting")]
+        Waiting,
     }
 }


### PR DESCRIPTION
Adds the `waiting` value to the `CheckRunStatus`, `DeploymentStatusState`, and `WorkflowRunStatus` enumerations.

Here's an example of the relevant part a webhook payload I received that had this status:

<details>
<summary>deployment_status payload</summary>

```json
{
  "deployment_status": {
    "url": "https://api.github.com/repos/martincostello/SignInWithAppleSample/deployments/534555140/statuses/962858309",
    "id": 962858309,
    "node_id": "DES_kwDOC2Wnd845ZA1F",
    "state": "waiting",
    "creator": {
      "login": "martincostello",
      "id": 1439341,
      "node_id": "MDQ6VXNlcjE0MzkzNDE=",
      "avatar_url": "https://avatars.githubusercontent.com/u/1439341?v=4",
      "gravatar_id": "",
      "url": "https://api.github.com/users/martincostello",
      "html_url": "https://github.com/martincostello",
      "followers_url": "https://api.github.com/users/martincostello/followers",
      "following_url": "https://api.github.com/users/martincostello/following{/other_user}",
      "gists_url": "https://api.github.com/users/martincostello/gists{/gist_id}",
      "starred_url": "https://api.github.com/users/martincostello/starred{/owner}{/repo}",
      "subscriptions_url": "https://api.github.com/users/martincostello/subscriptions",
      "organizations_url": "https://api.github.com/users/martincostello/orgs",
      "repos_url": "https://api.github.com/users/martincostello/repos",
      "events_url": "https://api.github.com/users/martincostello/events{/privacy}",
      "received_events_url": "https://api.github.com/users/martincostello/received_events",
      "type": "User",
      "site_admin": false
    }
}
```

</details>

It looks like the schema in the [webhooks repo](https://github.com/octokit/webhooks/blob/6a1d98eb83328d0c558d4702989cfb28341fb600/payload-schemas/api.github.com/deployment_status/created.schema.json#L37) and [the docs](https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#deployment_status) are out of sync with the values that users can actually receive as they're missing both `in_progress` and `waiting`.
