### PR TITLE
Support hot-swapping of webhok secrets

### DIFF
--- a/src/Octokit.Webhooks.AzureFunctions/GitHubWebhooksOptions.cs
+++ b/src/Octokit.Webhooks.AzureFunctions/GitHubWebhooksOptions.cs
@@ -1,6 +1,40 @@
 namespace Octokit.Webhooks.AzureFunctions;
 
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
 public sealed record GitHubWebhooksOptions
 {
+    /// <summary>
+    /// Gets or sets the secret to use to validate each webhook request's signature, or null if no
+    /// signature is to be expected.
+    /// </summary>
+    /// <remarks>
+    /// The property may not be set if <see cref="SecretsCallback"/> is set.
+    /// </remarks>
     public string? Secret { get; set; }
+
+    /// <summary>
+    /// Gets or sets a callback delegate that will return the list of secrets to use to validate a
+    /// request's signature.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The delegate will be invoked once for each request. If the delegate returns null, then no
+    /// signature will be expected. If the delegate returns a list of one or more secrets, then the
+    /// request's signature must match one of those secrets. If the delegate returns an empty list,
+    /// then the request's signature will be considered invalid.
+    /// </para>
+    /// <para>
+    /// Because the delegate is invoked separately for each request, the webhook secret can be
+    /// changed without modifying the route. Returning bpth the old and the new secrets for some
+    /// time will allow any webhook requests already in flight to validate against the old secret
+    /// while any new requests will validate against the new secret.
+    /// </para>
+    /// <para>
+    /// This property may not be set if <see cref="Secret"/> is set.
+    /// </para>
+    /// </remarks>
+    public Func<Task<IEnumerable<string>?>>? SecretsCallback { get; set; }
 }

--- a/src/Octokit.Webhooks/WebhookValidationError.cs
+++ b/src/Octokit.Webhooks/WebhookValidationError.cs
@@ -1,0 +1,20 @@
+namespace Octokit.Webhooks;
+
+/// <summary>
+/// The reason why a webhook request was invalid.
+/// </summary>
+[PublicAPI]
+public enum WebhookValidationError
+{
+    /// <summary>The "Content-Type" header was missing, or was not "application/json".</summary>
+    IncorrectContentType,
+
+    /// <summary>The requst contained a signature, but it did not match the expected signature.</summary>
+    InvalidSignature,
+
+    /// <summary>The client was expecting a signature, but the request did not contain one.</summary>
+    MissingSignature,
+
+    /// <summary>The request contained a signature, but the client was not expecting one.</summary>
+    UnexpectedSignature,
+}

--- a/src/Octokit.Webhooks/WebhookValidationException.cs
+++ b/src/Octokit.Webhooks/WebhookValidationException.cs
@@ -1,0 +1,33 @@
+namespace Octokit.Webhooks;
+
+using System.Net;
+
+/// <summary>
+/// An exception thrown when validation of a webhook request fails.
+/// </summary>
+[PublicAPI]
+public sealed class WebhookValidationException : Exception
+{
+    internal WebhookValidationException(WebhookValidationError error)
+        : base(GetMessage(error))
+    {
+        this.StatusCode = HttpStatusCode.BadRequest;  // Always 400 for now.
+        this.Error = error;
+    }
+
+    /// <summary>Gets the reason for the validation failure.</summary>
+    public WebhookValidationError Error { get; }
+
+    /// <summary>Gets the HTTP status code for the validation failure.</summary>
+    public HttpStatusCode StatusCode { get; }
+
+    private static string GetMessage(WebhookValidationError error) =>
+        error switch
+        {
+            WebhookValidationError.IncorrectContentType => "Webhook request has incorrect content type.",
+            WebhookValidationError.InvalidSignature => "Signature in webhook request does not match the expected signature.",
+            WebhookValidationError.UnexpectedSignature => "Webhook request has a signature, but the client is not expecting one.",
+            WebhookValidationError.MissingSignature => "Webhook request is missing a signature.",
+            _ => throw new ArgumentOutOfRangeException(nameof(error)),
+        };
+}

--- a/test/Octokit.Webhooks.Test/Converter/JsonStringEnumMemberConverterWithFallbackTests.cs
+++ b/test/Octokit.Webhooks.Test/Converter/JsonStringEnumMemberConverterWithFallbackTests.cs
@@ -34,7 +34,7 @@ public class JsonStringEnumMemberConverterWithFallbackTests
     public void AllEnumerationsUseJsonStringEnumMemberConverterForJsonConverter()
     {
         var assembly = typeof(WebhookEvent).Assembly;
-        var types = assembly.GetTypes().ThatDeriveFrom<Enum>();
+        var types = assembly.GetTypes().ThatDeriveFrom<Enum>().ThatSatisfy(t => !IgnoreType(t));
 
         foreach (var type in types)
         {
@@ -50,7 +50,7 @@ public class JsonStringEnumMemberConverterWithFallbackTests
     public void AllEnumerationsHaveUnknownMemberWithValueOfMinusOne()
     {
         var assembly = typeof(WebhookEvent).Assembly;
-        var types = assembly.GetTypes().ThatDeriveFrom<Enum>();
+        var types = assembly.GetTypes().ThatDeriveFrom<Enum>().ThatSatisfy(t => !IgnoreType(t));
 
         foreach (var type in types)
         {
@@ -62,4 +62,10 @@ public class JsonStringEnumMemberConverterWithFallbackTests
             intValue.Should().Be(-1, $"the Unknown value of the {type.Name} enumeration must have a value of -1");
         }
     }
+
+    private static bool IgnoreType(Type type) =>
+
+        // This type isn't part of the JSON serialization. It's only used in-process for handling
+        // validation errors.
+        type.Name == "WebhookValidationError";
 }


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->


<!-- Issues are required for both bug fixes and features. -->
Resolves #261
Resolves #24

----

(In draft until I finish implementing tests)

## Behavior

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* In both ASP.NET Core and Azure Functions, the webhook secret for the webhook processor must be specified when the processor is registered, and cannot be changed afterward. In addition, there can be only one secret specified.

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* A client now has the option of specifying a callback delegate to retrieve the list of secrets to validate against. This callback will be invoked for each request, so the results can change dynamically to allow rotation of the secret. In addition, the callback can return multiple secrets, with the request's signature required to match at least one of those secrets.

### Other information
<!-- Any other information that is important to this PR  -->

Since the request validation code that I was modifying was duplicated between the ASP.NET Core and Azure Functions packages, I took the opportunity to refactor the validation code to allow sharing (see #24). I chose to add the new `ValidateWebhookRequestAsync()` method to the existing `WebhookEventProcessor` class. It could go in a separate class, but I figured that most clients that process webhooks will also need to validate them. I'm tempted to also add a new `ValidateAndProcessWebhookAsync()` method that does both the validation and the processing, since they take essentially the same parameters and will almost always be used together. I didn't go that far in this PR, though.

The parameter types for the new `ValidateWebhookRequestAsync()` method include the request headers (as the same type used for `ProcessWebhookAsync()`), the body `Stream`, and the list of secrets to use. Allowing multiple secrets allows secret rotation to happen more smoothly, because the consumer can continue to process webhooks signed with the old secret for a while until everything starts using the new secret.

Passing the body as a `Stream` seems to be the least common denominator between the ASP.NET Core and Azure Functions packages, and is likely useful outside of those two scenarios. I considered just passing the body as a `string`, but that would make it more difficult to implement a defensive check against a maliciously large payload. That check was suggested in #24, but I have not implemented it here.

Validation errors are reported by throwing a `WebhookValidationException`. This class contains a `WebHookValidationError` enum that allows clients to determine exactly what went wrong. The two existing clients use this to determine what log message to emit, and what response text, if any, to return.

----

## Additional info

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Added the appropriate label for the given change

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes (Please add the `Type: Breaking change` label)
- [ ] No

If `Yes`, what's the impact:  

* N/A


### Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please add the corresponding label for change this PR introduces:
- Bugfix: `Type: Bug`
- Feature/model/API additions: `Type: Feature`
- Updates to docs or samples: `Type: Documentation`
- Dependencies/code cleanup: `Type: Maintenance`

----

