### PR TITLE
fix: Add App to HookType

### DIFF
--- a/src/Octokit.Webhooks/Models/PingEvent/HookType.cs
+++ b/src/Octokit.Webhooks/Models/PingEvent/HookType.cs
@@ -12,4 +12,6 @@ public enum HookType
     Repository,
     [EnumMember(Value = "Organization")]
     Organization,
+    [EnumMember(Value = "App")]
+    App,
 }


### PR DESCRIPTION
Add missing `App` value to `HookType`.

Looks like it's [missing from the schema](https://github.com/octokit/webhooks/blob/2bd8c0e7fff3d38a4a5669c4b52f4e05ba6bccf2/payload-schemas/api.github.com/ping/event.schema.json#L29), but I'm 99.9% sure that [this example](https://github.com/martincostello/costellobot/blob/420f9f4eeb78e5afa5da4e3fc3f32362e75ddf1f/tests/Costellobot.Tests/UITests.cs#L137-L164) from my GitHub App's tests [that now fail with the latest update](https://github.com/martincostello/costellobot/runs/7228744519?check_suite_focus=true#step:4:470) was adapted from the real webhook payload I received when I was developing it.

It would also make sense, because [the documentation mentions the app-specific property `app_id`](https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#ping).

I just created a new app to test the theory using GHES 3.5.1, and this was the payload delivered to the newly-created app.

```json
{
  "zen": "Half measures are as bad as nothing at all.",
  "hook_id": 5692,
  "hook": {
    "type": "App",
    "id": 5692,
    "name": "web",
    "active": true,
    "events": [
      "meta"
    ],
    "config": {
      "content_type": "json",
      "insecure_ssl": "0",
      "url": "https://GHESHOSTNAME/"
    },
    "updated_at": "2022-07-07T07:51:54Z",
    "created_at": "2022-07-07T07:51:54Z",
    "app_id": 28,
    "deliveries_url": "https://GHESHOSTNAME/api/v3/app/hook/deliveries"
  }
}
```
