### PR TITLE
Polymorphic custom property values (fixes deserialization bug)

### DIFF
--- a/src/Octokit.Webhooks/Models/CustomPropertyEvent/CustomPropertyValueType.cs
+++ b/src/Octokit.Webhooks/Models/CustomPropertyEvent/CustomPropertyValueType.cs
@@ -8,4 +8,10 @@ public enum CustomPropertyValueType
 
     [EnumMember(Value = "single_select")]
     SingleSelect,
+
+    [EnumMember(Value = "multi_select")]
+    MultiSelect,
+
+    [EnumMember(Value = "true_false")]
+    TrueFalse,
 }

--- a/src/Octokit.Webhooks/Models/Repository.cs
+++ b/src/Octokit.Webhooks/Models/Repository.cs
@@ -293,5 +293,5 @@ public sealed record Repository
     public string? Organization { get; init; }
 
     [JsonPropertyName("custom_properties")]
-    public IDictionary<string, string>? CustomProperties { get; init; }
+    public IDictionary<string, object>? CustomProperties { get; init; }
 }

--- a/test/Octokit.Webhooks.Test/Resources/custom_property/created.payload.json
+++ b/test/Octokit.Webhooks.Test/Resources/custom_property/created.payload.json
@@ -1,15 +1,17 @@
 {
   "action": "created",
   "definition": {
-    "property_name": "dev_platform_select",
+    "property_name": "test_ss",
     "value_type": "single_select",
     "required": true,
-    "default_value": "option_default",
-    "description": "select description",
+    "default_value": "option_c",
+    "description": "single_select property",
     "allowed_values": [
-      "option_one",
-      "option_two",
-      "option_default"
+      "option_a",
+      "option_b",
+      "option_c",
+      "option_d",
+      "option_e"
     ],
     "values_editable_by": "org_and_repo_actors"
   },

--- a/test/Octokit.Webhooks.Test/Resources/custom_property/updated.payload.json
+++ b/test/Octokit.Webhooks.Test/Resources/custom_property/updated.payload.json
@@ -1,14 +1,22 @@
 {
   "action": "updated",
   "definition": {
-    "property_name": "dev_platform_test",
-    "value_type": "single_select",
-    "required": false,
-    "allowed_values": [
-      "option_one",
-      "option_two"
+    "property_name": "test_ms",
+    "value_type": "multi_select",
+    "required": true,
+    "default_value": [
+      "option_d",
+      "option_e"
     ],
-    "values_editable_by": "org_and_repo_actors"
+    "description": "multi_select property",
+    "allowed_values": [
+      "option_a",
+      "option_b",
+      "option_c",
+      "option_d",
+      "option_e"
+    ],
+    "values_editable_by": "org_actors"
   },
   "organization": {
     "login": "Contoso-Inc",

--- a/test/Octokit.Webhooks.Test/Resources/custom_property_values/1.updated.payload.json
+++ b/test/Octokit.Webhooks.Test/Resources/custom_property_values/1.updated.payload.json
@@ -5,7 +5,24 @@
       "property_name": "test_ms",
       "value": [
         "option_c",
-        "option_b"
+        "option_d"
+      ]
+    },
+    {
+      "property_name": "test_ss",
+      "value": "option_b"
+    },
+    {
+      "property_name": "test_tf",
+      "value": "true"
+    }
+  ],
+  "old_property_values": [
+    {
+      "property_name": "test_ms",
+      "value": [
+        "option_b",
+        "option_c"
       ]
     },
     {
@@ -15,20 +32,6 @@
     {
       "property_name": "test_tf",
       "value": "false"
-    }
-  ],
-  "old_property_values": [
-    {
-      "property_name": "test_ms",
-      "value": null
-    },
-    {
-      "property_name": "test_ss",
-      "value": null
-    },
-    {
-      "property_name": "test_tf",
-      "value": null
     }
   ],
   "repository": {

--- a/test/Octokit.Webhooks.Test/Resources/deployment/payload.json
+++ b/test/Octokit.Webhooks.Test/Resources/deployment/payload.json
@@ -131,6 +131,14 @@
     "open_issues": 2,
     "watchers": 0,
     "default_branch": "master",
+    "custom_properties": {
+      "test_ms": [
+        "option_d",
+        "option_e"
+      ],
+      "test_ss": "option_c",
+      "test_tf": "foo"
+    },
     "is_template": false,
     "topics": [],
     "visibility": "public",

--- a/test/Octokit.Webhooks.Test/Resources/repository/created.payload.json
+++ b/test/Octokit.Webhooks.Test/Resources/repository/created.payload.json
@@ -93,6 +93,14 @@
     "open_issues": 0,
     "watchers": 0,
     "default_branch": "master",
+    "custom_properties": {
+      "test_ms": [
+        "option_d",
+        "option_e"
+      ],
+      "test_ss": "option_c",
+      "test_tf": "foo"
+    },
     "is_template": false,
     "topics": [],
     "visibility": "public",

--- a/test/Octokit.Webhooks.Test/Resources/repository/created.with-installation.payload.json
+++ b/test/Octokit.Webhooks.Test/Resources/repository/created.with-installation.payload.json
@@ -93,6 +93,14 @@
     "open_issues": 0,
     "watchers": 0,
     "default_branch": "master",
+    "custom_properties": {
+      "test_ms": [
+        "option_d",
+        "option_e"
+      ],
+      "test_ss": "option_c",
+      "test_tf": "foo"
+    },
     "is_template": false,
     "topics": [],
     "visibility": "public",

--- a/test/Octokit.Webhooks.Test/Resources/workflow_job/queued.payload.json
+++ b/test/Octokit.Webhooks.Test/Resources/workflow_job/queued.payload.json
@@ -18,7 +18,9 @@
     "name": "update",
     "steps": [],
     "check_run_url": "https://api.github.com/repos/octo-org/octo-repo/check-runs/1291536064",
-    "labels": ["ubuntu-latest"],
+    "labels": [
+      "ubuntu-latest"
+    ],
     "runner_id": 5,
     "runner_name": "GitHub Actions 5",
     "runner_group_id": 2,
@@ -118,6 +120,14 @@
     "open_issues": 2,
     "watchers": 0,
     "default_branch": "master",
+    "custom_properties": {
+      "test_ms": [
+        "option_d",
+        "option_e"
+      ],
+      "test_ss": "option_c",
+      "test_tf": "foo"
+    },
     "is_template": false,
     "topics": [],
     "visibility": "public",

--- a/test/Octokit.Webhooks.Test/Resources/workflow_run/completed.payload.json
+++ b/test/Octokit.Webhooks.Test/Resources/workflow_run/completed.payload.json
@@ -114,6 +114,14 @@
     "watchers": 1,
     "watchers_count": 1,
     "is_template": false,
+    "custom_properties": {
+      "test_ms": [
+        "option_d",
+        "option_e"
+      ],
+      "test_ss": "option_c",
+      "test_tf": "foo"
+    },
     "topics": [],
     "visibility": "public",
     "web_commit_signoff_required": false
@@ -166,7 +174,10 @@
         "email": "matfax@users.noreply.github.com",
         "name": "Matthias Fax"
       },
-      "committer": { "email": "noreply@github.com", "name": "GitHub" },
+      "committer": {
+        "email": "noreply@github.com",
+        "name": "GitHub"
+      },
       "id": "3484a3fb816e0859fd6e1cea078d76385ff50625",
       "message": "build(test): check workflow run event payload",
       "timestamp": "2020-10-05T16:32:07Z",


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #520

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* [Custom Property and Custom Property Value](https://docs.github.com/en/rest/repos/custom-properties?apiVersion=2022-11-28) schemas added new `value_types` and updated the `default_value` and `value` properties to allow for `null`, `string`, or `array`.  This breaks deserialization of payloads with Custom Property or Custom Property Values.  See issue for more details.

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* Added `multi_select`, and `true_false` custom property value types
* Custom Property definition `default_value` may be null, string, or array of strings
* Custom Property `value` property may be `null`, `string`, or `array` of strings
* Updated `Repository.CustomProperties` to be `IDictionary<string, object>` to support polymorphic values of either string or array

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

