### PR TITLE
ci: set `ignorePaths` for renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,5 +3,6 @@
   "extends": [
     "github>octokit/.github",
     ":dependencyDashboard"
-  ]
+  ],
+  "ignorePaths": []
 }


### PR DESCRIPTION
<!--
Please read the contributing guide before raising a pull request.
https://github.com/octokit/webhooks.net/blob/main/CONTRIBUTING.md
-->
The default setting for `ignorePaths` skips the projects under the `test` directory.