### PR TITLE
Only scan Octokit.Webhooks for [WebhookActionType]

### DIFF
--- a/src/Octokit.Webhooks/Converter/WebhookConverter.cs
+++ b/src/Octokit.Webhooks/Converter/WebhookConverter.cs
@@ -17,8 +17,7 @@
         public WebhookConverter()
         {
             var type = typeof(T);
-            this.types = AppDomain.CurrentDomain.GetAssemblies()
-                .SelectMany(x => x.GetTypes())
+            this.types = this.GetType().Assembly.GetTypes()
                 .Where(x => type.IsAssignableFrom(x) && x.IsClass && !x.IsAbstract &&
                             Attribute.GetCustomAttribute(x, typeof(WebhookActionTypeAttribute)) is not null)
                 .ToDictionary(


### PR DESCRIPTION
Only scan the types in the `Octokit.Webhooks` assembly for the `[WebhookActionType]`, rather than all assemblies in the current AppDomain.

`WebhookActionTypeAttribute` is internal and not inherited, and `InternalsVisibleToAttribute` isn't used, so it _should_ not be possible to be present on any types in any other assembly (assuming I've understood what's going on correctly).

I found this via an occasional test failure I'm getting in the CI for a project where I'm using Octokit.Webhooks.AspNetCore because the webhook converter is trying to scan dynamic assemblies created by Moq in my unit tests.

```
[2022-04-12 12:19:22Z] fail: Octokit.Webhooks.WebhookEventProcessor[0]
       Exception processing GitHub event.
 System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation.
  ---> System.Reflection.ReflectionTypeLoadException: Unable to load one or more of the requested types.
 Could not load type 'Castle.Proxies.IServiceScopeProxy' from assembly 'DynamicProxyGenAssembly2, Version=0.0.0.0, Culture=neutral, PublicKeyToken=a621a9e7e5c32e69'.
 Could not load type 'Castle.Proxies.Invocations.IMocked`1_get_Mock_7' from assembly 'DynamicProxyGenAssembly2, Version=0.0.0.0, Culture=neutral, PublicKeyToken=a621a9e7e5c32e69'.
    at System.Reflection.RuntimeModule.GetTypes(RuntimeModule module)
    at System.Reflection.RuntimeModule.GetTypes()
    at System.Reflection.Assembly.GetTypes()
    at Octokit.Webhooks.Converter.WebhookConverter`1.<>c.<.ctor>b__1_0(Assembly x)
    at System.Linq.Enumerable.SelectManySingleSelectorIterator`2.MoveNext()
    at System.Linq.Enumerable.WhereEnumerableIterator`1.MoveNext()
    at System.Linq.Enumerable.ToDictionary[TSource,TKey,TElement](IEnumerable`1 source, Func`2 keySelector, Func`2 elementSelector, IEqualityComparer`1 comparer)
    at System.Linq.Enumerable.ToDictionary[TSource,TKey,TElement](IEnumerable`1 source, Func`2 keySelector, Func`2 elementSelector)
    at Octokit.Webhooks.Converter.WebhookConverter`1..ctor()
    at System.RuntimeType.CreateInstanceDefaultCtor(Boolean publicOnly, Boolean wrapExceptions)
 System.TypeLoadException: Could not load type 'Castle.Proxies.IServiceScopeProxy' from assembly 'DynamicProxyGenAssembly2, Version=0.0.0.0, Culture=neutral, PublicKeyToken=a621a9e7e5c32e69'.
 System.TypeLoadException: Could not load type 'Castle.Proxies.Invocations.IMocked`1_get_Mock_7' from assembly 'DynamicProxyGenAssembly2, Version=0.0.0.0, Culture=neutral, PublicKeyToken=a621a9e7e5c32e69'.
    --- End of inner exception stack trace ---
    at System.RuntimeType.CreateInstanceDefaultCtor(Boolean publicOnly, Boolean wrapExceptions)
    at System.Activator.CreateInstance(Type type, Boolean nonPublic, Boolean wrapExceptions)
    at System.Activator.CreateInstance(Type type)
    at System.Text.Json.JsonSerializerOptions.GetConverterFromAttribute(JsonConverterAttribute converterAttribute, Type typeToConvert, Type classTypeAttributeIsOn, MemberInfo memberInfo)
    at System.Text.Json.JsonSerializerOptions.GetConverterInternal(Type typeToConvert)
    at System.Text.Json.JsonSerializerOptions.DetermineConverter(Type parentClassType, Type runtimePropertyType, MemberInfo memberInfo)
    at System.Text.Json.Serialization.Metadata.JsonTypeInfo.GetConverter(Type type, Type parentClassType, MemberInfo memberInfo, Type& runtimeType, JsonSerializerOptions options)
    at System.Text.Json.JsonSerializerOptions.<InitializeForReflectionSerializer>g__CreateJsonTypeInfo|[112](https://github.com/martincostello/costellobot/runs/5989735221?check_suite_focus=true#step:4:112)_0(Type type, JsonSerializerOptions options)
    at System.Text.Json.JsonSerializerOptions.GetClassFromContextOrCreate(Type type)
    at System.Text.Json.JsonSerializerOptions.GetOrAddClass(Type type)
    at System.Text.Json.JsonSerializer.GetTypeInfo(JsonSerializerOptions options, Type runtimeType)
    at System.Text.Json.JsonSerializer.Deserialize[TValue](String json, JsonSerializerOptions options)
    at Octokit.Webhooks.WebhookEventProcessor.DeserializeWebhookEvent(WebhookHeaders headers, String body)
    at MartinCostello.Costellobot.GitHubEventProcessor.ProcessWebhookAsync(IDictionary`2 headers, String body) in /_/src/Costellobot/GitHubEventProcessor.cs:line 49
    at Octokit.Webhooks.AspNetCore.GitHubWebhookExtensions.<>c__DisplayClass0_0.<<MapGitHubWebhooks>b__0>d.MoveNext()
```

As well as fixing this exception, it should make the construction of instances of the serializer more performant by reducing the work required to populate the dictionary.
