### PR TITLE
feat: Add missing deployment_status properties

### DIFF
--- a/src/Octokit.Webhooks/Events/DeploymentEvent.cs
+++ b/src/Octokit.Webhooks/Events/DeploymentEvent.cs
@@ -11,5 +11,11 @@
     {
         [JsonPropertyName("deployment")]
         public Models.DeploymentEvent.Deployment Deployment { get; init; } = null!;
+
+        [JsonPropertyName("workflow")]
+        public Models.Workflow? Workflow { get; init; } = null!;
+
+        [JsonPropertyName("workflow_run")]
+        public Models.DeploymentEvent.DeploymentWorkflowRun? WorkflowRun { get; init; } = null!;
     }
 }

--- a/src/Octokit.Webhooks/Events/DeploymentStatusEvent.cs
+++ b/src/Octokit.Webhooks/Events/DeploymentStatusEvent.cs
@@ -16,12 +16,12 @@
         public Models.DeploymentStatusEvent.Deployment Deployment { get; init; } = null!;
 
         [JsonPropertyName("check_run")]
-        public Models.CheckRunEvent.CheckRun? CheckRun { get; init; }
+        public Models.DeploymentEvent.DeploymentCheckRun? CheckRun { get; init; }
+
+        [JsonPropertyName("workflow_run")]
+        public Models.DeploymentEvent.DeploymentWorkflowRun? WorkflowRun { get; init; }
 
         [JsonPropertyName("workflow")]
         public Models.Workflow? Workflow { get; init; }
-
-        [JsonPropertyName("workflow_run")]
-        public Models.WorkflowRun? WorkflowRun { get; init; }
     }
 }

--- a/src/Octokit.Webhooks/Events/DeploymentStatusEvent.cs
+++ b/src/Octokit.Webhooks/Events/DeploymentStatusEvent.cs
@@ -14,5 +14,14 @@
 
         [JsonPropertyName("deployment")]
         public Models.DeploymentStatusEvent.Deployment Deployment { get; init; } = null!;
+
+        [JsonPropertyName("check_run")]
+        public Models.CheckRunEvent.CheckRun? CheckRun { get; init; }
+
+        [JsonPropertyName("workflow")]
+        public Models.Workflow? Workflow { get; init; }
+
+        [JsonPropertyName("workflow_run")]
+        public Models.WorkflowRun? WorkflowRun { get; init; }
     }
 }

--- a/src/Octokit.Webhooks/Models/DeploymentEvent/DeploymentCheckRun.cs
+++ b/src/Octokit.Webhooks/Models/DeploymentEvent/DeploymentCheckRun.cs
@@ -1,16 +1,18 @@
-﻿namespace Octokit.Webhooks.Models.CheckRunEvent
+namespace Octokit.Webhooks.Models.DeploymentEvent
 {
     using System;
-    using System.Collections.Generic;
     using System.Text.Json.Serialization;
     using JetBrains.Annotations;
     using Octokit.Webhooks.Converter;
 
     [PublicAPI]
-    public sealed record CheckRun
+    public sealed record DeploymentCheckRun
     {
         [JsonPropertyName("id")]
         public long Id { get; init; }
+
+        [JsonPropertyName("name")]
+        public string Name { get; init; } = null!;
 
         [JsonPropertyName("node_id")]
         public string NodeId { get; init; } = null!;
@@ -31,10 +33,10 @@
         public string DetailsUrl { get; init; } = null!;
 
         [JsonPropertyName("status")]
-        public CheckRunStatus Status { get; init; }
+        public DeploymentCheckRunStatus Status { get; init; }
 
         [JsonPropertyName("conclusion")]
-        public CheckRunConclusion? Conclusion { get; init; }
+        public DeploymentCheckRunConclusion? Conclusion { get; init; }
 
         [JsonPropertyName("started_at")]
         [JsonConverter(typeof(DateTimeOffsetConverter))]
@@ -43,23 +45,5 @@
         [JsonPropertyName("completed_at")]
         [JsonConverter(typeof(NullableDateTimeOffsetConverter))]
         public DateTimeOffset? CompletedAt { get; init; }
-
-        [JsonPropertyName("output")]
-        public CheckRunOutput Output { get; init; } = null!;
-
-        [JsonPropertyName("name")]
-        public string Name { get; init; } = null!;
-
-        [JsonPropertyName("check_suite")]
-        public CheckSuite CheckSuite { get; init; } = null!;
-
-        [JsonPropertyName("app")]
-        public App App { get; init; } = null!;
-
-        [JsonPropertyName("pull_requests")]
-        public IEnumerable<CheckRunPullRequest> PullRequests { get; init; } = null!;
-
-        [JsonPropertyName("deployment")]
-        public Deployment Deployment { get; init; } = null!;
     }
 }

--- a/src/Octokit.Webhooks/Models/DeploymentEvent/DeploymentCheckRunConclusion.cs
+++ b/src/Octokit.Webhooks/Models/DeploymentEvent/DeploymentCheckRunConclusion.cs
@@ -1,0 +1,26 @@
+namespace Octokit.Webhooks.Models.DeploymentEvent
+{
+    using System.Runtime.Serialization;
+    using System.Text.Json.Serialization;
+
+    [JsonConverter(typeof(JsonStringEnumMemberConverter))]
+    public enum DeploymentCheckRunConclusion
+    {
+        [EnumMember(Value = "success")]
+        Success,
+        [EnumMember(Value = "failure")]
+        Failure,
+        [EnumMember(Value = "neutral")]
+        Neutral,
+        [EnumMember(Value = "cancelled")]
+        Cancelled,
+        [EnumMember(Value = "timed_out")]
+        TimedOut,
+        [EnumMember(Value = "actionRequired")]
+        ActionRequired,
+        [EnumMember(Value = "stale")]
+        Stale,
+        [EnumMember(Value = "skipped")]
+        Skipped,
+    }
+}

--- a/src/Octokit.Webhooks/Models/DeploymentEvent/DeploymentCheckRunStatus.cs
+++ b/src/Octokit.Webhooks/Models/DeploymentEvent/DeploymentCheckRunStatus.cs
@@ -1,0 +1,20 @@
+namespace Octokit.Webhooks.Models.DeploymentEvent
+{
+    using System.Runtime.Serialization;
+    using System.Text.Json.Serialization;
+
+    [JsonConverter(typeof(JsonStringEnumMemberConverter))]
+    public enum DeploymentCheckRunStatus
+    {
+        [EnumMember(Value = "requested")]
+        Requested,
+        [EnumMember(Value = "in_progress")]
+        InProgress,
+        [EnumMember(Value = "completed")]
+        Completed,
+        [EnumMember(Value = "queued")]
+        Queued,
+        [EnumMember(Value = "waiting")]
+        Waiting,
+    }
+}

--- a/src/Octokit.Webhooks/Models/DeploymentEvent/DeploymentWorkflowRun.cs
+++ b/src/Octokit.Webhooks/Models/DeploymentEvent/DeploymentWorkflowRun.cs
@@ -1,0 +1,79 @@
+namespace Octokit.Webhooks.Models.DeploymentEvent
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Text.Json.Serialization;
+    using JetBrains.Annotations;
+    using Octokit.Webhooks.Converter;
+    using Octokit.Webhooks.Models.CheckRunEvent;
+
+    [PublicAPI]
+    public sealed record DeploymentWorkflowRun
+    {
+        [JsonPropertyName("id")]
+        public long Id { get; init; }
+
+        [JsonPropertyName("name")]
+        public string Name { get; init; } = null!;
+
+        [JsonPropertyName("node_id")]
+        public string NodeId { get; init; } = null!;
+
+        [JsonPropertyName("head_branch")]
+        public string HeadBranch { get; init; } = null!;
+
+        [JsonPropertyName("head_sha")]
+        public string HeadSha { get; init; } = null!;
+
+        [JsonPropertyName("run_number")]
+        public long RunNumber { get; init; }
+
+        [JsonPropertyName("event")]
+        public string Event { get; init; } = null!;
+
+        [JsonPropertyName("status")]
+        public DeploymentWorkflowRunStatus? Status { get; init; }
+
+        [JsonPropertyName("conclusion")]
+        public DeploymentWorkflowRunConclusion? Conclusion { get; init; }
+
+        [JsonPropertyName("workflow_id")]
+        public long WorkflowId { get; init; }
+
+        [JsonPropertyName("check_suite_id")]
+        public long CheckSuiteId { get; init; }
+
+        [JsonPropertyName("check_suite_node_id")]
+        public string CheckSuiteNodeId { get; init; } = null!;
+
+        [JsonPropertyName("url")]
+        public string Url { get; init; } = null!;
+
+        [JsonPropertyName("html_url")]
+        public string HtmlUrl { get; init; } = null!;
+
+        [JsonPropertyName("pull_requests")]
+        public IEnumerable<CheckRunPullRequest> PullRequests { get; init; } = null!;
+
+        [JsonPropertyName("created_at")]
+        [JsonConverter(typeof(DateTimeOffsetConverter))]
+        public DateTimeOffset CreatedAt { get; init; }
+
+        [JsonPropertyName("updated_at")]
+        [JsonConverter(typeof(DateTimeOffsetConverter))]
+        public DateTimeOffset UpdatedAt { get; init; }
+
+        [JsonPropertyName("actor")]
+        public User Actor { get; init; } = null!;
+
+        [JsonPropertyName("triggering_actor")]
+        public User TriggeringActor { get; init; } = null!;
+
+        [JsonPropertyName("run_attempt")]
+        public long RunAttempt { get; init; }
+
+        [JsonPropertyName("run_started_at")]
+        [JsonConverter(typeof(DateTimeOffsetConverter))]
+        public DateTimeOffset RunStartedAt { get; init; }
+    }
+}

--- a/src/Octokit.Webhooks/Models/DeploymentEvent/DeploymentWorkflowRunConclusion.cs
+++ b/src/Octokit.Webhooks/Models/DeploymentEvent/DeploymentWorkflowRunConclusion.cs
@@ -1,0 +1,24 @@
+namespace Octokit.Webhooks.Models.DeploymentEvent
+{
+    using System.Runtime.Serialization;
+    using System.Text.Json.Serialization;
+
+    [JsonConverter(typeof(JsonStringEnumMemberConverter))]
+    public enum DeploymentWorkflowRunConclusion
+    {
+        [EnumMember(Value = "success")]
+        Success,
+        [EnumMember(Value = "failure")]
+        Failure,
+        [EnumMember(Value = "neutral")]
+        Neutral,
+        [EnumMember(Value = "cancelled")]
+        Cancelled,
+        [EnumMember(Value = "timed_out")]
+        TimedOut,
+        [EnumMember(Value = "action_required")]
+        ActionRequired,
+        [EnumMember(Value = "stale")]
+        Stale,
+    }
+}

--- a/src/Octokit.Webhooks/Models/DeploymentEvent/DeploymentWorkflowRunStatus.cs
+++ b/src/Octokit.Webhooks/Models/DeploymentEvent/DeploymentWorkflowRunStatus.cs
@@ -1,0 +1,20 @@
+namespace Octokit.Webhooks.Models.DeploymentEvent
+{
+    using System.Runtime.Serialization;
+    using System.Text.Json.Serialization;
+
+    [JsonConverter(typeof(JsonStringEnumMemberConverter))]
+    public enum DeploymentWorkflowRunStatus
+    {
+        [EnumMember(Value = "requested")]
+        Requested,
+        [EnumMember(Value = "in_progress")]
+        InProgress,
+        [EnumMember(Value = "completed")]
+        Completed,
+        [EnumMember(Value = "queued")]
+        Queued,
+        [EnumMember(Value = "waiting")]
+        Waiting,
+    }
+}

--- a/src/Octokit.Webhooks/Models/DeploymentStatusEvent/DeploymentStatus.cs
+++ b/src/Octokit.Webhooks/Models/DeploymentStatusEvent/DeploymentStatus.cs
@@ -29,6 +29,12 @@ namespace Octokit.Webhooks.Models.DeploymentStatusEvent
         [JsonPropertyName("environment")]
         public string Environment { get; init; } = null!;
 
+        [JsonPropertyName("environment_url")]
+        public string? EnvironmentUrl { get; init; }
+
+        [JsonPropertyName("log_url")]
+        public string? LogUrl { get; init; }
+
         [JsonPropertyName("target_url")]
         public string TargetUrl { get; init; } = null!;
 

--- a/src/Octokit.Webhooks/Models/WorkflowRun.cs
+++ b/src/Octokit.Webhooks/Models/WorkflowRun.cs
@@ -91,5 +91,12 @@ namespace Octokit.Webhooks.Models
 
         [JsonPropertyName("workflow_url")]
         public string WorkflowUrl { get; init; } = null!;
+
+        [JsonPropertyName("run_attempt")]
+        public long RunAttempt { get; init; }
+
+        [JsonPropertyName("run_started_at")]
+        [JsonConverter(typeof(DateTimeOffsetConverter))]
+        public DateTimeOffset RunStartedAt { get; init; }
     }
 }

--- a/src/Octokit.Webhooks/Models/WorkflowRun.cs
+++ b/src/Octokit.Webhooks/Models/WorkflowRun.cs
@@ -92,15 +92,18 @@ namespace Octokit.Webhooks.Models
         [JsonPropertyName("workflow_url")]
         public string WorkflowUrl { get; init; } = null!;
 
-        [JsonPropertyName("actor")]
-        public User Actor { get; init; } = null!;
-
         [JsonPropertyName("run_attempt")]
         public long RunAttempt { get; init; }
 
         [JsonPropertyName("run_started_at")]
         [JsonConverter(typeof(DateTimeOffsetConverter))]
         public DateTimeOffset RunStartedAt { get; init; }
+
+        [JsonPropertyName("previous_attempt_url")]
+        public string? PreviousAttemptUrl { get; init; }
+
+        [JsonPropertyName("actor")]
+        public User Actor { get; init; } = null!;
 
         [JsonPropertyName("triggering_actor")]
         public User TriggeringActor { get; init; } = null!;

--- a/src/Octokit.Webhooks/Models/WorkflowRun.cs
+++ b/src/Octokit.Webhooks/Models/WorkflowRun.cs
@@ -92,11 +92,17 @@ namespace Octokit.Webhooks.Models
         [JsonPropertyName("workflow_url")]
         public string WorkflowUrl { get; init; } = null!;
 
+        [JsonPropertyName("actor")]
+        public User Actor { get; init; } = null!;
+
         [JsonPropertyName("run_attempt")]
         public long RunAttempt { get; init; }
 
         [JsonPropertyName("run_started_at")]
         [JsonConverter(typeof(DateTimeOffsetConverter))]
         public DateTimeOffset RunStartedAt { get; init; }
+
+        [JsonPropertyName("triggering_actor")]
+        public User TriggeringActor { get; init; } = null!;
     }
 }


### PR DESCRIPTION
- Add missing properties to `DeploymentStatusEvent`
- Add missing properties to `WorkflowRun`

~I've made an assumption here that the properties for check suite and workflows are nullable.~ https://github.com/octokit/webhooks.net/pull/55#discussion_r837234585

~I've also omitted the missing `actor` and `triggering_actor` properties at this point as I'm not sure what the type should be with respect to the schema and I couldn't see an obvious existing type for it.~

Resolves #54.
