### PR TITLE
Add Skipped to WorkflowRunConclusion

### DIFF
--- a/src/Octokit.Webhooks/Models/WorkflowRunConclusion.cs
+++ b/src/Octokit.Webhooks/Models/WorkflowRunConclusion.cs
@@ -20,5 +20,7 @@
         ActionRequired,
         [EnumMember(Value = "stale")]
         Stale,
+        [EnumMember(Value = "skipped")]
+        Skipped,
     }
 }


### PR DESCRIPTION
We are seeing the following exceptions logged in an application using this framework:
```
System.Text.Json.JsonException: The JSON value 'skipped' could not be converted to Octokit.Webhooks.Models.WorkflowRunConclusion.
```
