### PR TITLE
feat: return IEndpointConventionBuilder from MapGitHubWebhooks to allow additional configuration of endpoint

### DIFF
--- a/src/Octokit.Webhooks.AspNetCore/GitHubWebhookExtensions.cs
+++ b/src/Octokit.Webhooks.AspNetCore/GitHubWebhookExtensions.cs
@@ -19,7 +19,7 @@ using Microsoft.Extensions.Logging;
 /// </summary>
 public static partial class GitHubWebhookExtensions
 {
-    public static void MapGitHubWebhooks(this IEndpointRouteBuilder endpoints, string path = "/api/github/webhooks", string secret = null!) =>
+    public static IEndpointConventionBuilder MapGitHubWebhooks(this IEndpointRouteBuilder endpoints, string path = "/api/github/webhooks", string secret = null!) =>
         endpoints.MapPost(path, async context =>
         {
             var logger = context.RequestServices.GetRequiredService<ILogger<WebhookEventProcessor>>();


### PR DESCRIPTION
Allows additional configuration of endpoint. For example, allowing anonymous access for the endpoint for an app that otherwise requires a specific type of authentication: `app.MapGitHubWebhooks("/api/github/webhooks, githubWebhookSecret).AllowAnonymous()`

Resolves #476

----

### Before the change?
If you have authentication on your entire app but you want to allow anonymous access to the GitHub webhook endpoint, there doesn't seem to be a way to do that currently.

### After the change?
The IEndpointConventionBuilder is available to users of the library, so they can configure any of the settings that you normally could for a `app.MapPost( ... )` call, including `AllowAnonymous()`.

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

