### PR TITLE
feat: allow serialization of `DateTimeOffset`

### DIFF
--- a/src/Octokit.Webhooks/Converter/DateTimeOffsetConverter.cs
+++ b/src/Octokit.Webhooks/Converter/DateTimeOffsetConverter.cs
@@ -6,7 +6,7 @@ public class DateTimeOffsetConverter : JsonConverter<DateTimeOffset>
         ReadInternal(ref reader);
 
     public override void Write(Utf8JsonWriter writer, DateTimeOffset value, JsonSerializerOptions options) =>
-        throw new NotImplementedException($"The {nameof(DateTimeOffsetConverter)} does not support serializing to JSON");
+        WriteInternal(writer, value);
 
     internal static DateTimeOffset ReadInternal(ref Utf8JsonReader reader) => reader.TokenType switch
     {
@@ -14,6 +14,9 @@ public class DateTimeOffsetConverter : JsonConverter<DateTimeOffset>
         JsonTokenType.Number => HandleNumber(reader),
         _ => throw new JsonException($"'{reader.TokenType}' is not an allowed token type for the {nameof(DateTimeOffsetConverter)}"),
     };
+
+    internal static void WriteInternal(Utf8JsonWriter writer, DateTimeOffset value) =>
+        writer.WriteStringValue(value.ToString("o"));
 
     private static DateTimeOffset HandleString(Utf8JsonReader reader)
     {

--- a/src/Octokit.Webhooks/Converter/NullableDateTimeOffsetConverter.cs
+++ b/src/Octokit.Webhooks/Converter/NullableDateTimeOffsetConverter.cs
@@ -8,6 +8,16 @@ public class NullableDateTimeOffsetConverter : JsonConverter<DateTimeOffset?>
         _ => DateTimeOffsetConverter.ReadInternal(ref reader),
     };
 
-    public override void Write(Utf8JsonWriter writer, DateTimeOffset? value, JsonSerializerOptions options) =>
-        throw new NotImplementedException($"The {nameof(NullableDateTimeOffsetConverter)} does not support serializing to JSON");
+    public override void Write(Utf8JsonWriter writer, DateTimeOffset? value, JsonSerializerOptions options)
+    {
+        switch (value)
+        {
+            case null:
+                writer.WriteNullValue();
+                break;
+            default:
+                DateTimeOffsetConverter.WriteInternal(writer, (DateTimeOffset)value);
+                break;
+        }
+    }
 }

--- a/test/Octokit.Webhooks.Test/Converter/DateTimeOffsetConverterTests.cs
+++ b/test/Octokit.Webhooks.Test/Converter/DateTimeOffsetConverterTests.cs
@@ -21,30 +21,30 @@ public class DateTimeOffsetConverterTests
     [Theory]
     [InlineData(@"""2019-05-15T15:20:40Z""")]
     [InlineData(@"""2019-05-15T15:20:40.000+00:00""")]
-    public void CanConvertString(string input)
+    public void CanDeserializeString(string input)
     {
         var result = JsonSerializer.Deserialize<DateTimeOffset>(input, this.options);
         result.Should().Be(this.expected);
     }
 
     [Fact]
-    public void CanConvertNumber()
+    public void CanDeserializeNumber()
     {
         var result = JsonSerializer.Deserialize<DateTimeOffset>(@"1557933640", this.options);
         result.Should().Be(this.expected);
     }
 
     [Fact]
-    public void ThrowsForNull()
+    public void DeserializeThrowsForNull()
     {
         var result = () => JsonSerializer.Deserialize<DateTimeOffset>(@"null", this.options);
         result.Should().Throw<JsonException>();
     }
 
     [Fact]
-    public void ThrowsForWrite()
+    public void CanSerialize()
     {
-        var result = () => JsonSerializer.Serialize(this.expected, this.options);
-        result.Should().Throw<NotImplementedException>();
+        var result = JsonSerializer.Serialize(this.expected, this.options);
+        result.Should().Be(@"""2019-05-15T15:20:40.0000000\u002B00:00""");
     }
 }

--- a/test/Octokit.Webhooks.Test/Converter/NullableDateTimeOffsetConverterTests.cs
+++ b/test/Octokit.Webhooks.Test/Converter/NullableDateTimeOffsetConverterTests.cs
@@ -21,30 +21,37 @@ public class NullableDateTimeOffsetConverterTests
     [Theory]
     [InlineData(@"""2019-05-15T15:20:40Z""")]
     [InlineData(@"""2019-05-15T15:20:40.000+00:00""")]
-    public void CanConvertString(string input)
+    public void CanDeserializeString(string input)
     {
         var result = JsonSerializer.Deserialize<DateTimeOffset?>(input, this.options);
         result.Should().Be(this.expected);
     }
 
     [Fact]
-    public void CanConvertNumber()
+    public void CanDeserializeNumber()
     {
         var result = JsonSerializer.Deserialize<DateTimeOffset?>(@"1557933640", this.options);
         result.Should().Be(this.expected);
     }
 
     [Fact]
-    public void CanConvertNull()
+    public void CanDeserializeNull()
     {
         var result = JsonSerializer.Deserialize<DateTimeOffset?>(@"null", this.options);
         result.Should().BeNull();
     }
 
     [Fact]
-    public void ThrowsForWrite()
+    public void CanSerializeDateTimeOffset()
     {
-        var result = () => JsonSerializer.Serialize(this.expected, this.options);
-        result.Should().Throw<NotImplementedException>();
+        var result = JsonSerializer.Serialize(this.expected, this.options);
+        result.Should().Be(@"""2019-05-15T15:20:40.0000000\u002B00:00""");
+    }
+
+    [Fact]
+    public void CanSerializeNull()
+    {
+        var result = JsonSerializer.Serialize((DateTimeOffset?)null, this.options);
+        result.Should().Be(@"null");
     }
 }


### PR DESCRIPTION
Resolves #103 

## Behavior

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* Calling `JsonSerializer.Serialize` for any webhook payloads that had `DateTimeOffset` properties would throw a `JsonException`

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* Allows serialization of `DateTimeOffset` and `DateTimeOffset?` to ISO 8601 using [the round-trip format][1]


### Other information
<!-- Any other information that is important to this PR  -->

* 

----

## Additional info

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Added the appropriate label for the given change

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes (Please add the `Type: Breaking change` label)
- [x] No

If `Yes`, what's the impact:  

* N/A


### Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

- Feature/model/API additions: `Type: Feature`

----

[1]: https://learn.microsoft.com/en-us/dotnet/standard/base-types/standard-date-and-time-format-strings#the-round-trip-o-o-format-specifier
