### PR TITLE
feat: Add fallback for unknown enum values

### DIFF
--- a/src/Octokit.Webhooks/Converter/JsonStringEnumMemberConverterWithFallback.cs
+++ b/src/Octokit.Webhooks/Converter/JsonStringEnumMemberConverterWithFallback.cs
@@ -1,0 +1,14 @@
+namespace System.Text.Json.Serialization;
+
+public sealed class JsonStringEnumMemberConverterWithFallback : JsonStringEnumMemberConverter
+{
+    private static readonly JsonStringEnumMemberConverterOptions Options = new()
+    {
+        DeserializationFailureFallbackValue = 0,
+    };
+
+    public JsonStringEnumMemberConverterWithFallback()
+        : base(Options)
+    {
+    }
+}

--- a/src/Octokit.Webhooks/Converter/JsonStringEnumMemberConverterWithFallback.cs
+++ b/src/Octokit.Webhooks/Converter/JsonStringEnumMemberConverterWithFallback.cs
@@ -4,7 +4,7 @@ public sealed class JsonStringEnumMemberConverterWithFallback : JsonStringEnumMe
 {
     private static readonly JsonStringEnumMemberConverterOptions Options = new()
     {
-        DeserializationFailureFallbackValue = 0,
+        DeserializationFailureFallbackValue = -1, // By convention, we use -1 to represent unknown values in all enums.
     };
 
     public JsonStringEnumMemberConverterWithFallback()

--- a/src/Octokit.Webhooks/Models/ActiveLockReason.cs
+++ b/src/Octokit.Webhooks/Models/ActiveLockReason.cs
@@ -5,7 +5,7 @@ using System.Text.Json.Serialization;
 using JetBrains.Annotations;
 
 [PublicAPI]
-[JsonConverter(typeof(JsonStringEnumMemberConverter))]
+[JsonConverter(typeof(JsonStringEnumMemberConverterWithFallback))]
 public enum ActiveLockReason
 {
     [EnumMember(Value = "resolved")]

--- a/src/Octokit.Webhooks/Models/ActiveLockReason.cs
+++ b/src/Octokit.Webhooks/Models/ActiveLockReason.cs
@@ -8,6 +8,7 @@ using JetBrains.Annotations;
 [JsonConverter(typeof(JsonStringEnumMemberConverterWithFallback))]
 public enum ActiveLockReason
 {
+    Unknown = -1,
     [EnumMember(Value = "resolved")]
     Resolved,
     [EnumMember(Value = "off-topic")]

--- a/src/Octokit.Webhooks/Models/AppEvent.cs
+++ b/src/Octokit.Webhooks/Models/AppEvent.cs
@@ -8,6 +8,7 @@ using JetBrains.Annotations;
 [JsonConverter(typeof(JsonStringEnumMemberConverterWithFallback))]
 public enum AppEvent
 {
+    Unknown = -1,
     [EnumMember(Value = "*")]
     All,
     [EnumMember(Value = "branch_protection_rule")]

--- a/src/Octokit.Webhooks/Models/AppEvent.cs
+++ b/src/Octokit.Webhooks/Models/AppEvent.cs
@@ -5,7 +5,7 @@ using System.Text.Json.Serialization;
 using JetBrains.Annotations;
 
 [PublicAPI]
-[JsonConverter(typeof(JsonStringEnumMemberConverter))]
+[JsonConverter(typeof(JsonStringEnumMemberConverterWithFallback))]
 public enum AppEvent
 {
     [EnumMember(Value = "*")]

--- a/src/Octokit.Webhooks/Models/AppPermissionsLevel.cs
+++ b/src/Octokit.Webhooks/Models/AppPermissionsLevel.cs
@@ -8,6 +8,7 @@ using JetBrains.Annotations;
 [JsonConverter(typeof(JsonStringEnumMemberConverterWithFallback))]
 public enum AppPermissionsLevel
 {
+    Unknown = -1,
     [EnumMember(Value = "read")]
     Read,
     [EnumMember(Value = "write")]

--- a/src/Octokit.Webhooks/Models/AppPermissionsLevel.cs
+++ b/src/Octokit.Webhooks/Models/AppPermissionsLevel.cs
@@ -5,7 +5,7 @@ using System.Text.Json.Serialization;
 using JetBrains.Annotations;
 
 [PublicAPI]
-[JsonConverter(typeof(JsonStringEnumMemberConverter))]
+[JsonConverter(typeof(JsonStringEnumMemberConverterWithFallback))]
 public enum AppPermissionsLevel
 {
     [EnumMember(Value = "read")]

--- a/src/Octokit.Webhooks/Models/AuthorAssociation.cs
+++ b/src/Octokit.Webhooks/Models/AuthorAssociation.cs
@@ -8,6 +8,7 @@ using JetBrains.Annotations;
 [JsonConverter(typeof(JsonStringEnumMemberConverterWithFallback))]
 public enum AuthorAssociation
 {
+    Unknown = -1,
     [EnumMember(Value = "COLLABORATOR")]
     Collaborator,
     [EnumMember(Value = "CONTRIBUTOR")]

--- a/src/Octokit.Webhooks/Models/AuthorAssociation.cs
+++ b/src/Octokit.Webhooks/Models/AuthorAssociation.cs
@@ -5,7 +5,7 @@ using System.Text.Json.Serialization;
 using JetBrains.Annotations;
 
 [PublicAPI]
-[JsonConverter(typeof(JsonStringEnumMemberConverter))]
+[JsonConverter(typeof(JsonStringEnumMemberConverterWithFallback))]
 public enum AuthorAssociation
 {
     [EnumMember(Value = "COLLABORATOR")]

--- a/src/Octokit.Webhooks/Models/CheckRunEvent/CheckRunConclusion.cs
+++ b/src/Octokit.Webhooks/Models/CheckRunEvent/CheckRunConclusion.cs
@@ -8,6 +8,7 @@ using JetBrains.Annotations;
 [JsonConverter(typeof(JsonStringEnumMemberConverterWithFallback))]
 public enum CheckRunConclusion
 {
+    Unknown = -1,
     [EnumMember(Value = "success")]
     Success,
     [EnumMember(Value = "failure")]

--- a/src/Octokit.Webhooks/Models/CheckRunEvent/CheckRunConclusion.cs
+++ b/src/Octokit.Webhooks/Models/CheckRunEvent/CheckRunConclusion.cs
@@ -5,7 +5,7 @@ using System.Text.Json.Serialization;
 using JetBrains.Annotations;
 
 [PublicAPI]
-[JsonConverter(typeof(JsonStringEnumMemberConverter))]
+[JsonConverter(typeof(JsonStringEnumMemberConverterWithFallback))]
 public enum CheckRunConclusion
 {
     [EnumMember(Value = "success")]

--- a/src/Octokit.Webhooks/Models/CheckRunEvent/CheckRunStatus.cs
+++ b/src/Octokit.Webhooks/Models/CheckRunEvent/CheckRunStatus.cs
@@ -5,7 +5,7 @@ using System.Text.Json.Serialization;
 using JetBrains.Annotations;
 
 [PublicAPI]
-[JsonConverter(typeof(JsonStringEnumMemberConverter))]
+[JsonConverter(typeof(JsonStringEnumMemberConverterWithFallback))]
 public enum CheckRunStatus
 {
     [EnumMember(Value = "requested")]

--- a/src/Octokit.Webhooks/Models/CheckRunEvent/CheckRunStatus.cs
+++ b/src/Octokit.Webhooks/Models/CheckRunEvent/CheckRunStatus.cs
@@ -8,6 +8,7 @@ using JetBrains.Annotations;
 [JsonConverter(typeof(JsonStringEnumMemberConverterWithFallback))]
 public enum CheckRunStatus
 {
+    Unknown = -1,
     [EnumMember(Value = "requested")]
     Requested,
     [EnumMember(Value = "in_progress")]

--- a/src/Octokit.Webhooks/Models/CheckRunEvent/CheckSuiteConclusion.cs
+++ b/src/Octokit.Webhooks/Models/CheckRunEvent/CheckSuiteConclusion.cs
@@ -8,6 +8,7 @@ using JetBrains.Annotations;
 [JsonConverter(typeof(JsonStringEnumMemberConverterWithFallback))]
 public enum CheckSuiteConclusion
 {
+    Unknown = -1,
     [EnumMember(Value = "success")]
     Success,
     [EnumMember(Value = "failure")]

--- a/src/Octokit.Webhooks/Models/CheckRunEvent/CheckSuiteConclusion.cs
+++ b/src/Octokit.Webhooks/Models/CheckRunEvent/CheckSuiteConclusion.cs
@@ -5,7 +5,7 @@ using System.Text.Json.Serialization;
 using JetBrains.Annotations;
 
 [PublicAPI]
-[JsonConverter(typeof(JsonStringEnumMemberConverter))]
+[JsonConverter(typeof(JsonStringEnumMemberConverterWithFallback))]
 public enum CheckSuiteConclusion
 {
     [EnumMember(Value = "success")]

--- a/src/Octokit.Webhooks/Models/CheckRunEvent/CheckSuiteStatus.cs
+++ b/src/Octokit.Webhooks/Models/CheckRunEvent/CheckSuiteStatus.cs
@@ -5,7 +5,7 @@ using System.Text.Json.Serialization;
 using JetBrains.Annotations;
 
 [PublicAPI]
-[JsonConverter(typeof(JsonStringEnumMemberConverter))]
+[JsonConverter(typeof(JsonStringEnumMemberConverterWithFallback))]
 public enum CheckSuiteStatus
 {
     [EnumMember(Value = "queued")]

--- a/src/Octokit.Webhooks/Models/CheckRunEvent/CheckSuiteStatus.cs
+++ b/src/Octokit.Webhooks/Models/CheckRunEvent/CheckSuiteStatus.cs
@@ -8,6 +8,7 @@ using JetBrains.Annotations;
 [JsonConverter(typeof(JsonStringEnumMemberConverterWithFallback))]
 public enum CheckSuiteStatus
 {
+    Unknown = -1,
     [EnumMember(Value = "queued")]
     Queued,
     [EnumMember(Value = "in_progress")]

--- a/src/Octokit.Webhooks/Models/CheckSuiteEvent/CheckSuiteConclusion.cs
+++ b/src/Octokit.Webhooks/Models/CheckSuiteEvent/CheckSuiteConclusion.cs
@@ -8,6 +8,7 @@ using JetBrains.Annotations;
 [JsonConverter(typeof(JsonStringEnumMemberConverterWithFallback))]
 public enum CheckSuiteConclusion
 {
+    Unknown = -1,
     [EnumMember(Value = "success")]
     Success,
     [EnumMember(Value = "failure")]

--- a/src/Octokit.Webhooks/Models/CheckSuiteEvent/CheckSuiteConclusion.cs
+++ b/src/Octokit.Webhooks/Models/CheckSuiteEvent/CheckSuiteConclusion.cs
@@ -5,7 +5,7 @@ using System.Text.Json.Serialization;
 using JetBrains.Annotations;
 
 [PublicAPI]
-[JsonConverter(typeof(JsonStringEnumMemberConverter))]
+[JsonConverter(typeof(JsonStringEnumMemberConverterWithFallback))]
 public enum CheckSuiteConclusion
 {
     [EnumMember(Value = "success")]

--- a/src/Octokit.Webhooks/Models/CheckSuiteEvent/CheckSuiteStatus.cs
+++ b/src/Octokit.Webhooks/Models/CheckSuiteEvent/CheckSuiteStatus.cs
@@ -8,6 +8,7 @@ using JetBrains.Annotations;
 [JsonConverter(typeof(JsonStringEnumMemberConverterWithFallback))]
 public enum CheckSuiteStatus
 {
+    Unknown = -1,
     [EnumMember(Value = "requested")]
     Requested,
     [EnumMember(Value = "in_progress")]

--- a/src/Octokit.Webhooks/Models/CheckSuiteEvent/CheckSuiteStatus.cs
+++ b/src/Octokit.Webhooks/Models/CheckSuiteEvent/CheckSuiteStatus.cs
@@ -5,7 +5,7 @@ using System.Text.Json.Serialization;
 using JetBrains.Annotations;
 
 [PublicAPI]
-[JsonConverter(typeof(JsonStringEnumMemberConverter))]
+[JsonConverter(typeof(JsonStringEnumMemberConverterWithFallback))]
 public enum CheckSuiteStatus
 {
     [EnumMember(Value = "requested")]

--- a/src/Octokit.Webhooks/Models/CodeScanningAlertEvent/AlertRuleSeverity.cs
+++ b/src/Octokit.Webhooks/Models/CodeScanningAlertEvent/AlertRuleSeverity.cs
@@ -8,6 +8,7 @@ using JetBrains.Annotations;
 [JsonConverter(typeof(JsonStringEnumMemberConverterWithFallback))]
 public enum AlertRuleSeverity
 {
+    Unknown = -1,
     [EnumMember(Value = "none")]
     Open,
     [EnumMember(Value = "note")]

--- a/src/Octokit.Webhooks/Models/CodeScanningAlertEvent/AlertRuleSeverity.cs
+++ b/src/Octokit.Webhooks/Models/CodeScanningAlertEvent/AlertRuleSeverity.cs
@@ -5,7 +5,7 @@ using System.Text.Json.Serialization;
 using JetBrains.Annotations;
 
 [PublicAPI]
-[JsonConverter(typeof(JsonStringEnumMemberConverter))]
+[JsonConverter(typeof(JsonStringEnumMemberConverterWithFallback))]
 public enum AlertRuleSeverity
 {
     [EnumMember(Value = "none")]

--- a/src/Octokit.Webhooks/Models/CodeScanningAlertEvent/AlertState.cs
+++ b/src/Octokit.Webhooks/Models/CodeScanningAlertEvent/AlertState.cs
@@ -8,6 +8,7 @@ using JetBrains.Annotations;
 [JsonConverter(typeof(JsonStringEnumMemberConverterWithFallback))]
 public enum AlertState
 {
+    Unknown = -1,
     [EnumMember(Value = "open")]
     Open,
     [EnumMember(Value = "dismissed")]

--- a/src/Octokit.Webhooks/Models/CodeScanningAlertEvent/AlertState.cs
+++ b/src/Octokit.Webhooks/Models/CodeScanningAlertEvent/AlertState.cs
@@ -5,7 +5,7 @@ using System.Text.Json.Serialization;
 using JetBrains.Annotations;
 
 [PublicAPI]
-[JsonConverter(typeof(JsonStringEnumMemberConverter))]
+[JsonConverter(typeof(JsonStringEnumMemberConverterWithFallback))]
 public enum AlertState
 {
     [EnumMember(Value = "open")]

--- a/src/Octokit.Webhooks/Models/CodeScanningAlertEvent/DismissedReason.cs
+++ b/src/Octokit.Webhooks/Models/CodeScanningAlertEvent/DismissedReason.cs
@@ -5,7 +5,7 @@ using System.Text.Json.Serialization;
 using JetBrains.Annotations;
 
 [PublicAPI]
-[JsonConverter(typeof(JsonStringEnumMemberConverter))]
+[JsonConverter(typeof(JsonStringEnumMemberConverterWithFallback))]
 public enum DismissedReason
 {
     [EnumMember(Value = "false positive")]

--- a/src/Octokit.Webhooks/Models/CodeScanningAlertEvent/DismissedReason.cs
+++ b/src/Octokit.Webhooks/Models/CodeScanningAlertEvent/DismissedReason.cs
@@ -8,6 +8,7 @@ using JetBrains.Annotations;
 [JsonConverter(typeof(JsonStringEnumMemberConverterWithFallback))]
 public enum DismissedReason
 {
+    Unknown = -1,
     [EnumMember(Value = "false positive")]
     FalsePositive,
     [EnumMember(Value = "won't fix")]

--- a/src/Octokit.Webhooks/Models/DeploymentEvent/DeploymentCheckRunConclusion.cs
+++ b/src/Octokit.Webhooks/Models/DeploymentEvent/DeploymentCheckRunConclusion.cs
@@ -5,7 +5,7 @@ using System.Text.Json.Serialization;
 using JetBrains.Annotations;
 
 [PublicAPI]
-[JsonConverter(typeof(JsonStringEnumMemberConverter))]
+[JsonConverter(typeof(JsonStringEnumMemberConverterWithFallback))]
 public enum DeploymentCheckRunConclusion
 {
     [EnumMember(Value = "success")]

--- a/src/Octokit.Webhooks/Models/DeploymentEvent/DeploymentCheckRunConclusion.cs
+++ b/src/Octokit.Webhooks/Models/DeploymentEvent/DeploymentCheckRunConclusion.cs
@@ -8,6 +8,7 @@ using JetBrains.Annotations;
 [JsonConverter(typeof(JsonStringEnumMemberConverterWithFallback))]
 public enum DeploymentCheckRunConclusion
 {
+    Unknown = -1,
     [EnumMember(Value = "success")]
     Success,
     [EnumMember(Value = "failure")]

--- a/src/Octokit.Webhooks/Models/DeploymentEvent/DeploymentCheckRunStatus.cs
+++ b/src/Octokit.Webhooks/Models/DeploymentEvent/DeploymentCheckRunStatus.cs
@@ -5,7 +5,7 @@ using System.Text.Json.Serialization;
 using JetBrains.Annotations;
 
 [PublicAPI]
-[JsonConverter(typeof(JsonStringEnumMemberConverter))]
+[JsonConverter(typeof(JsonStringEnumMemberConverterWithFallback))]
 public enum DeploymentCheckRunStatus
 {
     [EnumMember(Value = "requested")]

--- a/src/Octokit.Webhooks/Models/DeploymentEvent/DeploymentCheckRunStatus.cs
+++ b/src/Octokit.Webhooks/Models/DeploymentEvent/DeploymentCheckRunStatus.cs
@@ -8,6 +8,7 @@ using JetBrains.Annotations;
 [JsonConverter(typeof(JsonStringEnumMemberConverterWithFallback))]
 public enum DeploymentCheckRunStatus
 {
+    Unknown = -1,
     [EnumMember(Value = "requested")]
     Requested,
     [EnumMember(Value = "in_progress")]

--- a/src/Octokit.Webhooks/Models/DeploymentEvent/DeploymentWorkflowRunConclusion.cs
+++ b/src/Octokit.Webhooks/Models/DeploymentEvent/DeploymentWorkflowRunConclusion.cs
@@ -8,6 +8,7 @@ using JetBrains.Annotations;
 [JsonConverter(typeof(JsonStringEnumMemberConverterWithFallback))]
 public enum DeploymentWorkflowRunConclusion
 {
+    Unknown = -1,
     [EnumMember(Value = "success")]
     Success,
     [EnumMember(Value = "failure")]

--- a/src/Octokit.Webhooks/Models/DeploymentEvent/DeploymentWorkflowRunConclusion.cs
+++ b/src/Octokit.Webhooks/Models/DeploymentEvent/DeploymentWorkflowRunConclusion.cs
@@ -5,7 +5,7 @@ using System.Text.Json.Serialization;
 using JetBrains.Annotations;
 
 [PublicAPI]
-[JsonConverter(typeof(JsonStringEnumMemberConverter))]
+[JsonConverter(typeof(JsonStringEnumMemberConverterWithFallback))]
 public enum DeploymentWorkflowRunConclusion
 {
     [EnumMember(Value = "success")]

--- a/src/Octokit.Webhooks/Models/DeploymentEvent/DeploymentWorkflowRunStatus.cs
+++ b/src/Octokit.Webhooks/Models/DeploymentEvent/DeploymentWorkflowRunStatus.cs
@@ -5,7 +5,7 @@ using System.Text.Json.Serialization;
 using JetBrains.Annotations;
 
 [PublicAPI]
-[JsonConverter(typeof(JsonStringEnumMemberConverter))]
+[JsonConverter(typeof(JsonStringEnumMemberConverterWithFallback))]
 public enum DeploymentWorkflowRunStatus
 {
     [EnumMember(Value = "requested")]

--- a/src/Octokit.Webhooks/Models/DeploymentEvent/DeploymentWorkflowRunStatus.cs
+++ b/src/Octokit.Webhooks/Models/DeploymentEvent/DeploymentWorkflowRunStatus.cs
@@ -8,6 +8,7 @@ using JetBrains.Annotations;
 [JsonConverter(typeof(JsonStringEnumMemberConverterWithFallback))]
 public enum DeploymentWorkflowRunStatus
 {
+    Unknown = -1,
     [EnumMember(Value = "requested")]
     Requested,
     [EnumMember(Value = "in_progress")]

--- a/src/Octokit.Webhooks/Models/DeploymentStatusEvent/DeploymentStatusState.cs
+++ b/src/Octokit.Webhooks/Models/DeploymentStatusEvent/DeploymentStatusState.cs
@@ -5,7 +5,7 @@ using System.Text.Json.Serialization;
 using JetBrains.Annotations;
 
 [PublicAPI]
-[JsonConverter(typeof(JsonStringEnumMemberConverter))]
+[JsonConverter(typeof(JsonStringEnumMemberConverterWithFallback))]
 public enum DeploymentStatusState
 {
     [EnumMember(Value = "pending")]

--- a/src/Octokit.Webhooks/Models/DeploymentStatusEvent/DeploymentStatusState.cs
+++ b/src/Octokit.Webhooks/Models/DeploymentStatusEvent/DeploymentStatusState.cs
@@ -8,6 +8,7 @@ using JetBrains.Annotations;
 [JsonConverter(typeof(JsonStringEnumMemberConverterWithFallback))]
 public enum DeploymentStatusState
 {
+    Unknown = -1,
     [EnumMember(Value = "pending")]
     Pending,
     [EnumMember(Value = "in_progress")]

--- a/src/Octokit.Webhooks/Models/DiscussionState.cs
+++ b/src/Octokit.Webhooks/Models/DiscussionState.cs
@@ -5,7 +5,7 @@ using System.Text.Json.Serialization;
 using JetBrains.Annotations;
 
 [PublicAPI]
-[JsonConverter(typeof(JsonStringEnumMemberConverter))]
+[JsonConverter(typeof(JsonStringEnumMemberConverterWithFallback))]
 public enum DiscussionState
 {
     [EnumMember(Value = "open")]

--- a/src/Octokit.Webhooks/Models/DiscussionState.cs
+++ b/src/Octokit.Webhooks/Models/DiscussionState.cs
@@ -8,6 +8,7 @@ using JetBrains.Annotations;
 [JsonConverter(typeof(JsonStringEnumMemberConverterWithFallback))]
 public enum DiscussionState
 {
+    Unknown = -1,
     [EnumMember(Value = "open")]
     Open,
     [EnumMember(Value = "locked")]

--- a/src/Octokit.Webhooks/Models/EnforcementLevel.cs
+++ b/src/Octokit.Webhooks/Models/EnforcementLevel.cs
@@ -5,7 +5,7 @@ using System.Text.Json.Serialization;
 using JetBrains.Annotations;
 
 [PublicAPI]
-[JsonConverter(typeof(JsonStringEnumMemberConverter))]
+[JsonConverter(typeof(JsonStringEnumMemberConverterWithFallback))]
 public enum EnforcementLevel
 {
     [EnumMember(Value = "off")]

--- a/src/Octokit.Webhooks/Models/EnforcementLevel.cs
+++ b/src/Octokit.Webhooks/Models/EnforcementLevel.cs
@@ -8,6 +8,7 @@ using JetBrains.Annotations;
 [JsonConverter(typeof(JsonStringEnumMemberConverterWithFallback))]
 public enum EnforcementLevel
 {
+    Unknown = -1,
     [EnumMember(Value = "off")]
     Off,
     [EnumMember(Value = "non_admins")]

--- a/src/Octokit.Webhooks/Models/GollumEvent/PageAction.cs
+++ b/src/Octokit.Webhooks/Models/GollumEvent/PageAction.cs
@@ -8,6 +8,7 @@ using JetBrains.Annotations;
 [JsonConverter(typeof(JsonStringEnumMemberConverterWithFallback))]
 public enum PageAction
 {
+    Unknown = -1,
     [EnumMember(Value = "created")]
     Created,
     [EnumMember(Value = "edited")]

--- a/src/Octokit.Webhooks/Models/GollumEvent/PageAction.cs
+++ b/src/Octokit.Webhooks/Models/GollumEvent/PageAction.cs
@@ -5,7 +5,7 @@ using System.Text.Json.Serialization;
 using JetBrains.Annotations;
 
 [PublicAPI]
-[JsonConverter(typeof(JsonStringEnumMemberConverter))]
+[JsonConverter(typeof(JsonStringEnumMemberConverterWithFallback))]
 public enum PageAction
 {
     [EnumMember(Value = "created")]

--- a/src/Octokit.Webhooks/Models/InstallationRepositorySelection.cs
+++ b/src/Octokit.Webhooks/Models/InstallationRepositorySelection.cs
@@ -5,7 +5,7 @@ using System.Text.Json.Serialization;
 using JetBrains.Annotations;
 
 [PublicAPI]
-[JsonConverter(typeof(JsonStringEnumMemberConverter))]
+[JsonConverter(typeof(JsonStringEnumMemberConverterWithFallback))]
 public enum InstallationRepositorySelection
 {
     [EnumMember(Value = "all")]

--- a/src/Octokit.Webhooks/Models/InstallationRepositorySelection.cs
+++ b/src/Octokit.Webhooks/Models/InstallationRepositorySelection.cs
@@ -8,6 +8,7 @@ using JetBrains.Annotations;
 [JsonConverter(typeof(JsonStringEnumMemberConverterWithFallback))]
 public enum InstallationRepositorySelection
 {
+    Unknown = -1,
     [EnumMember(Value = "all")]
     All,
     [EnumMember(Value = "selected")]

--- a/src/Octokit.Webhooks/Models/InstallationTargetType.cs
+++ b/src/Octokit.Webhooks/Models/InstallationTargetType.cs
@@ -8,6 +8,7 @@ using JetBrains.Annotations;
 [JsonConverter(typeof(JsonStringEnumMemberConverterWithFallback))]
 public enum InstallationTargetType
 {
+    Unknown = -1,
     [EnumMember(Value = "User")]
     User,
     [EnumMember(Value = "Organization")]

--- a/src/Octokit.Webhooks/Models/InstallationTargetType.cs
+++ b/src/Octokit.Webhooks/Models/InstallationTargetType.cs
@@ -5,7 +5,7 @@ using System.Text.Json.Serialization;
 using JetBrains.Annotations;
 
 [PublicAPI]
-[JsonConverter(typeof(JsonStringEnumMemberConverter))]
+[JsonConverter(typeof(JsonStringEnumMemberConverterWithFallback))]
 public enum InstallationTargetType
 {
     [EnumMember(Value = "User")]

--- a/src/Octokit.Webhooks/Models/IssueState.cs
+++ b/src/Octokit.Webhooks/Models/IssueState.cs
@@ -5,7 +5,7 @@ using System.Text.Json.Serialization;
 using JetBrains.Annotations;
 
 [PublicAPI]
-[JsonConverter(typeof(JsonStringEnumMemberConverter))]
+[JsonConverter(typeof(JsonStringEnumMemberConverterWithFallback))]
 public enum IssueState
 {
     [EnumMember(Value = "open")]

--- a/src/Octokit.Webhooks/Models/IssueState.cs
+++ b/src/Octokit.Webhooks/Models/IssueState.cs
@@ -8,6 +8,7 @@ using JetBrains.Annotations;
 [JsonConverter(typeof(JsonStringEnumMemberConverterWithFallback))]
 public enum IssueState
 {
+    Unknown = -1,
     [EnumMember(Value = "open")]
     Open,
     [EnumMember(Value = "closed")]

--- a/src/Octokit.Webhooks/Models/MembershipAddedEvent/Scope.cs
+++ b/src/Octokit.Webhooks/Models/MembershipAddedEvent/Scope.cs
@@ -8,6 +8,7 @@ using JetBrains.Annotations;
 [JsonConverter(typeof(JsonStringEnumMemberConverterWithFallback))]
 public enum Scope
 {
+    Unknown = -1,
     [EnumMember(Value = "team")]
     Team,
 }

--- a/src/Octokit.Webhooks/Models/MembershipAddedEvent/Scope.cs
+++ b/src/Octokit.Webhooks/Models/MembershipAddedEvent/Scope.cs
@@ -5,7 +5,7 @@ using System.Text.Json.Serialization;
 using JetBrains.Annotations;
 
 [PublicAPI]
-[JsonConverter(typeof(JsonStringEnumMemberConverter))]
+[JsonConverter(typeof(JsonStringEnumMemberConverterWithFallback))]
 public enum Scope
 {
     [EnumMember(Value = "team")]

--- a/src/Octokit.Webhooks/Models/MetaEvent/HookConfigContentType.cs
+++ b/src/Octokit.Webhooks/Models/MetaEvent/HookConfigContentType.cs
@@ -8,6 +8,7 @@ using JetBrains.Annotations;
 [JsonConverter(typeof(JsonStringEnumMemberConverterWithFallback))]
 public enum HookConfigContentType
 {
+    Unknown = -1,
     [EnumMember(Value = "json")]
     Json,
     [EnumMember(Value = "form")]

--- a/src/Octokit.Webhooks/Models/MetaEvent/HookConfigContentType.cs
+++ b/src/Octokit.Webhooks/Models/MetaEvent/HookConfigContentType.cs
@@ -5,7 +5,7 @@ using System.Text.Json.Serialization;
 using JetBrains.Annotations;
 
 [PublicAPI]
-[JsonConverter(typeof(JsonStringEnumMemberConverter))]
+[JsonConverter(typeof(JsonStringEnumMemberConverterWithFallback))]
 public enum HookConfigContentType
 {
     [EnumMember(Value = "json")]

--- a/src/Octokit.Webhooks/Models/MilestoneState.cs
+++ b/src/Octokit.Webhooks/Models/MilestoneState.cs
@@ -8,6 +8,7 @@ using JetBrains.Annotations;
 [JsonConverter(typeof(JsonStringEnumMemberConverterWithFallback))]
 public enum MilestoneState
 {
+    Unknown = -1,
     [EnumMember(Value = "open")]
     Open,
     [EnumMember(Value = "closed")]

--- a/src/Octokit.Webhooks/Models/MilestoneState.cs
+++ b/src/Octokit.Webhooks/Models/MilestoneState.cs
@@ -5,7 +5,7 @@ using System.Text.Json.Serialization;
 using JetBrains.Annotations;
 
 [PublicAPI]
-[JsonConverter(typeof(JsonStringEnumMemberConverter))]
+[JsonConverter(typeof(JsonStringEnumMemberConverterWithFallback))]
 public enum MilestoneState
 {
     [EnumMember(Value = "open")]

--- a/src/Octokit.Webhooks/Models/PingEvent/HookConfigContentType.cs
+++ b/src/Octokit.Webhooks/Models/PingEvent/HookConfigContentType.cs
@@ -8,6 +8,7 @@ using JetBrains.Annotations;
 [JsonConverter(typeof(JsonStringEnumMemberConverterWithFallback))]
 public enum HookConfigContentType
 {
+    Unknown = -1,
     [EnumMember(Value = "json")]
     Json,
     [EnumMember(Value = "form")]

--- a/src/Octokit.Webhooks/Models/PingEvent/HookConfigContentType.cs
+++ b/src/Octokit.Webhooks/Models/PingEvent/HookConfigContentType.cs
@@ -5,7 +5,7 @@ using System.Text.Json.Serialization;
 using JetBrains.Annotations;
 
 [PublicAPI]
-[JsonConverter(typeof(JsonStringEnumMemberConverter))]
+[JsonConverter(typeof(JsonStringEnumMemberConverterWithFallback))]
 public enum HookConfigContentType
 {
     [EnumMember(Value = "json")]

--- a/src/Octokit.Webhooks/Models/PingEvent/HookType.cs
+++ b/src/Octokit.Webhooks/Models/PingEvent/HookType.cs
@@ -5,7 +5,7 @@ using System.Text.Json.Serialization;
 using JetBrains.Annotations;
 
 [PublicAPI]
-[JsonConverter(typeof(JsonStringEnumMemberConverter))]
+[JsonConverter(typeof(JsonStringEnumMemberConverterWithFallback))]
 public enum HookType
 {
     [EnumMember(Value = "Repository")]

--- a/src/Octokit.Webhooks/Models/PingEvent/HookType.cs
+++ b/src/Octokit.Webhooks/Models/PingEvent/HookType.cs
@@ -8,6 +8,7 @@ using JetBrains.Annotations;
 [JsonConverter(typeof(JsonStringEnumMemberConverterWithFallback))]
 public enum HookType
 {
+    Unknown = -1,
     [EnumMember(Value = "Repository")]
     Repository,
     [EnumMember(Value = "Organization")]

--- a/src/Octokit.Webhooks/Models/ProjectState.cs
+++ b/src/Octokit.Webhooks/Models/ProjectState.cs
@@ -8,6 +8,7 @@ using JetBrains.Annotations;
 [JsonConverter(typeof(JsonStringEnumMemberConverterWithFallback))]
 public enum ProjectState
 {
+    Unknown = -1,
     [EnumMember(Value = "open")]
     Open,
     [EnumMember(Value = "closed")]

--- a/src/Octokit.Webhooks/Models/ProjectState.cs
+++ b/src/Octokit.Webhooks/Models/ProjectState.cs
@@ -5,7 +5,7 @@ using System.Text.Json.Serialization;
 using JetBrains.Annotations;
 
 [PublicAPI]
-[JsonConverter(typeof(JsonStringEnumMemberConverter))]
+[JsonConverter(typeof(JsonStringEnumMemberConverterWithFallback))]
 public enum ProjectState
 {
     [EnumMember(Value = "open")]

--- a/src/Octokit.Webhooks/Models/ProjectsV2ItemContentType.cs
+++ b/src/Octokit.Webhooks/Models/ProjectsV2ItemContentType.cs
@@ -8,6 +8,7 @@ using JetBrains.Annotations;
 [JsonConverter(typeof(JsonStringEnumMemberConverterWithFallback))]
 public enum ProjectsV2ItemContentType
 {
+    Unknown = -1,
     [EnumMember(Value = "DraftIssue")]
     DraftIssue,
     [EnumMember(Value = "Issue")]

--- a/src/Octokit.Webhooks/Models/ProjectsV2ItemContentType.cs
+++ b/src/Octokit.Webhooks/Models/ProjectsV2ItemContentType.cs
@@ -5,7 +5,7 @@ using System.Text.Json.Serialization;
 using JetBrains.Annotations;
 
 [PublicAPI]
-[JsonConverter(typeof(JsonStringEnumMemberConverter))]
+[JsonConverter(typeof(JsonStringEnumMemberConverterWithFallback))]
 public enum ProjectsV2ItemContentType
 {
     [EnumMember(Value = "DraftIssue")]

--- a/src/Octokit.Webhooks/Models/ProjectsV2ItemEvent/FieldType.cs
+++ b/src/Octokit.Webhooks/Models/ProjectsV2ItemEvent/FieldType.cs
@@ -5,7 +5,7 @@ using System.Text.Json.Serialization;
 using JetBrains.Annotations;
 
 [PublicAPI]
-[JsonConverter(typeof(JsonStringEnumMemberConverter))]
+[JsonConverter(typeof(JsonStringEnumMemberConverterWithFallback))]
 public enum FieldType
 {
     [EnumMember(Value = "single_select")]

--- a/src/Octokit.Webhooks/Models/ProjectsV2ItemEvent/FieldType.cs
+++ b/src/Octokit.Webhooks/Models/ProjectsV2ItemEvent/FieldType.cs
@@ -8,6 +8,7 @@ using JetBrains.Annotations;
 [JsonConverter(typeof(JsonStringEnumMemberConverterWithFallback))]
 public enum FieldType
 {
+    Unknown = -1,
     [EnumMember(Value = "single_select")]
     SingleSelect,
     [EnumMember(Value = "date")]

--- a/src/Octokit.Webhooks/Models/PullRequestEvent/PullRequestState.cs
+++ b/src/Octokit.Webhooks/Models/PullRequestEvent/PullRequestState.cs
@@ -8,6 +8,7 @@ using JetBrains.Annotations;
 [JsonConverter(typeof(JsonStringEnumMemberConverterWithFallback))]
 public enum PullRequestState
 {
+    Unknown = -1,
     [EnumMember(Value = "open")]
     Open,
     [EnumMember(Value = "closed")]

--- a/src/Octokit.Webhooks/Models/PullRequestEvent/PullRequestState.cs
+++ b/src/Octokit.Webhooks/Models/PullRequestEvent/PullRequestState.cs
@@ -5,7 +5,7 @@ using System.Text.Json.Serialization;
 using JetBrains.Annotations;
 
 [PublicAPI]
-[JsonConverter(typeof(JsonStringEnumMemberConverter))]
+[JsonConverter(typeof(JsonStringEnumMemberConverterWithFallback))]
 public enum PullRequestState
 {
     [EnumMember(Value = "open")]

--- a/src/Octokit.Webhooks/Models/RefType.cs
+++ b/src/Octokit.Webhooks/Models/RefType.cs
@@ -5,7 +5,7 @@ using System.Text.Json.Serialization;
 using JetBrains.Annotations;
 
 [PublicAPI]
-[JsonConverter(typeof(JsonStringEnumMemberConverter))]
+[JsonConverter(typeof(JsonStringEnumMemberConverterWithFallback))]
 public enum RefType
 {
     [EnumMember(Value = "tag")]

--- a/src/Octokit.Webhooks/Models/RefType.cs
+++ b/src/Octokit.Webhooks/Models/RefType.cs
@@ -8,6 +8,7 @@ using JetBrains.Annotations;
 [JsonConverter(typeof(JsonStringEnumMemberConverterWithFallback))]
 public enum RefType
 {
+    Unknown = -1,
     [EnumMember(Value = "tag")]
     Tag,
     [EnumMember(Value = "branch")]

--- a/src/Octokit.Webhooks/Models/ReleaseAssetState.cs
+++ b/src/Octokit.Webhooks/Models/ReleaseAssetState.cs
@@ -8,6 +8,7 @@ using JetBrains.Annotations;
 [JsonConverter(typeof(JsonStringEnumMemberConverterWithFallback))]
 public enum ReleaseAssetState
 {
+    Unknown = -1,
     [EnumMember(Value = "uploaded")]
     Uploaded,
 }

--- a/src/Octokit.Webhooks/Models/ReleaseAssetState.cs
+++ b/src/Octokit.Webhooks/Models/ReleaseAssetState.cs
@@ -5,7 +5,7 @@ using System.Text.Json.Serialization;
 using JetBrains.Annotations;
 
 [PublicAPI]
-[JsonConverter(typeof(JsonStringEnumMemberConverter))]
+[JsonConverter(typeof(JsonStringEnumMemberConverterWithFallback))]
 public enum ReleaseAssetState
 {
     [EnumMember(Value = "uploaded")]

--- a/src/Octokit.Webhooks/Models/RepositoryImportEvent/Status.cs
+++ b/src/Octokit.Webhooks/Models/RepositoryImportEvent/Status.cs
@@ -8,6 +8,7 @@ using JetBrains.Annotations;
 [JsonConverter(typeof(JsonStringEnumMemberConverterWithFallback))]
 public enum Status
 {
+    Unknown = -1,
     [EnumMember(Value = "success")]
     Success,
     [EnumMember(Value = "cancelled")]

--- a/src/Octokit.Webhooks/Models/RepositoryImportEvent/Status.cs
+++ b/src/Octokit.Webhooks/Models/RepositoryImportEvent/Status.cs
@@ -5,7 +5,7 @@ using System.Text.Json.Serialization;
 using JetBrains.Annotations;
 
 [PublicAPI]
-[JsonConverter(typeof(JsonStringEnumMemberConverter))]
+[JsonConverter(typeof(JsonStringEnumMemberConverterWithFallback))]
 public enum Status
 {
     [EnumMember(Value = "success")]

--- a/src/Octokit.Webhooks/Models/RepositoryVisibility.cs
+++ b/src/Octokit.Webhooks/Models/RepositoryVisibility.cs
@@ -5,7 +5,7 @@ using System.Text.Json.Serialization;
 using JetBrains.Annotations;
 
 [PublicAPI]
-[JsonConverter(typeof(JsonStringEnumMemberConverter))]
+[JsonConverter(typeof(JsonStringEnumMemberConverterWithFallback))]
 public enum RepositoryVisibility
 {
     [EnumMember(Value = "public")]

--- a/src/Octokit.Webhooks/Models/RepositoryVisibility.cs
+++ b/src/Octokit.Webhooks/Models/RepositoryVisibility.cs
@@ -8,6 +8,7 @@ using JetBrains.Annotations;
 [JsonConverter(typeof(JsonStringEnumMemberConverterWithFallback))]
 public enum RepositoryVisibility
 {
+    Unknown = -1,
     [EnumMember(Value = "public")]
     Public,
     [EnumMember(Value = "private")]

--- a/src/Octokit.Webhooks/Models/SecretScanningAlertEvent/AlertResolution.cs
+++ b/src/Octokit.Webhooks/Models/SecretScanningAlertEvent/AlertResolution.cs
@@ -5,7 +5,7 @@ using System.Text.Json.Serialization;
 using JetBrains.Annotations;
 
 [PublicAPI]
-[JsonConverter(typeof(JsonStringEnumMemberConverter))]
+[JsonConverter(typeof(JsonStringEnumMemberConverterWithFallback))]
 public enum AlertResolution
 {
     [EnumMember(Value = "false_positive")]

--- a/src/Octokit.Webhooks/Models/SecretScanningAlertEvent/AlertResolution.cs
+++ b/src/Octokit.Webhooks/Models/SecretScanningAlertEvent/AlertResolution.cs
@@ -8,6 +8,7 @@ using JetBrains.Annotations;
 [JsonConverter(typeof(JsonStringEnumMemberConverterWithFallback))]
 public enum AlertResolution
 {
+    Unknown = -1,
     [EnumMember(Value = "false_positive")]
     FalsePositive,
     [EnumMember(Value = "wontfix")]

--- a/src/Octokit.Webhooks/Models/Side.cs
+++ b/src/Octokit.Webhooks/Models/Side.cs
@@ -8,6 +8,7 @@ using JetBrains.Annotations;
 [JsonConverter(typeof(JsonStringEnumMemberConverterWithFallback))]
 public enum Side
 {
+    Unknown = -1,
     [EnumMember(Value = "LEFT")]
     Left,
     [EnumMember(Value = "RIGHT")]

--- a/src/Octokit.Webhooks/Models/Side.cs
+++ b/src/Octokit.Webhooks/Models/Side.cs
@@ -5,7 +5,7 @@ using System.Text.Json.Serialization;
 using JetBrains.Annotations;
 
 [PublicAPI]
-[JsonConverter(typeof(JsonStringEnumMemberConverter))]
+[JsonConverter(typeof(JsonStringEnumMemberConverterWithFallback))]
 public enum Side
 {
     [EnumMember(Value = "LEFT")]

--- a/src/Octokit.Webhooks/Models/SimplePullRequestState.cs
+++ b/src/Octokit.Webhooks/Models/SimplePullRequestState.cs
@@ -5,7 +5,7 @@ using System.Text.Json.Serialization;
 using JetBrains.Annotations;
 
 [PublicAPI]
-[JsonConverter(typeof(JsonStringEnumMemberConverter))]
+[JsonConverter(typeof(JsonStringEnumMemberConverterWithFallback))]
 public enum SimplePullRequestState
 {
     [EnumMember(Value = "open")]

--- a/src/Octokit.Webhooks/Models/SimplePullRequestState.cs
+++ b/src/Octokit.Webhooks/Models/SimplePullRequestState.cs
@@ -8,6 +8,7 @@ using JetBrains.Annotations;
 [JsonConverter(typeof(JsonStringEnumMemberConverterWithFallback))]
 public enum SimplePullRequestState
 {
+    Unknown = -1,
     [EnumMember(Value = "open")]
     Open,
     [EnumMember(Value = "closed")]

--- a/src/Octokit.Webhooks/Models/StatusEvent/CommitVerificationReason.cs
+++ b/src/Octokit.Webhooks/Models/StatusEvent/CommitVerificationReason.cs
@@ -5,7 +5,7 @@ using System.Text.Json.Serialization;
 using JetBrains.Annotations;
 
 [PublicAPI]
-[JsonConverter(typeof(JsonStringEnumMemberConverter))]
+[JsonConverter(typeof(JsonStringEnumMemberConverterWithFallback))]
 public enum CommitVerificationReason
 {
     [EnumMember(Value = "expired_key")]

--- a/src/Octokit.Webhooks/Models/StatusEvent/CommitVerificationReason.cs
+++ b/src/Octokit.Webhooks/Models/StatusEvent/CommitVerificationReason.cs
@@ -8,6 +8,7 @@ using JetBrains.Annotations;
 [JsonConverter(typeof(JsonStringEnumMemberConverterWithFallback))]
 public enum CommitVerificationReason
 {
+    Unknown = -1,
     [EnumMember(Value = "expired_key")]
     ExpiredKey,
     [EnumMember(Value = "not_signing_key")]

--- a/src/Octokit.Webhooks/Models/StatusEvent/StatusState.cs
+++ b/src/Octokit.Webhooks/Models/StatusEvent/StatusState.cs
@@ -5,7 +5,7 @@ using System.Text.Json.Serialization;
 using JetBrains.Annotations;
 
 [PublicAPI]
-[JsonConverter(typeof(JsonStringEnumMemberConverter))]
+[JsonConverter(typeof(JsonStringEnumMemberConverterWithFallback))]
 public enum StatusState
 {
     [EnumMember(Value = "pending")]

--- a/src/Octokit.Webhooks/Models/StatusEvent/StatusState.cs
+++ b/src/Octokit.Webhooks/Models/StatusEvent/StatusState.cs
@@ -8,6 +8,7 @@ using JetBrains.Annotations;
 [JsonConverter(typeof(JsonStringEnumMemberConverterWithFallback))]
 public enum StatusState
 {
+    Unknown = -1,
     [EnumMember(Value = "pending")]
     Pending,
     [EnumMember(Value = "success")]

--- a/src/Octokit.Webhooks/Models/TeamParentPrivacy.cs
+++ b/src/Octokit.Webhooks/Models/TeamParentPrivacy.cs
@@ -8,6 +8,7 @@ using JetBrains.Annotations;
 [JsonConverter(typeof(JsonStringEnumMemberConverterWithFallback))]
 public enum TeamParentPrivacy
 {
+    Unknown = -1,
     [EnumMember(Value = "Open")]
     Open,
     [EnumMember(Value = "Closed")]

--- a/src/Octokit.Webhooks/Models/TeamParentPrivacy.cs
+++ b/src/Octokit.Webhooks/Models/TeamParentPrivacy.cs
@@ -5,7 +5,7 @@ using System.Text.Json.Serialization;
 using JetBrains.Annotations;
 
 [PublicAPI]
-[JsonConverter(typeof(JsonStringEnumMemberConverter))]
+[JsonConverter(typeof(JsonStringEnumMemberConverterWithFallback))]
 public enum TeamParentPrivacy
 {
     [EnumMember(Value = "Open")]

--- a/src/Octokit.Webhooks/Models/TeamPrivacy.cs
+++ b/src/Octokit.Webhooks/Models/TeamPrivacy.cs
@@ -5,7 +5,7 @@ using System.Text.Json.Serialization;
 using JetBrains.Annotations;
 
 [PublicAPI]
-[JsonConverter(typeof(JsonStringEnumMemberConverter))]
+[JsonConverter(typeof(JsonStringEnumMemberConverterWithFallback))]
 public enum TeamPrivacy
 {
     [EnumMember(Value = "Open")]

--- a/src/Octokit.Webhooks/Models/TeamPrivacy.cs
+++ b/src/Octokit.Webhooks/Models/TeamPrivacy.cs
@@ -8,6 +8,7 @@ using JetBrains.Annotations;
 [JsonConverter(typeof(JsonStringEnumMemberConverterWithFallback))]
 public enum TeamPrivacy
 {
+    Unknown = -1,
     [EnumMember(Value = "Open")]
     Open,
     [EnumMember(Value = "Closed")]

--- a/src/Octokit.Webhooks/Models/UserType.cs
+++ b/src/Octokit.Webhooks/Models/UserType.cs
@@ -5,7 +5,7 @@ using System.Text.Json.Serialization;
 using JetBrains.Annotations;
 
 [PublicAPI]
-[JsonConverter(typeof(JsonStringEnumMemberConverter))]
+[JsonConverter(typeof(JsonStringEnumMemberConverterWithFallback))]
 public enum UserType
 {
     [EnumMember(Value = "Bot")]

--- a/src/Octokit.Webhooks/Models/UserType.cs
+++ b/src/Octokit.Webhooks/Models/UserType.cs
@@ -8,6 +8,7 @@ using JetBrains.Annotations;
 [JsonConverter(typeof(JsonStringEnumMemberConverterWithFallback))]
 public enum UserType
 {
+    Unknown = -1,
     [EnumMember(Value = "Bot")]
     Bot,
     [EnumMember(Value = "User")]

--- a/src/Octokit.Webhooks/Models/WorkflowJobEvent/WorkflowJobConclusion.cs
+++ b/src/Octokit.Webhooks/Models/WorkflowJobEvent/WorkflowJobConclusion.cs
@@ -8,6 +8,7 @@ using JetBrains.Annotations;
 [JsonConverter(typeof(JsonStringEnumMemberConverterWithFallback))]
 public enum WorkflowJobConclusion
 {
+    Unknown = -1,
     [EnumMember(Value = "success")]
     Success,
     [EnumMember(Value = "failure")]

--- a/src/Octokit.Webhooks/Models/WorkflowJobEvent/WorkflowJobConclusion.cs
+++ b/src/Octokit.Webhooks/Models/WorkflowJobEvent/WorkflowJobConclusion.cs
@@ -5,7 +5,7 @@ using System.Text.Json.Serialization;
 using JetBrains.Annotations;
 
 [PublicAPI]
-[JsonConverter(typeof(JsonStringEnumMemberConverter))]
+[JsonConverter(typeof(JsonStringEnumMemberConverterWithFallback))]
 public enum WorkflowJobConclusion
 {
     [EnumMember(Value = "success")]

--- a/src/Octokit.Webhooks/Models/WorkflowJobEvent/WorkflowJobStatus.cs
+++ b/src/Octokit.Webhooks/Models/WorkflowJobEvent/WorkflowJobStatus.cs
@@ -8,6 +8,7 @@ using JetBrains.Annotations;
 [JsonConverter(typeof(JsonStringEnumMemberConverterWithFallback))]
 public enum WorkflowJobStatus
 {
+    Unknown = -1,
     [EnumMember(Value = "queued")]
     Queued,
     [EnumMember(Value = "in_progress")]

--- a/src/Octokit.Webhooks/Models/WorkflowJobEvent/WorkflowJobStatus.cs
+++ b/src/Octokit.Webhooks/Models/WorkflowJobEvent/WorkflowJobStatus.cs
@@ -5,7 +5,7 @@ using System.Text.Json.Serialization;
 using JetBrains.Annotations;
 
 [PublicAPI]
-[JsonConverter(typeof(JsonStringEnumMemberConverter))]
+[JsonConverter(typeof(JsonStringEnumMemberConverterWithFallback))]
 public enum WorkflowJobStatus
 {
     [EnumMember(Value = "queued")]

--- a/src/Octokit.Webhooks/Models/WorkflowJobEvent/WorkflowJobStepConclusion.cs
+++ b/src/Octokit.Webhooks/Models/WorkflowJobEvent/WorkflowJobStepConclusion.cs
@@ -8,6 +8,7 @@ using JetBrains.Annotations;
 [JsonConverter(typeof(JsonStringEnumMemberConverterWithFallback))]
 public enum WorkflowJobStepConclusion
 {
+    Unknown = -1,
     [EnumMember(Value = "failure")]
     Failure,
     [EnumMember(Value = "skipped")]

--- a/src/Octokit.Webhooks/Models/WorkflowJobEvent/WorkflowJobStepConclusion.cs
+++ b/src/Octokit.Webhooks/Models/WorkflowJobEvent/WorkflowJobStepConclusion.cs
@@ -5,7 +5,7 @@ using System.Text.Json.Serialization;
 using JetBrains.Annotations;
 
 [PublicAPI]
-[JsonConverter(typeof(JsonStringEnumMemberConverter))]
+[JsonConverter(typeof(JsonStringEnumMemberConverterWithFallback))]
 public enum WorkflowJobStepConclusion
 {
     [EnumMember(Value = "failure")]

--- a/src/Octokit.Webhooks/Models/WorkflowJobEvent/WorkflowJobStepStatus.cs
+++ b/src/Octokit.Webhooks/Models/WorkflowJobEvent/WorkflowJobStepStatus.cs
@@ -5,7 +5,7 @@ using System.Text.Json.Serialization;
 using JetBrains.Annotations;
 
 [PublicAPI]
-[JsonConverter(typeof(JsonStringEnumMemberConverter))]
+[JsonConverter(typeof(JsonStringEnumMemberConverterWithFallback))]
 public enum WorkflowJobStepStatus
 {
     [EnumMember(Value = "in_progress")]

--- a/src/Octokit.Webhooks/Models/WorkflowJobEvent/WorkflowJobStepStatus.cs
+++ b/src/Octokit.Webhooks/Models/WorkflowJobEvent/WorkflowJobStepStatus.cs
@@ -8,6 +8,7 @@ using JetBrains.Annotations;
 [JsonConverter(typeof(JsonStringEnumMemberConverterWithFallback))]
 public enum WorkflowJobStepStatus
 {
+    Unknown = -1,
     [EnumMember(Value = "in_progress")]
     InProgress,
     [EnumMember(Value = "completed")]

--- a/src/Octokit.Webhooks/Models/WorkflowRunConclusion.cs
+++ b/src/Octokit.Webhooks/Models/WorkflowRunConclusion.cs
@@ -5,7 +5,7 @@ using System.Text.Json.Serialization;
 using JetBrains.Annotations;
 
 [PublicAPI]
-[JsonConverter(typeof(JsonStringEnumMemberConverter))]
+[JsonConverter(typeof(JsonStringEnumMemberConverterWithFallback))]
 public enum WorkflowRunConclusion
 {
     [EnumMember(Value = "success")]

--- a/src/Octokit.Webhooks/Models/WorkflowRunConclusion.cs
+++ b/src/Octokit.Webhooks/Models/WorkflowRunConclusion.cs
@@ -8,6 +8,7 @@ using JetBrains.Annotations;
 [JsonConverter(typeof(JsonStringEnumMemberConverterWithFallback))]
 public enum WorkflowRunConclusion
 {
+    Unknown = -1,
     [EnumMember(Value = "success")]
     Success,
     [EnumMember(Value = "failure")]

--- a/src/Octokit.Webhooks/Models/WorkflowRunStatus.cs
+++ b/src/Octokit.Webhooks/Models/WorkflowRunStatus.cs
@@ -5,7 +5,7 @@ using System.Text.Json.Serialization;
 using JetBrains.Annotations;
 
 [PublicAPI]
-[JsonConverter(typeof(JsonStringEnumMemberConverter))]
+[JsonConverter(typeof(JsonStringEnumMemberConverterWithFallback))]
 public enum WorkflowRunStatus
 {
     [EnumMember(Value = "requested")]

--- a/src/Octokit.Webhooks/Models/WorkflowRunStatus.cs
+++ b/src/Octokit.Webhooks/Models/WorkflowRunStatus.cs
@@ -8,6 +8,7 @@ using JetBrains.Annotations;
 [JsonConverter(typeof(JsonStringEnumMemberConverterWithFallback))]
 public enum WorkflowRunStatus
 {
+    Unknown = -1,
     [EnumMember(Value = "requested")]
     Requested,
     [EnumMember(Value = "in_progress")]

--- a/test/Octokit.Webhooks.Test/Converter/JsonStringEnumMemberConverterWithFallbackTests.cs
+++ b/test/Octokit.Webhooks.Test/Converter/JsonStringEnumMemberConverterWithFallbackTests.cs
@@ -1,0 +1,29 @@
+namespace Octokit.Webhooks.Test.Converter;
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using FluentAssertions;
+using Octokit.Webhooks.Models.PingEvent;
+using Xunit;
+
+public class JsonStringEnumMemberConverterWithFallbackTests
+{
+    private readonly JsonSerializerOptions options = new()
+    {
+        Converters =
+        {
+            new JsonStringEnumMemberConverterWithFallback(),
+        },
+    };
+
+    [Theory]
+    [InlineData(@"""App""", HookType.App)]
+    [InlineData(@"""Organization""", HookType.Organization)]
+    [InlineData(@"""Repository""", HookType.Repository)]
+    [InlineData(@"""Foo""", HookType.Repository)]
+    public void CanConvertString(string input, HookType expected)
+    {
+        var actual = JsonSerializer.Deserialize<HookType>(input, this.options);
+        actual.Should().Be(expected);
+    }
+}

--- a/test/Octokit.Webhooks.Test/Converter/JsonStringEnumMemberConverterWithFallbackTests.cs
+++ b/test/Octokit.Webhooks.Test/Converter/JsonStringEnumMemberConverterWithFallbackTests.cs
@@ -20,7 +20,7 @@ public class JsonStringEnumMemberConverterWithFallbackTests
     [InlineData(@"""App""", HookType.App)]
     [InlineData(@"""Organization""", HookType.Organization)]
     [InlineData(@"""Repository""", HookType.Repository)]
-    [InlineData(@"""Foo""", HookType.Repository)]
+    [InlineData(@"""Foo""", HookType.Unknown)]
     public void CanConvertString(string input, HookType expected)
     {
         var actual = JsonSerializer.Deserialize<HookType>(input, this.options);


### PR DESCRIPTION
Add fallback value for unknown enumeration values.

Unfortunately my original idea of using `-1` as an invalid value doesn't work because:

1. It gets converted to a `ulong` under the hood, so ends up as `ulong.MaxValue`.
2. The converter throws if the value doesn't match to a defined name in the target enum.

As a starting point I've just used `0` to illustrate the changes, but that effectively means that an unknown value over-the-wire gets turned into a "random" value in the target enum type (whichever one happens to be defined first and gets the value `0`).

I think doing this "properly" would require defining an explicit "Unknown" member on all of the enums,  but that doesn't quite feel right to me.

Thoughts on this @JamieMagee?

Relates to #90.
