### PR TITLE
feat: add `octokit.webhooks.azurefunctions` library

### DIFF
--- a/Octokit.Webhooks.sln
+++ b/Octokit.Webhooks.sln
@@ -66,6 +66,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "samples", "samples", "{174C
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Octokit.Webhooks.TestUtils", "test\Octokit.Webhooks.TestUtils\Octokit.Webhooks.TestUtils.csproj", "{48EB4752-1A23-4DD2-AF86-21ED12475F8B}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AzureFunctions", "samples\AzureFunctions\AzureFunctions.csproj", "{8731AAA1-8F8D-441A-BD61-6CA3A16A805B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Octokit.Webhooks.AzureFunctions", "src\Octokit.Webhooks.AzureFunctions\Octokit.Webhooks.AzureFunctions.csproj", "{E7A3E0C8-CE8E-434D-8E97-723F9D5206FA}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -92,6 +96,14 @@ Global
 		{48EB4752-1A23-4DD2-AF86-21ED12475F8B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{48EB4752-1A23-4DD2-AF86-21ED12475F8B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{48EB4752-1A23-4DD2-AF86-21ED12475F8B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8731AAA1-8F8D-441A-BD61-6CA3A16A805B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8731AAA1-8F8D-441A-BD61-6CA3A16A805B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8731AAA1-8F8D-441A-BD61-6CA3A16A805B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8731AAA1-8F8D-441A-BD61-6CA3A16A805B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E7A3E0C8-CE8E-434D-8E97-723F9D5206FA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E7A3E0C8-CE8E-434D-8E97-723F9D5206FA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E7A3E0C8-CE8E-434D-8E97-723F9D5206FA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E7A3E0C8-CE8E-434D-8E97-723F9D5206FA}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -105,6 +117,8 @@ Global
 		{566DF0E2-1288-4083-9B55-4C8B69BB1432} = {EFE1E5ED-D337-4874-82EC-D9FA0BC7D3AB}
 		{2EE1581B-E8B6-409E-8879-6F1EFC8C682B} = {174C8B3B-E8D3-4845-AE7C-8C0DEC43354F}
 		{48EB4752-1A23-4DD2-AF86-21ED12475F8B} = {E1B24F25-B8A4-46EE-B7EB-7803DCFC543F}
+		{8731AAA1-8F8D-441A-BD61-6CA3A16A805B} = {174C8B3B-E8D3-4845-AE7C-8C0DEC43354F}
+		{E7A3E0C8-CE8E-434D-8E97-723F9D5206FA} = {719809C2-A551-4C4A-9EFD-B10FB5E35BC0}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {73F36209-F8D6-4066-8951-D97729F773CF}

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Libraries to handle GitHub Webhooks in .NET applications.
     builder.Services.AddSingleton<WebhookEventProcessor, MyWebhookEventProcessor>();
     ```
 
-4. Map the webhook end point:
+4. Map the webhook endpoint:
 
     ```C#
     app.UseEndpoints(endpoints =>

--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@
 
 Libraries to handle GitHub Webhooks in .NET applications.
 
-## Usage in ASP.NET Core
+## Usage
+
+### ASP.NET Core
 
 1. `dotnet add package Octokit.Webhooks.AspNetCore`
 2. Create a class that derives from `WebhookEventProcessor` and override any of the virtual methods to handle webhooks from GitHub. For example, to handle Pull Request webhooks:
@@ -20,17 +22,13 @@ Libraries to handle GitHub Webhooks in .NET applications.
     }
     ```
 
-3. Modify your `ConfigureServices()` method to register an implementation for `GitHubEventProcessor`:
+3. Register your implementation of `WebhookEventProcessor`:
 
     ```C#
-    public void ConfigureServices(IServiceCollection services)
-    {
-        ...
-        services.AddSingleton<WebhookEventProcessor, MyWebhookEventProcessor>();
-        ...
-    }
+    builder.Services.AddSingleton<WebhookEventProcessor, MyWebhookEventProcessor>();
     ```
-4. Modify your `Configure()` method to map the webhook end point:
+
+4. Map the webhook end point:
 
     ```C#
     app.UseEndpoints(endpoints =>
@@ -45,6 +43,49 @@ Libraries to handle GitHub Webhooks in .NET applications.
 
 * `path`. Defaults to `/api/github/webhooks`, the URL of the endpoint to use for GitHub.
 * `secret`. The secret you have configured in GitHub, if you have set this up.
+
+### Azure Functions
+
+**NOTE**: Support is only provided for isolated process Azure Functions.
+
+1. `dotnet add package Octokit.Webhooks.AzureFunctions`
+2. Create a class that derives from `WebhookEventProcessor` and override any of the virtual methods to handle webhooks from GitHub. For example, to handle Pull Request webhooks:
+
+    ```C#
+    public sealed class MyWebhookEventProcessor : WebhookEventProcessor
+    {
+        protected override Task ProcessPullRequestWebhookAsync(WebhookHeaders headers, PullRequestEvent pullRequestEvent, PullRequestAction action) {
+            ...
+        }
+    }
+    ```
+
+3. Register your implementation of `WebhookEventProcessor`:
+
+    ```C#
+    .ConfigureServices(collection =>
+    {
+        ...
+        collection.AddSingleton<WebhookEventProcessor, MyWebhookEventProcessor>();
+        ...
+    })
+    ```
+
+4. Configure the webhook function:
+
+    ```C#
+    new HostBuilder()
+    ...
+    .ConfigureGitHubWebhooks()
+    ...
+    .Build();
+    ```
+
+`ConfigureGitHubWebhooks()` takes one optional parameter:
+
+* `secret`. The secret you have configured in GitHub, if you have set this up.
+
+The function is available on the `/api/github/webhooks` endpoint.
 
 ## Thanks
 

--- a/samples/AzureFunctions/AzureFunctions.csproj
+++ b/samples/AzureFunctions/AzureFunctions.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <AzureFunctionsVersion>V4</AzureFunctionsVersion>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);CA1848;IDE0021;IDE0053;VSTHRD111</NoWarn>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.3.0" OutputItemType="Analyzer" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.6.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="host.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="local.settings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>Never</CopyToPublishDirectory>
+    </None>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Octokit.Webhooks.AzureFunctions\Octokit.Webhooks.AzureFunctions.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/samples/AzureFunctions/AzureFunctions.csproj
+++ b/samples/AzureFunctions/AzureFunctions.csproj
@@ -6,6 +6,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);CA1848;IDE0021;IDE0053;VSTHRD111</NoWarn>
     <OutputType>Exe</OutputType>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/AzureFunctions/AzureFunctions.csproj
+++ b/samples/AzureFunctions/AzureFunctions.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.3.0" OutputItemType="Analyzer" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.6.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.8.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/AzureFunctions/MyWebhookEventProcessor.cs
+++ b/samples/AzureFunctions/MyWebhookEventProcessor.cs
@@ -1,0 +1,32 @@
+namespace AzureFunctions;
+
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Octokit.Webhooks;
+using Octokit.Webhooks.Events;
+using Octokit.Webhooks.Events.PullRequest;
+
+public class MyWebhookEventProcessor : WebhookEventProcessor
+{
+    private readonly ILogger<MyWebhookEventProcessor> logger;
+
+    public MyWebhookEventProcessor(ILogger<MyWebhookEventProcessor> logger)
+    {
+        this.logger = logger;
+    }
+
+    protected override async Task ProcessPullRequestWebhookAsync(WebhookHeaders headers, PullRequestEvent pullRequestEvent, PullRequestAction action)
+    {
+        switch (action)
+        {
+            case PullRequestActionValue.Opened:
+                this.logger.LogInformation("pull request opened");
+                await Task.Delay(1000);
+                break;
+            default:
+                this.logger.LogInformation("Some other pull request event");
+                await Task.Delay(1000);
+                break;
+        }
+    }
+}

--- a/samples/AzureFunctions/Program.cs
+++ b/samples/AzureFunctions/Program.cs
@@ -1,0 +1,15 @@
+using AzureFunctions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Octokit.Webhooks;
+using Octokit.Webhooks.AzureFunctions;
+
+new HostBuilder()
+    .ConfigureServices(collection =>
+    {
+        collection.AddSingleton<WebhookEventProcessor, MyWebhookEventProcessor>();
+    })
+    .ConfigureGitHubWebhooks()
+    .ConfigureFunctionsWorkerDefaults()
+    .Build()
+    .Run();

--- a/samples/AzureFunctions/host.json
+++ b/samples/AzureFunctions/host.json
@@ -1,0 +1,11 @@
+{
+    "version": "2.0",
+    "logging": {
+        "applicationInsights": {
+            "samplingSettings": {
+                "isEnabled": true,
+                "excludedTypes": "Request"
+            }
+        }
+    }
+}

--- a/samples/AzureFunctions/local.settings.json
+++ b/samples/AzureFunctions/local.settings.json
@@ -1,0 +1,7 @@
+{
+    "IsEncrypted": false,
+    "Values": {
+        "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+        "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated"
+    }
+}

--- a/src/Octokit.Webhooks.AzureFunctions/GitHubWebhooksHttpFunction.cs
+++ b/src/Octokit.Webhooks.AzureFunctions/GitHubWebhooksHttpFunction.cs
@@ -1,0 +1,150 @@
+namespace Octokit.Webhooks.AzureFunctions;
+
+using System;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Mime;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Primitives;
+
+/// <summary>
+/// A class containing an Azure Function that processes GitHub webhooks.
+/// </summary>
+public partial class GitHubWebhooksHttpFunction
+{
+    private readonly IOptions<GitHubWebhooksOptions> options;
+
+    public GitHubWebhooksHttpFunction(IOptions<GitHubWebhooksOptions> options) => this.options = options;
+
+    [Function(nameof(MapGitHubWebhooksAsync))]
+    public async Task<HttpResponseData?> MapGitHubWebhooksAsync(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "POST", Route = "github/webhooks")] HttpRequestData req,
+        FunctionContext ctx)
+    {
+        var logger = ctx.InstanceServices.GetService<ILogger<GitHubWebhooksHttpFunction>>()!;
+
+        // Verify content type
+        if (!VerifyContentType(req, MediaTypeNames.Application.Json))
+        {
+            Log.IncorrectContentType(logger);
+            return req.CreateResponse(HttpStatusCode.BadRequest);
+        }
+
+        // Get body
+        var body = await GetBodyAsync(req).ConfigureAwait(false);
+
+        // Verify signature
+        if (!VerifySignature(req, this.options.Value.Secret, body))
+        {
+            Log.SignatureValidationFailed(logger);
+            return req.CreateResponse(HttpStatusCode.BadRequest);
+        }
+
+        // Process body
+        try
+        {
+            var service = ctx.InstanceServices.GetService<WebhookEventProcessor>()!;
+            var headers = req.Headers.ToDictionary(
+                kv => kv.Key,
+                kv => new StringValues(kv.Value.ToArray()),
+                StringComparer.OrdinalIgnoreCase);
+            await service.ProcessWebhookAsync(headers, body)
+                .ConfigureAwait(false);
+            return req.CreateResponse(HttpStatusCode.OK);
+        }
+        catch (Exception ex)
+        {
+            Log.ProcessingFailed(logger, ex);
+            return req.CreateResponse(HttpStatusCode.InternalServerError);
+        }
+    }
+
+    private static bool VerifyContentType(HttpRequestData req, string expectedContentType)
+    {
+        var contentHeader = req.Headers.GetValues("Content-Type").FirstOrDefault();
+        if (contentHeader is null)
+        {
+            return false;
+        }
+
+        var contentType = new ContentType(contentHeader);
+        if (contentType.MediaType != expectedContentType)
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    private static async Task<string> GetBodyAsync(HttpRequestData req)
+    {
+        using var reader = new StreamReader(req.Body);
+        return await reader.ReadToEndAsync().ConfigureAwait(false);
+    }
+
+    private static bool VerifySignature(HttpRequestData req, string? secret, string body)
+    {
+        var isSigned = req.Headers.TryGetValues("X-Hub-Signature-256", out var signatureHeader);
+        var signature = signatureHeader?.FirstOrDefault();
+
+        var isSignatureExpected = !string.IsNullOrEmpty(secret);
+
+        if (!isSigned && !isSignatureExpected)
+        {
+            // Nothing to do.
+            return true;
+        }
+
+        if (!isSigned && isSignatureExpected)
+        {
+            return false;
+        }
+
+        if (isSigned && !isSignatureExpected)
+        {
+            return false;
+        }
+
+        var keyBytes = Encoding.UTF8.GetBytes(secret!);
+        var bodyBytes = Encoding.UTF8.GetBytes(body);
+
+        var hash = HMACSHA256.HashData(keyBytes, bodyBytes);
+        var hashHex = Convert.ToHexString(hash);
+        var expectedHeader = $"sha256={hashHex.ToLower(CultureInfo.InvariantCulture)}";
+        return signature == expectedHeader;
+    }
+
+    /// <summary>
+    /// Log messages for the class.
+    /// </summary>
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+    internal static partial class Log
+    {
+        [LoggerMessage(
+            EventId = 1,
+            Level = LogLevel.Error,
+            Message = "GitHub event does not have the correct content type.")]
+        public static partial void IncorrectContentType(ILogger logger);
+
+        [LoggerMessage(
+            EventId = 2,
+            Level = LogLevel.Error,
+            Message = "GitHub event failed signature validation.")]
+        public static partial void SignatureValidationFailed(ILogger logger);
+
+        [LoggerMessage(
+            EventId = 3,
+            Level = LogLevel.Error,
+            Message = "Exception processing GitHub event.")]
+        public static partial void ProcessingFailed(ILogger logger, Exception exception);
+    }
+}

--- a/src/Octokit.Webhooks.AzureFunctions/GitHubWebhooksHttpFunction.cs
+++ b/src/Octokit.Webhooks.AzureFunctions/GitHubWebhooksHttpFunction.cs
@@ -30,7 +30,7 @@ public partial class GitHubWebhooksHttpFunction
         [HttpTrigger(AuthorizationLevel.Anonymous, "POST", Route = "github/webhooks")] HttpRequestData req,
         FunctionContext ctx)
     {
-        var logger = ctx.InstanceServices.GetService<ILogger<GitHubWebhooksHttpFunction>>()!;
+        var logger = ctx.InstanceServices.GetRequiredService<ILogger<GitHubWebhooksHttpFunction>>();
 
         // Verify content type
         if (!VerifyContentType(req, MediaTypeNames.Application.Json))
@@ -52,7 +52,7 @@ public partial class GitHubWebhooksHttpFunction
         // Process body
         try
         {
-            var service = ctx.InstanceServices.GetService<WebhookEventProcessor>()!;
+            var service = ctx.InstanceServices.GetRequiredService<WebhookEventProcessor>();
             var headers = req.Headers.ToDictionary(
                 kv => kv.Key,
                 kv => new StringValues(kv.Value.ToArray()),

--- a/src/Octokit.Webhooks.AzureFunctions/GitHubWebhooksHttpFunction.cs
+++ b/src/Octokit.Webhooks.AzureFunctions/GitHubWebhooksHttpFunction.cs
@@ -19,7 +19,7 @@ using Microsoft.Extensions.Primitives;
 /// <summary>
 /// A class containing an Azure Function that processes GitHub webhooks.
 /// </summary>
-public partial class GitHubWebhooksHttpFunction
+public sealed partial class GitHubWebhooksHttpFunction
 {
     private readonly IOptions<GitHubWebhooksOptions> options;
 
@@ -77,12 +77,7 @@ public partial class GitHubWebhooksHttpFunction
         }
 
         var contentType = new ContentType(contentHeader);
-        if (contentType.MediaType != expectedContentType)
-        {
-            return false;
-        }
-
-        return true;
+        return contentType.MediaType == expectedContentType;
     }
 
     private static async Task<string> GetBodyAsync(HttpRequestData req)

--- a/src/Octokit.Webhooks.AzureFunctions/GitHubWebhooksHttpFunction.cs
+++ b/src/Octokit.Webhooks.AzureFunctions/GitHubWebhooksHttpFunction.cs
@@ -30,7 +30,7 @@ public sealed partial class GitHubWebhooksHttpFunction
         [HttpTrigger(AuthorizationLevel.Anonymous, "POST", Route = "github/webhooks")] HttpRequestData req,
         FunctionContext ctx)
     {
-        var logger = ctx.InstanceServices.GetRequiredService<ILogger<GitHubWebhooksHttpFunction>>();
+        var logger = ctx.GetLogger(nameof(GitHubWebhooksHttpFunction));
 
         // Verify content type
         if (!VerifyContentType(req, MediaTypeNames.Application.Json))

--- a/src/Octokit.Webhooks.AzureFunctions/GitHubWebhooksOptions.cs
+++ b/src/Octokit.Webhooks.AzureFunctions/GitHubWebhooksOptions.cs
@@ -1,0 +1,6 @@
+namespace Octokit.Webhooks.AzureFunctions;
+
+public record GitHubWebhooksOptions
+{
+    public string? Secret { get; set; }
+}

--- a/src/Octokit.Webhooks.AzureFunctions/GitHubWebhooksOptions.cs
+++ b/src/Octokit.Webhooks.AzureFunctions/GitHubWebhooksOptions.cs
@@ -1,6 +1,6 @@
 namespace Octokit.Webhooks.AzureFunctions;
 
-public record GitHubWebhooksOptions
+public sealed record GitHubWebhooksOptions
 {
     public string? Secret { get; set; }
 }

--- a/src/Octokit.Webhooks.AzureFunctions/GithubWebhookHostBuilderExtensions.cs
+++ b/src/Octokit.Webhooks.AzureFunctions/GithubWebhookHostBuilderExtensions.cs
@@ -1,0 +1,19 @@
+﻿namespace Octokit.Webhooks.AzureFunctions;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+public static class GithubWebhookHostBuilderExtensions
+{
+    /// <summary>
+    /// Configures GitHub webhook function.
+    /// </summary>
+    /// <param name="hostBuilder"><see cref="IHostBuilder" /> instance.</param>
+    /// <param name="secret">The secret you have configured in GitHub, if you have set this up.</param>
+    /// <returns>Returns <see cref="IHostBuilder" /> instance.</returns>
+    public static IHostBuilder ConfigureGitHubWebhooks(this IHostBuilder hostBuilder, string? secret = null) =>
+        hostBuilder.ConfigureServices(services =>
+        {
+            services.AddOptions<GitHubWebhooksOptions>().Configure(options => { options.Secret = secret; });
+        });
+}

--- a/src/Octokit.Webhooks.AzureFunctions/GithubWebhookHostBuilderExtensions.cs
+++ b/src/Octokit.Webhooks.AzureFunctions/GithubWebhookHostBuilderExtensions.cs
@@ -13,7 +13,5 @@ public static class GithubWebhookHostBuilderExtensions
     /// <returns>Returns <see cref="IHostBuilder" /> instance.</returns>
     public static IHostBuilder ConfigureGitHubWebhooks(this IHostBuilder hostBuilder, string? secret = null) =>
         hostBuilder.ConfigureServices(services =>
-        {
-            services.AddOptions<GitHubWebhooksOptions>().Configure(options => { options.Secret = secret; });
-        });
+            services.AddOptions<GitHubWebhooksOptions>().Configure(options => { options.Secret = secret; }));
 }

--- a/src/Octokit.Webhooks.AzureFunctions/Octokit.Webhooks.AzureFunctions.csproj
+++ b/src/Octokit.Webhooks.AzureFunctions/Octokit.Webhooks.AzureFunctions.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+  </PropertyGroup>
+
+  <PropertyGroup Label="Package">
+    <Product>Octokit.Webhooks.AzureFunctions</Product>
+    <Description>GitHub webhook events toolset for .NET</Description>
+    <PackageTags>Octokit;GitHub;Webhooks</PackageTags>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Octokit.Webhooks\Octokit.Webhooks.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Core" Version="1.4.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Abstractions" Version="1.1.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.0.13" />
+  </ItemGroup>
+
+</Project>

--- a/src/Octokit.Webhooks.AzureFunctions/Octokit.Webhooks.AzureFunctions.csproj
+++ b/src/Octokit.Webhooks.AzureFunctions/Octokit.Webhooks.AzureFunctions.csproj
@@ -6,8 +6,8 @@
 
   <PropertyGroup Label="Package">
     <Product>Octokit.Webhooks.AzureFunctions</Product>
-    <Description>GitHub webhook events toolset for .NET</Description>
-    <PackageTags>Octokit;GitHub;Webhooks</PackageTags>
+    <Description>GitHub webhook events toolset for Azure Functions</Description>
+    <PackageTags>Octokit;GitHub;Webhooks;AzureFunctions</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Octokit.Webhooks.AzureFunctions/Octokit.Webhooks.AzureFunctions.csproj
+++ b/src/Octokit.Webhooks.AzureFunctions/Octokit.Webhooks.AzureFunctions.csproj
@@ -19,7 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Core" Version="1.4.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Core" Version="1.6.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Abstractions" Version="1.1.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.0.13" />
   </ItemGroup>


### PR DESCRIPTION
<!--
Please read the contributing guide before raising a pull request.
https://github.com/octokit/webhooks.net/blob/main/CONTRIBUTING.md
-->
This adds the `Octokit.Webhooks.AzureFunctions` package, which allows for easy use of `Octokit.Webhooks` in Azure Functions projects. The package targets .NET 6.0 isolated Azure Functions[^1]

By adding the package to your project, an HTTP POST triggered function is registered under the `/api/github/webhooks` path.

This also includes an MVP sample project to show how to configure an Azure Functions project.

Closes #36

[^1]: https://docs.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide