### PR TITLE
fix: Fix CheckSuiteConclusion enum

### DIFF
--- a/src/Octokit.Webhooks/Models/CheckSuiteEvent/CheckSuiteConclusion.cs
+++ b/src/Octokit.Webhooks/Models/CheckSuiteEvent/CheckSuiteConclusion.cs
@@ -13,8 +13,12 @@ public enum CheckSuiteConclusion
     Cancelled,
     [EnumMember(Value = "timed_out")]
     TimedOut,
-    [EnumMember(Value = "actionRequired")]
+    [EnumMember(Value = "action_required")]
     ActionRequired,
     [EnumMember(Value = "stale")]
     Stale,
+    [EnumMember(Value = "skipped")]
+    Skipped,
+    [EnumMember(Value = "startup_failure")]
+    StartupFailure,
 }


### PR DESCRIPTION
Resolves #283

----

## Behavior

### Before the change?

* Check suite conclusions for `action_required`, `startup_failure` and `skipped` fail to be parsed.

### After the change?

* Check suite conclusions for `action_required`, `startup_failure` and `skipped` can be parsed and represented in C#.

### Other information

None.

----

## Additional info

### Pull request checklist

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Added the appropriate label for the given change

### Does this introduce a breaking change?

- [ ] Yes (Please add the `Type: Breaking change` label)
- [x] No

If `Yes`, what's the impact:  

* N/A
