### PR TITLE
feat: deserialize any additional data to a dictionary

### DIFF
--- a/src/Octokit.Webhooks/WebhookEvent.cs
+++ b/src/Octokit.Webhooks/WebhookEvent.cs
@@ -17,4 +17,10 @@ public abstract record WebhookEvent
 
     [JsonPropertyName("sender")]
     public User? Sender { get; init; }
+
+    /// <summary>
+    /// Gets any additional properties that were not mapped to a strongly-typed property on the event.
+    /// </summary>
+    [JsonExtensionData]
+    public IDictionary<string, JsonElement>? AdditionalProperties { get; init; }
 }


### PR DESCRIPTION
This is mostly to cover the case where we've incorrectly typed an event, or haven't updated quick enough to represent GitHub webhook changes.