### PR TITLE
add custom_property and custom_property_values

### DIFF
--- a/src/Octokit.Webhooks/Events/CustomProperty/CustomPropertyAction.cs
+++ b/src/Octokit.Webhooks/Events/CustomProperty/CustomPropertyAction.cs
@@ -1,0 +1,16 @@
+namespace Octokit.Webhooks.Events.CustomProperty;
+
+[PublicAPI]
+public sealed record CustomPropertyAction : WebhookEventAction
+{
+    public static readonly CustomPropertyAction Created = new(CustomPropertyActionValue.Created);
+
+    public static readonly CustomPropertyAction Updated = new(CustomPropertyActionValue.Updated);
+
+    public static readonly CustomPropertyAction Deleted = new(CustomPropertyActionValue.Deleted);
+
+    private CustomPropertyAction(string value)
+        : base(value)
+    {
+    }
+}

--- a/src/Octokit.Webhooks/Events/CustomProperty/CustomPropertyActionValue.cs
+++ b/src/Octokit.Webhooks/Events/CustomProperty/CustomPropertyActionValue.cs
@@ -1,0 +1,10 @@
+namespace Octokit.Webhooks.Events.CustomProperty;
+
+public static class CustomPropertyActionValue
+{
+    public const string Created = "created";
+
+    public const string Updated = "updated";
+
+    public const string Deleted = "deleted";
+}

--- a/src/Octokit.Webhooks/Events/CustomProperty/CustomPropertyCreatedEvent.cs
+++ b/src/Octokit.Webhooks/Events/CustomProperty/CustomPropertyCreatedEvent.cs
@@ -1,0 +1,27 @@
+using Octokit.Webhooks.Models.CustomProperty;
+
+namespace Octokit.Webhooks.Events.CustomProperty;
+
+[PublicAPI]
+[WebhookActionType(CustomPropertyActionValue.Created)]
+public sealed record CustomPropertyCreatedEvent : CustomPropertyEvent
+{
+    [JsonPropertyName("action")]
+    public override string Action => CustomPropertyAction.Created;
+
+    [JsonPropertyName("value_type")]
+    [JsonConverter(typeof(StringEnumConverter<CustomPropertyValueType>))]
+    public StringEnum<CustomPropertyValueType> ValueType { get; init; } = null!;
+
+    [JsonPropertyName("default_value")]
+    public string? DefaultValue { get; init; }
+
+    [JsonPropertyName("required")]
+    public bool Required { get; init; }
+
+    [JsonPropertyName("description")]
+    public string? Description { get; init; }
+
+    [JsonPropertyName("allowed_values")]
+    public IEnumerable<string>? AllowedValues { get; init; }
+}

--- a/src/Octokit.Webhooks/Events/CustomProperty/CustomPropertyDeletedEvent.cs
+++ b/src/Octokit.Webhooks/Events/CustomProperty/CustomPropertyDeletedEvent.cs
@@ -1,0 +1,9 @@
+namespace Octokit.Webhooks.Events.CustomProperty;
+
+[PublicAPI]
+[WebhookActionType(CustomPropertyActionValue.Deleted)]
+public sealed record CustomPropertyDeletedEvent : CustomPropertyEvent
+{
+    [JsonPropertyName("action")]
+    public override string Action => CustomPropertyAction.Deleted;
+}

--- a/src/Octokit.Webhooks/Events/CustomProperty/CustomPropertyUpdatedEvent.cs
+++ b/src/Octokit.Webhooks/Events/CustomProperty/CustomPropertyUpdatedEvent.cs
@@ -1,0 +1,27 @@
+using Octokit.Webhooks.Models.CustomProperty;
+
+namespace Octokit.Webhooks.Events.CustomProperty;
+
+[PublicAPI]
+[WebhookActionType(CustomPropertyActionValue.Updated)]
+public sealed record CustomPropertyUpdatedEvent : CustomPropertyEvent
+{
+    [JsonPropertyName("action")]
+    public override string Action => CustomPropertyAction.Updated;
+
+    [JsonPropertyName("value_type")]
+    [JsonConverter(typeof(StringEnumConverter<CustomPropertyValueType>))]
+    public StringEnum<CustomPropertyValueType> ValueType { get; init; } = null!;
+
+    [JsonPropertyName("default_value")]
+    public string? DefaultValue { get; init; }
+
+    [JsonPropertyName("required")]
+    public bool Required { get; init; }
+
+    [JsonPropertyName("description")]
+    public string? Description { get; init; }
+
+    [JsonPropertyName("allowed_values")]
+    public IEnumerable<string>? AllowedValues { get; init; }
+}

--- a/src/Octokit.Webhooks/Events/CustomPropertyEvent.cs
+++ b/src/Octokit.Webhooks/Events/CustomPropertyEvent.cs
@@ -1,0 +1,10 @@
+namespace Octokit.Webhooks.Events;
+
+[PublicAPI]
+[WebhookEventType(WebhookEventType.CustomProperty)]
+[JsonConverter(typeof(WebhookConverter<CustomPropertyEvent>))]
+public abstract record CustomPropertyEvent : WebhookEvent
+{
+    [JsonPropertyName("property_name")]
+    public string PropertyName { get; init; } = null!;
+}

--- a/src/Octokit.Webhooks/Events/CustomPropertyValues/CustomPropertyValuesAction.cs
+++ b/src/Octokit.Webhooks/Events/CustomPropertyValues/CustomPropertyValuesAction.cs
@@ -1,0 +1,12 @@
+namespace Octokit.Webhooks.Events.CustomPropertyValues;
+
+[PublicAPI]
+public sealed record CustomPropertyValuesAction : WebhookEventAction
+{
+    public static readonly CustomPropertyValuesAction Updated = new(CustomPropertyValuesActionValue.Updated);
+
+    private CustomPropertyValuesAction(string value)
+        : base(value)
+    {
+    }
+}

--- a/src/Octokit.Webhooks/Events/CustomPropertyValues/CustomPropertyValuesActionValue.cs
+++ b/src/Octokit.Webhooks/Events/CustomPropertyValues/CustomPropertyValuesActionValue.cs
@@ -1,0 +1,6 @@
+namespace Octokit.Webhooks.Events.CustomPropertyValues;
+
+public static class CustomPropertyValuesActionValue
+{
+    public const string Updated = "updated";
+}

--- a/src/Octokit.Webhooks/Events/CustomPropertyValues/CustomPropertyValuesUpdatedEvent.cs
+++ b/src/Octokit.Webhooks/Events/CustomPropertyValues/CustomPropertyValuesUpdatedEvent.cs
@@ -1,0 +1,9 @@
+namespace Octokit.Webhooks.Events.CustomPropertyValues;
+
+[PublicAPI]
+[WebhookActionType(CustomPropertyValuesActionValue.Updated)]
+public abstract record CustomPropertyValuesUpdatedEvent : CustomPropertyValuesEvent
+{
+    [JsonPropertyName("action")]
+    public override string Action => CustomPropertyValuesAction.Updated;
+}

--- a/src/Octokit.Webhooks/Events/CustomPropertyValuesEvent.cs
+++ b/src/Octokit.Webhooks/Events/CustomPropertyValuesEvent.cs
@@ -1,0 +1,15 @@
+using Octokit.Webhooks.Models.CustomPropertyValues;
+
+namespace Octokit.Webhooks.Events;
+
+[PublicAPI]
+[WebhookEventType(WebhookEventType.CustomPropertyValues)]
+[JsonConverter(typeof(WebhookConverter<CustomPropertyValuesEvent>))]
+public abstract record CustomPropertyValuesEvent : WebhookEvent
+{
+    [JsonPropertyName("new_property_values")]
+    public IEnumerable<CustomPropertyValue> NewPropertyValues { get; init; } = null!;
+
+    [JsonPropertyName("old_property_values")]
+    public IEnumerable<CustomPropertyValue> OldPropertyValues { get; init; } = null!;
+}

--- a/src/Octokit.Webhooks/Models/CustomProperty/CustomPropertyValueType.cs
+++ b/src/Octokit.Webhooks/Models/CustomProperty/CustomPropertyValueType.cs
@@ -1,0 +1,11 @@
+namespace Octokit.Webhooks.Models.CustomProperty;
+
+[PublicAPI]
+public enum CustomPropertyValueType
+{
+    [EnumMember(Value = "string")]
+    String,
+
+    [EnumMember(Value = "single_select")]
+    SingleSelect,
+}

--- a/src/Octokit.Webhooks/Models/CustomPropertyValues/CustomPropertyValue.cs
+++ b/src/Octokit.Webhooks/Models/CustomPropertyValues/CustomPropertyValue.cs
@@ -1,0 +1,11 @@
+namespace Octokit.Webhooks.Models.CustomPropertyValues;
+
+[PublicAPI]
+public record CustomPropertyValue
+{
+    [JsonPropertyName("property_name")]
+    public string PropertyName { get; set; } = null!;
+
+    [JsonPropertyName("value")]
+    public string? Value { get; set; }
+}

--- a/src/Octokit.Webhooks/WebHookEventType.cs
+++ b/src/Octokit.Webhooks/WebHookEventType.cs
@@ -9,6 +9,8 @@ public static class WebhookEventType
     public const string CommitComment = "commit_comment";
     public const string ContentReference = "content_reference";
     public const string Create = "create";
+    public const string CustomProperty = "custom_property";
+    public const string CustomPropertyValues = "custom_property_values";
     public const string Delete = "delete";
     public const string DependabotAlert = "dependabot_alert";
     public const string Deployment = "deployment";

--- a/src/Octokit.Webhooks/WebhookEventProcessor.cs
+++ b/src/Octokit.Webhooks/WebhookEventProcessor.cs
@@ -9,6 +9,8 @@ using Octokit.Webhooks.Events.CheckSuite;
 using Octokit.Webhooks.Events.CodeScanningAlert;
 using Octokit.Webhooks.Events.CommitComment;
 using Octokit.Webhooks.Events.ContentReference;
+using Octokit.Webhooks.Events.CustomProperty;
+using Octokit.Webhooks.Events.CustomPropertyValues;
 using Octokit.Webhooks.Events.DependabotAlert;
 using Octokit.Webhooks.Events.DeployKey;
 using Octokit.Webhooks.Events.Deployment;
@@ -83,6 +85,8 @@ public abstract class WebhookEventProcessor
             CommitCommentEvent commitCommentEvent => this.ProcessCommitCommentWebhookAsync(headers, commitCommentEvent),
             ContentReferenceEvent contentReferenceEvent => this.ProcessContentReferenceWebhookAsync(headers, contentReferenceEvent),
             CreateEvent createEvent => this.ProcessCreateWebhookAsync(headers, createEvent),
+            CustomPropertyEvent customPropertyEvent => this.ProcessCustomPropertyWebhookAsync(headers, customPropertyEvent),
+            CustomPropertyValuesEvent customPropertyValuesEvent => this.ProcessCustomPropertyValuesWebhookAsync(headers, customPropertyValuesEvent),
             DeleteEvent deleteEvent => this.ProcessDeleteWebhookAsync(headers, deleteEvent),
             DependabotAlertEvent dependabotAlertEvent => this.ProcessDependabotAlertWebhookAsync(headers, dependabotAlertEvent),
             DeployKeyEvent deployKeyEvent => this.ProcessDeployKeyWebhookAsync(headers, deployKeyEvent),
@@ -165,6 +169,8 @@ public abstract class WebhookEventProcessor
             WebhookEventType.CommitComment => JsonSerializer.Deserialize<CommitCommentEvent>(body)!,
             WebhookEventType.ContentReference => JsonSerializer.Deserialize<ContentReferenceEvent>(body)!,
             WebhookEventType.Create => JsonSerializer.Deserialize<CreateEvent>(body)!,
+            WebhookEventType.CustomProperty => JsonSerializer.Deserialize<CustomPropertyEvent>(body)!,
+            WebhookEventType.CustomPropertyValues => JsonSerializer.Deserialize<CustomPropertyValuesEvent>(body)!,
             WebhookEventType.Delete => JsonSerializer.Deserialize<DeleteEvent>(body)!,
             WebhookEventType.DependabotAlert => JsonSerializer.Deserialize<DependabotAlertEvent>(body)!,
             WebhookEventType.DeployKey => JsonSerializer.Deserialize<DeployKeyEvent>(body)!,
@@ -329,6 +335,38 @@ public abstract class WebhookEventProcessor
 
     [PublicAPI]
     protected virtual Task ProcessCreateWebhookAsync(WebhookHeaders headers, CreateEvent createEvent) => Task.CompletedTask;
+
+    private Task ProcessCustomPropertyWebhookAsync(WebhookHeaders headers, CustomPropertyEvent customPropertyEvent) =>
+        customPropertyEvent.Action switch
+        {
+            CustomPropertyActionValue.Created
+                => this.ProcessCustomPropertyWebhookAsync(headers, customPropertyEvent, CustomPropertyAction.Created),
+            CustomPropertyActionValue.Deleted
+                => this.ProcessCustomPropertyWebhookAsync(headers, customPropertyEvent, CustomPropertyAction.Deleted),
+            CustomPropertyActionValue.Updated
+                => this.ProcessCustomPropertyWebhookAsync(headers, customPropertyEvent, CustomPropertyAction.Updated),
+            _ => Task.CompletedTask,
+        };
+
+    [PublicAPI]
+    protected virtual Task ProcessCustomPropertyWebhookAsync(
+        WebhookHeaders headers,
+        CustomPropertyEvent hookEvent,
+        CustomPropertyAction action) => Task.CompletedTask;
+
+    private Task ProcessCustomPropertyValuesWebhookAsync(WebhookHeaders headers, CustomPropertyValuesEvent customPropertyValuesEvent) =>
+        customPropertyValuesEvent.Action switch
+        {
+            CustomPropertyValuesActionValue.Updated
+                => this.ProcessCustomPropertyValuesWebhookAsync(headers, customPropertyValuesEvent, CustomPropertyValuesAction.Updated),
+            _ => Task.CompletedTask,
+        };
+
+    [PublicAPI]
+    protected virtual Task ProcessCustomPropertyValuesWebhookAsync(
+        WebhookHeaders headers,
+        CustomPropertyValuesEvent hookEvent,
+        CustomPropertyValuesAction action) => Task.CompletedTask;
 
     [PublicAPI]
     protected virtual Task ProcessDeleteWebhookAsync(WebhookHeaders headers, DeleteEvent deleteEvent) => Task.CompletedTask;


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #416

----

### Before the change?

Missing support for:
- [`custom_property`](https://docs.github.com/en/webhooks/webhook-events-and-payloads?actionType=created#custom_property)
- [`custom_property_values`](https://docs.github.com/en/webhooks/webhook-events-and-payloads#custom_property_values)

* 

### After the change?

Adds support for:
- [`custom_property`](https://docs.github.com/en/webhooks/webhook-events-and-payloads?actionType=created#custom_property)
- [`custom_property_values`](https://docs.github.com/en/webhooks/webhook-events-and-payloads#custom_property_values)

* 

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

