### PR TITLE
Add in_progress and queued to WorkflowJobStepConclusion enums

### DIFF
--- a/src/Octokit.Webhooks/Models/WorkflowJobEvent/WorkflowJobStepConclusion.cs
+++ b/src/Octokit.Webhooks/Models/WorkflowJobEvent/WorkflowJobStepConclusion.cs
@@ -11,4 +11,8 @@ public enum WorkflowJobStepConclusion
     Skipped,
     [EnumMember(Value = "success")]
     Success,
+    [EnumMember(Value = "in_progress")]
+    InProgress,
+    [EnumMember(Value = "queued")]
+    Queued,
 }


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->


<!-- Issues are required for both bug fixes and features. -->
Resolves #169

----

## Behavior

### Before the change?
When a workflow_job.completed with a `failed` conclusion event is deserialized it fails because steps can have `in_progress` and `queued` status which are not included in the WorkflowJobStepConclusion enums

* 

### After the change?
The `in_progress` & `queued`  status steps can be deserialized for a workflowflow completed event with a failed conclusion and steps that are in_progress or queued.

* 


### Other information
<!-- Any other information that is important to this PR  -->

* 

----

## Additional info

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Added the appropriate label for the given change

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes (Please add the `Type: Breaking change` label)
- [x] No

If `Yes`, what's the impact:  

* N/A


### Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please add the corresponding label for change this PR introduces:
- Bugfix: `Type: Bug`
- Feature/model/API additions: `Type: Feature`
- Updates to docs or samples: `Type: Documentation`
- Dependencies/code cleanup: `Type: Maintenance`

----

