### PR TITLE
chore: explicitly enable renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,6 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "github>octokit/.github"
-  ]
+  ],
+  "enabled": true
 }


### PR DESCRIPTION
It's disabled at the organization level for Octokit because there is no overall maintainer. Specific projects within the Octokit organization, with maintainers, can enable it.

<!--
Please read the contributing guide before raising a pull request.
https://github.com/octokit/webhooks.net/blob/main/CONTRIBUTING.md
-->
