### PR TITLE
chore(deps): upgrade to .net 8 sdk

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Octokit.Webhooks",
-  "image": "mcr.microsoft.com/devcontainers/dotnet:7.0",
+  "image": "mcr.microsoft.com/devcontainers/dotnet:dev-8.0",
   "postCreateCommand": "dotnet restore",
   "customizations": {
     "vscode": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,11 +2,14 @@
   "name": "Octokit.Webhooks",
   "image": "mcr.microsoft.com/devcontainers/dotnet:dev-8.0",
   "postCreateCommand": "dotnet restore",
+  "features": {
+    "ghcr.io/devcontainers/features/dotnet": {
+      "dotnetRuntimeVersions": "6.0"
+    }
+  },
   "customizations": {
     "vscode": {
-      "extensions": [
-        "ms-dotnettools.csdevkit"
-      ]
+      "extensions": ["ms-dotnettools.csdevkit"]
     }
   }
 }

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup Label="Build">
-    <LangVersion>latest</LangVersion>
+    <LangVersion>preview</LangVersion>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <AnalysisLevel>latest</AnalysisLevel>
     <Nullable>enable</Nullable>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup Label="Build">
-    <LangVersion>preview</LangVersion>
+    <LangVersion>latest</LangVersion>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <AnalysisLevel>latest</AnalysisLevel>
     <Nullable>enable</Nullable>

--- a/global.json
+++ b/global.json
@@ -2,6 +2,6 @@
   "sdk": {
     "rollForward": "latestFeature",
     "allowPrerelease": false,
-    "version": "7.0.403"
+    "version": "8.0.100"
   }
 }

--- a/samples/AspNetCore/MyWebhookEventProcessor.cs
+++ b/samples/AspNetCore/MyWebhookEventProcessor.cs
@@ -6,22 +6,18 @@ using Octokit.Webhooks;
 using Octokit.Webhooks.Events;
 using Octokit.Webhooks.Events.PullRequest;
 
-public class MyWebhookEventProcessor : WebhookEventProcessor
+public class MyWebhookEventProcessor(ILogger<MyWebhookEventProcessor> logger) : WebhookEventProcessor
 {
-    private readonly ILogger<MyWebhookEventProcessor> logger;
-
-    public MyWebhookEventProcessor(ILogger<MyWebhookEventProcessor> logger) => this.logger = logger;
-
     protected override async Task ProcessPullRequestWebhookAsync(WebhookHeaders headers, PullRequestEvent pullRequestEvent, PullRequestAction action)
     {
         switch (action)
         {
             case PullRequestActionValue.Opened:
-                this.logger.LogInformation("pull request opened");
+                logger.LogInformation("pull request opened");
                 await Task.Delay(1000);
                 break;
             default:
-                this.logger.LogInformation("Some other pull request event");
+                logger.LogInformation("Some other pull request event");
                 await Task.Delay(1000);
                 break;
         }

--- a/samples/AzureFunctions/MyWebhookEventProcessor.cs
+++ b/samples/AzureFunctions/MyWebhookEventProcessor.cs
@@ -6,25 +6,18 @@ using Octokit.Webhooks;
 using Octokit.Webhooks.Events;
 using Octokit.Webhooks.Events.PullRequest;
 
-public class MyWebhookEventProcessor : WebhookEventProcessor
+public class MyWebhookEventProcessor(ILogger<MyWebhookEventProcessor> logger) : WebhookEventProcessor
 {
-    private readonly ILogger<MyWebhookEventProcessor> logger;
-
-    public MyWebhookEventProcessor(ILogger<MyWebhookEventProcessor> logger)
-    {
-        this.logger = logger;
-    }
-
     protected override async Task ProcessPullRequestWebhookAsync(WebhookHeaders headers, PullRequestEvent pullRequestEvent, PullRequestAction action)
     {
         switch (action)
         {
             case PullRequestActionValue.Opened:
-                this.logger.LogInformation("pull request opened");
+                logger.LogInformation("pull request opened");
                 await Task.Delay(1000);
                 break;
             default:
-                this.logger.LogInformation("Some other pull request event");
+                logger.LogInformation("Some other pull request event");
                 await Task.Delay(1000);
                 break;
         }

--- a/src/Octokit.Webhooks.AzureFunctions/GitHubWebhooksHttpFunction.cs
+++ b/src/Octokit.Webhooks.AzureFunctions/GitHubWebhooksHttpFunction.cs
@@ -19,12 +19,8 @@ using Microsoft.Extensions.Primitives;
 /// <summary>
 /// A class containing an Azure Function that processes GitHub webhooks.
 /// </summary>
-public sealed partial class GitHubWebhooksHttpFunction
+public sealed partial class GitHubWebhooksHttpFunction(IOptions<GitHubWebhooksOptions> options)
 {
-    private readonly IOptions<GitHubWebhooksOptions> options;
-
-    public GitHubWebhooksHttpFunction(IOptions<GitHubWebhooksOptions> options) => this.options = options;
-
     [Function(nameof(MapGitHubWebhooksAsync))]
     public async Task<HttpResponseData?> MapGitHubWebhooksAsync(
         [HttpTrigger(AuthorizationLevel.Anonymous, "POST", Route = "github/webhooks")] HttpRequestData req,
@@ -43,7 +39,7 @@ public sealed partial class GitHubWebhooksHttpFunction
         var body = await GetBodyAsync(req).ConfigureAwait(false);
 
         // Verify signature
-        if (!VerifySignature(req, this.options.Value.Secret, body))
+        if (!VerifySignature(req, options.Value.Secret, body))
         {
             Log.SignatureValidationFailed(logger);
             return req.CreateResponse(HttpStatusCode.BadRequest);

--- a/src/Octokit.Webhooks/Octokit.Webhooks.csproj
+++ b/src/Octokit.Webhooks/Octokit.Webhooks.csproj
@@ -16,6 +16,4 @@
     <PackageReference Include="Microsoft.Extensions.Primitives" Version="8.0.0" />
   </ItemGroup>
 
-
-
 </Project>

--- a/src/Octokit.Webhooks/WebhookActionTypeAttribute.cs
+++ b/src/Octokit.Webhooks/WebhookActionTypeAttribute.cs
@@ -1,9 +1,7 @@
 ﻿namespace Octokit.Webhooks;
 
 [AttributeUsage(AttributeTargets.Class)]
-internal sealed class WebhookActionTypeAttribute : Attribute
+internal sealed class WebhookActionTypeAttribute(string actionType) : Attribute
 {
-    public WebhookActionTypeAttribute(string actionType) => this.ActionType = actionType;
-
-    public string ActionType { get; }
+    public string ActionType { get; } = actionType;
 }

--- a/src/Octokit.Webhooks/WebhookEventTypeAttribute.cs
+++ b/src/Octokit.Webhooks/WebhookEventTypeAttribute.cs
@@ -1,9 +1,7 @@
 ﻿namespace Octokit.Webhooks;
 
 [AttributeUsage(AttributeTargets.Class)]
-internal sealed class WebhookEventTypeAttribute : Attribute
+internal sealed class WebhookEventTypeAttribute(string eventType) : Attribute
 {
-    public WebhookEventTypeAttribute(string eventType) => this.EventType = eventType;
-
-    public string EventType { get; }
+    public string EventType { get; } = eventType;
 }


### PR DESCRIPTION
The packages are still published as targeting .NET 6, but this change requires .NET 8 to build the packages. This allows us to take advantage _some_ newer .NET features in a backwards compatible way.