### PR TITLE
Install .NET 6 in CI builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,6 +39,8 @@ jobs:
           fetch-depth: 0
       - name: 'Install .NET Core SDK'
         uses: actions/setup-dotnet@4d6c8fcf3c8f7a60068d26b594648e99df24cee3 # v4.0.0
+        with:
+          dotnet-version: 6.0.x
       - name: 'Dotnet Tool Restore'
         run: dotnet tool restore
         shell: pwsh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,9 @@ jobs:
       - name: 'Install .NET Core SDK'
         uses: actions/setup-dotnet@4d6c8fcf3c8f7a60068d26b594648e99df24cee3 # v4.0.0
         with:
-          dotnet-version: 6.0.x
+          dotnet-version: |
+            6.0.x
+            8.0.x
       - name: 'Dotnet Tool Restore'
         run: dotnet tool restore
         shell: pwsh


### PR DESCRIPTION
All PR builds on this repo are currently failing because Actions dropped .NET 6 from its default runners. The long-term fix is to upgrade our .NET versions across all of our repositories, but this should allow our Dependabot upgrades to ship in the short-term. 