### PR TITLE
Fix: Nuget PackageEvent

### DIFF
--- a/src/Octokit.Webhooks/Models/PackageType.cs
+++ b/src/Octokit.Webhooks/Models/PackageType.cs
@@ -11,7 +11,7 @@ public enum PackageType
     RubyGems,
     [EnumMember(Value = "docker")]
     Docker,
-    [EnumMember(Value = "nuget")]
+    [EnumMember(Value = "NUGET")]
     NuGet,
     [EnumMember(Value = "CONTAINER")]
     Container,

--- a/src/Octokit.Webhooks/Models/PackageVersion.cs
+++ b/src/Octokit.Webhooks/Models/PackageVersion.cs
@@ -69,7 +69,7 @@ public sealed record PackageVersion
     public IDictionary<string, dynamic>? NpmMetadata { get; init; }
 
     [JsonPropertyName("nuget_metadata")]
-    public IDictionary<string, dynamic>? NugetMetadata { get; init; }
+    public IEnumerable<PackageVersionNugetMetadata>? NugetMetadata { get; init; }
 
     [JsonPropertyName("rubygems_metadata")]
     public IDictionary<string, dynamic>? RubygemsMetadata { get; init; }

--- a/src/Octokit.Webhooks/Models/PackageVersionNugetMetadata.cs
+++ b/src/Octokit.Webhooks/Models/PackageVersionNugetMetadata.cs
@@ -1,0 +1,14 @@
+namespace Octokit.Webhooks.Models;
+
+[PublicAPI]
+public sealed record PackageVersionNugetMetadata
+{
+    [JsonPropertyName("name")]
+    public string? Name { get; init; }
+
+    [JsonPropertyName("id")]
+    public string? Id { get; init; }
+
+    [JsonPropertyName("value")]
+    public dynamic? Value { get; init; }
+}


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #462
Resolves #460 

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* The value of Nuget **PackageType** is `nuget` (in lowercase)
* The type of **NugetMetatada** property of **PackageVersion** is `IDictionary<string, dynamic>?`

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* The value of Nuget **PackageType** is now `NUGET` (in uppercase) according to the payload sent by GitHub Webhooks.
* The type of **NugetMetatada** property of **PackageVersion** is now `IEnumerable<PackageVersionNugetMetadata>?` according to the paylod sent by GitHub Webhooks and according to the [GitHub Webhooks Docs](https://docs.github.com/en/webhooks/webhook-events-and-payloads#package)
* Added **PackageVersionNugetMetadata** type for better binding **nuget_metadata** field of webhook according to the paylod sent by GitHub Webhooks and according to the [GitHub Webhooks Docs](https://docs.github.com/en/webhooks/webhook-events-and-payloads#package)

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

