### PR TITLE
refactor: mark internal attributes as sealed

### DIFF
--- a/src/Octokit.Webhooks/WebhookActionTypeAttribute.cs
+++ b/src/Octokit.Webhooks/WebhookActionTypeAttribute.cs
@@ -1,7 +1,7 @@
 ﻿namespace Octokit.Webhooks;
 
 [AttributeUsage(AttributeTargets.Class)]
-internal class WebhookActionTypeAttribute : Attribute
+internal sealed class WebhookActionTypeAttribute : Attribute
 {
     public WebhookActionTypeAttribute(string actionType) => this.ActionType = actionType;
 

--- a/src/Octokit.Webhooks/WebhookEventTypeAttribute.cs
+++ b/src/Octokit.Webhooks/WebhookEventTypeAttribute.cs
@@ -1,7 +1,7 @@
 ﻿namespace Octokit.Webhooks;
 
 [AttributeUsage(AttributeTargets.Class)]
-internal class WebhookEventTypeAttribute : Attribute
+internal sealed class WebhookEventTypeAttribute : Attribute
 {
     public WebhookEventTypeAttribute(string eventType) => this.EventType = eventType;
 


### PR DESCRIPTION
This fixes the CA1852 analyzer warning

<!--
Please read the contributing guide before raising a pull request.
https://github.com/octokit/webhooks.net/blob/main/CONTRIBUTING.md
-->
