### PR TITLE
[fix]: Add missing "waiting" enum to WorkflowJobStatus.cs

### DIFF
--- a/src/Octokit.Webhooks/Models/WorkflowJobEvent/WorkflowJobStatus.cs
+++ b/src/Octokit.Webhooks/Models/WorkflowJobEvent/WorkflowJobStatus.cs
@@ -9,6 +9,6 @@ public enum WorkflowJobStatus
     InProgress,
     [EnumMember(Value = "completed")]
     Completed,
-    [Parameter(Value = "waiting")]
+    [EnumMember(Value = "waiting")]
     Waiting,    
 }

--- a/src/Octokit.Webhooks/Models/WorkflowJobEvent/WorkflowJobStatus.cs
+++ b/src/Octokit.Webhooks/Models/WorkflowJobEvent/WorkflowJobStatus.cs
@@ -9,4 +9,6 @@ public enum WorkflowJobStatus
     InProgress,
     [EnumMember(Value = "completed")]
     Completed,
+    [Parameter(Value = "waiting")]
+    Waiting,    
 }

--- a/src/Octokit.Webhooks/Models/WorkflowJobEvent/WorkflowJobStatus.cs
+++ b/src/Octokit.Webhooks/Models/WorkflowJobEvent/WorkflowJobStatus.cs
@@ -10,5 +10,5 @@ public enum WorkflowJobStatus
     [EnumMember(Value = "completed")]
     Completed,
     [EnumMember(Value = "waiting")]
-    Waiting,    
+    Waiting,
 }


### PR DESCRIPTION
The `WorkflowJobStatus` enum is lacking the `Waiting`, which cases an exception.

```
[Parameter(Value = "waiting")]
Waiting,
```

```
System.AggregateException: An error occurred while writing to logger(s). (Value 'waiting' is not a valid 'WorkflowJobStatus' enum value.)  ---> System.ArgumentException: Value 'waiting' is not a valid 'WorkflowJobStatus' enum value.   
   at Octokit.Webhooks.Extensions.StringEnum`1.ParseValue()   
   at Octokit.Webhooks.Extensions.StringEnum`1.get_Value()   
   at Octokit.Webhooks.Extensions.StringEnum`1.PrintMembers(StringBuilder builder)   
   at Octokit.Webhooks.Extensions.StringEnum`1.ToString()   
   at Octokit.Webhooks.Models.WorkflowJobEvent.WorkflowJob.PrintMembers(StringBuilder builder)   
   at Octokit.Webhooks.Models.WorkflowJobEvent.WorkflowJob.ToString()   
   at Octokit.Webhooks.Events.WorkflowJobEvent.PrintMembers(StringBuilder builder)   
   at Octokit.Webhooks.Events.WorkflowJob.WorkflowJobWaitingEvent.PrintMembers(StringBuilder builder)   
   at Octokit.Webhooks.Events.WorkflowJob.WorkflowJobWaitingEvent.ToString()   
   at Microsoft.Extensions.Logging.Console.JsonConsoleFormatter.WriteItem(Utf8JsonWriter writer, KeyValuePair`2 item)   
   at Microsoft.Extensions.Logging.Console.JsonConsoleFormatter.<WriteScopeInformation>b__4_0(Object scope, Utf8JsonWriter state)   
   at Microsoft.Extensions.Logging.LoggerFactoryScopeProvider.ForEachScope[TState](Action`2 callback, TState state)   
   at Microsoft.Extensions.Logging.Console.JsonConsoleFormatter.WriteScopeInformation(Utf8JsonWriter writer, IExternalScopeProvider scopeProvider)   
   at Microsoft.Extensions.Logging.Console.JsonConsoleFormatter.Write[TState](LogEntry`1& logEntry, IExternalScopeProvider scopeProvider, TextWriter textWriter)   
   at Microsoft.Extensions.Logging.Console.ConsoleLogger.Log[TState](LogLevel logLevel, EventId eventId, TState state, Exception exception, Func`3 formatter)   
   at Microsoft.Extensions.Logging.Logger.<Log>g__LoggerLog|12_0[TState](LogLevel logLevel, EventId eventId, ILogger logger, Exception exception, Func`3 formatter, List`1& exceptions, TState& state)    
   --- End of inner exception stack trace ---   
   at Microsoft.Extensions.Logging.Logger.ThrowLoggingError(List`1 exceptions)   
   at Microsoft.Extensions.Logging.Logger.Log[TState](LogLevel logLevel, EventId eventId, TState state, Exception exception, Func`3 formatter)   
   at Microsoft.Extensions.Logging.Logger`1.Microsoft.Extensions.Logging.ILogger.Log[TState](LogLevel logLevel, EventId eventId, TState state, Exception exception, Func`3 formatter)   
   at Microsoft.Extensionsging.LoggerExtensions.Log.Log(ILogger logger, LogLevel logLevel, EventId eventId, Exception exception, String message, Object[] args)   
 [...]
```
----

### Before the change?

* Exception being thrown due to unknown enum value

### After the change?

* No exception

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [ ] No

----

