### PR TITLE
bug: Add Unknown to ReviewState

### DIFF
--- a/src/Octokit.Webhooks/Models/PullRequestReviewEvent/ReviewState.cs
+++ b/src/Octokit.Webhooks/Models/PullRequestReviewEvent/ReviewState.cs
@@ -5,9 +5,10 @@ using System.Text.Json.Serialization;
 using JetBrains.Annotations;
 
 [PublicAPI]
-[JsonConverter(typeof(JsonStringEnumMemberConverter))]
+[JsonConverter(typeof(JsonStringEnumMemberConverterWithFallback))]
 public enum ReviewState
 {
+    Unknown = -1,
     [EnumMember(Value = "commented")]
     Commented,
     [EnumMember(Value = "changes_requested")]

--- a/test/Octokit.Webhooks.Test/Converter/JsonStringEnumMemberConverterWithFallbackTests.cs
+++ b/test/Octokit.Webhooks.Test/Converter/JsonStringEnumMemberConverterWithFallbackTests.cs
@@ -1,5 +1,8 @@
 namespace Octokit.Webhooks.Test.Converter;
 
+using System;
+using System.Globalization;
+using System.Reflection;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using FluentAssertions;
@@ -25,5 +28,38 @@ public class JsonStringEnumMemberConverterWithFallbackTests
     {
         var actual = JsonSerializer.Deserialize<HookType>(input, this.options);
         actual.Should().Be(expected);
+    }
+
+    [Fact]
+    public void AllEnumerationsUseJsonStringEnumMemberConverterForJsonConverter()
+    {
+        var assembly = typeof(WebhookEvent).Assembly;
+        var types = assembly.GetTypes().ThatDeriveFrom<Enum>();
+
+        foreach (var type in types)
+        {
+            type.Should().BeDecoratedWith<JsonConverterAttribute>($"the {type.Name} enumeration must be decorated with [JsonConverter(...)]");
+
+            var converter = type.GetCustomAttribute<JsonConverterAttribute>();
+            converter.Should().NotBeNull();
+            converter!.ConverterType.Should().Be(typeof(JsonStringEnumMemberConverterWithFallback));
+        }
+    }
+
+    [Fact]
+    public void AllEnumerationsHaveUnknownMemberWithValueOfMinusOne()
+    {
+        var assembly = typeof(WebhookEvent).Assembly;
+        var types = assembly.GetTypes().ThatDeriveFrom<Enum>();
+
+        foreach (var type in types)
+        {
+            var names = Enum.GetNames(type);
+            names.Should().Contain("Unknown", $"the {type.Name} enumeration must contain an Unknown value");
+
+            var enumValue = Enum.Parse(type, "Unknown");
+            var intValue = Convert.ToInt32(enumValue, CultureInfo.InvariantCulture);
+            intValue.Should().Be(-1, $"the Unknown value of the {type.Name} enumeration must have a value of -1");
+        }
     }
 }


### PR DESCRIPTION
- Add an `Unknown` value to the `ReviewState` enum added by #91 as it wasn't accounted for in #93 before it was merged.
- Add unit tests to catch future missing `Unknown` values.
