### PR TITLE
Upgrade to .NET 6.0

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
     "rollForward": "latestFeature",
-    "version": "5.0.100"
+    "version": "6.0.100"
   }
 }

--- a/samples/AspNetCore/AspNetCore.csproj
+++ b/samples/AspNetCore/AspNetCore.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 

--- a/src/Octokit.Webhooks.AspNetCore/GitHubWebhookExtensions.cs
+++ b/src/Octokit.Webhooks.AspNetCore/GitHubWebhookExtensions.cs
@@ -54,6 +54,11 @@
 
         private static bool VerifyContentType(HttpContext context, string expectedContentType)
         {
+            if (context.Request.ContentType is null)
+            {
+                return false;
+            }
+
             var contentType = new ContentType(context.Request.ContentType);
             if (contentType.MediaType != expectedContentType)
             {

--- a/src/Octokit.Webhooks.AspNetCore/Octokit.Webhooks.AspNetCore.csproj
+++ b/src/Octokit.Webhooks.AspNetCore/Octokit.Webhooks.AspNetCore.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup Label="Build">
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup Label="Package">

--- a/src/Octokit.Webhooks/Octokit.Webhooks.csproj
+++ b/src/Octokit.Webhooks/Octokit.Webhooks.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup Label="Build">
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup Label="Package">

--- a/test/Octokit.Webhooks.Test/Octokit.Webhooks.Test.csproj
+++ b/test/Octokit.Webhooks.Test/Octokit.Webhooks.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup Label="Build">
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup Label="Project References">

--- a/test/Octokit.Webhooks.TestUtils/Octokit.Webhooks.TestUtils.csproj
+++ b/test/Octokit.Webhooks.TestUtils/Octokit.Webhooks.TestUtils.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup Label="Build">
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
.NET 5 goes out of support on the 10th May 2022[^1]. This PR should be merged before then.

Closes #37

[^1]: https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core