### PR TITLE
fix: Add merge_group app event

### DIFF
--- a/src/Octokit.Webhooks/Models/AppEvent.cs
+++ b/src/Octokit.Webhooks/Models/AppEvent.cs
@@ -50,6 +50,8 @@ public enum AppEvent
     Member,
     [EnumMember(Value = "membership")]
     Membership,
+    [EnumMember(Value = "merge_group")]
+    MergeGroup,
     [EnumMember(Value = "meta")]
     Meta,
     [EnumMember(Value = "milestone")]


### PR DESCRIPTION
Add the `merge_group` value for app events.

I just spotted this problem in an app of mine, where handling check_suite events was failing due to `merge_group` being sent in the webhook payload.

```json
      "events": [
        "branch_protection_rule",
        "check_run",
        "check_suite",
        "create",
        "delete",
        "deployment",
        "deployment_status",
        "discussion",
        "discussion_comment",
        "fork",
        "gollum",
        "issues",
        "issue_comment",
        "label",
        "merge_group",
        "milestone",
        "page_build",
        "project",
        "project_card",
        "project_column",
        "public",
        "pull_request",
        "pull_request_review",
        "pull_request_review_comment",
        "push",
        "registry_package",
        "release",
        "repository",
        "repository_dispatch",
        "status",
        "watch",
        "workflow_dispatch",
        "workflow_run"
      ]
```

```
2022-06-25 09:05:17.236 +00:00 [Error] Octokit.Webhooks.WebhookEventProcessor: Exception processing GitHub event.System.Text.Json.JsonException: The JSON value 'merge_group' could not be converted to Octokit.Webhooks.Models.AppEvent. Path: $.check_suite.app.events[14] | LineNumber: 0 | BytePositionInLine: 2251
```
