### PR TITLE
Use `DateTimeOffset` everywhere instead of `string`

### DIFF
--- a/src/Octokit.Webhooks/Models/WorkflowJobEvent/WorkflowJob.cs
+++ b/src/Octokit.Webhooks/Models/WorkflowJobEvent/WorkflowJob.cs
@@ -60,7 +60,8 @@ public sealed record WorkflowJob
     public string? RunnerGroupName { get; init; }
 
     [JsonPropertyName("started_at")]
-    public string StartedAt { get; init; } = null!;
+    [JsonConverter(typeof(DateTimeOffsetConverter))]
+    public DateTimeOffset StartedAt { get; init; }
 
     [JsonPropertyName("completed_at")]
     public string? CompletedAt { get; init; }
@@ -72,5 +73,6 @@ public sealed record WorkflowJob
     public string? HeadBranch { get; init; }
 
     [JsonPropertyName("created_at")]
-    public string CreatedAt { get; init; } = null!;
+    [JsonConverter(typeof(DateTimeOffsetConverter))]
+    public DateTimeOffset CreatedAt { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/WorkflowJobEvent/WorkflowJobStep.cs
+++ b/src/Octokit.Webhooks/Models/WorkflowJobEvent/WorkflowJobStep.cs
@@ -18,7 +18,8 @@ public sealed record WorkflowJobStep
     public long Number { get; init; }
 
     [JsonPropertyName("started_at")]
-    public string StartedAt { get; init; } = null!;
+    [JsonConverter(typeof(DateTimeOffsetConverter))]
+    public DateTimeOffset StartedAt { get; init; }
 
     [JsonPropertyName("completed_at")]
     [JsonConverter(typeof(NullableDateTimeOffsetConverter))]


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #524 

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* An inconsistent mix of `string` and `DateTimeOffset` for `*_at` fields.

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* Use `DateTimeOffset` everywhere instead of `string`

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [x] Yes
- [ ] No

----

