### PR TITLE
fix: move common properties from `DeploymentProtectionRuleRequestedEvent` to `DeploymentProtectionRuleRequestedEvent`

### DIFF
--- a/src/Octokit.Webhooks/Events/DeploymentProtectionRule/DeploymentProtectionRuleRequestedEvent.cs
+++ b/src/Octokit.Webhooks/Events/DeploymentProtectionRule/DeploymentProtectionRuleRequestedEvent.cs
@@ -6,19 +6,4 @@ public sealed record DeploymentProtectionRuleRequestedEvent : DeploymentProtecti
 {
     [JsonPropertyName("action")]
     public override string Action => DeploymentProtectionRuleAction.Requested;
-
-    [JsonPropertyName("environment")]
-    public string Environment { get; init; } = null!;
-
-    [JsonPropertyName("event")]
-    public string Event { get; init; } = null!;
-
-    [JsonPropertyName("deployment_callback_url")]
-    public string DeploymentCallbackUrl { get; init; } = null!;
-
-    [JsonPropertyName("deployment")]
-    public Models.DeploymentEvent.Deployment Deployment { get; init; } = null!;
-
-    [JsonPropertyName("pull_requests")]
-    public IEnumerable<Models.PullRequestEvent.PullRequest> PullRequests { get; init; } = null!;
 }

--- a/src/Octokit.Webhooks/Events/DeploymentProtectionRuleEvent.cs
+++ b/src/Octokit.Webhooks/Events/DeploymentProtectionRuleEvent.cs
@@ -3,4 +3,20 @@ namespace Octokit.Webhooks.Events;
 [PublicAPI]
 [WebhookEventType(WebhookEventType.DeploymentProtectionRule)]
 [JsonConverter(typeof(WebhookConverter<DeploymentProtectionRuleEvent>))]
-public abstract record DeploymentProtectionRuleEvent : WebhookEvent;
+public abstract record DeploymentProtectionRuleEvent : WebhookEvent
+{
+    [JsonPropertyName("environment")]
+    public string Environment { get; init; } = null!;
+
+    [JsonPropertyName("event")]
+    public string Event { get; init; } = null!;
+
+    [JsonPropertyName("deployment_callback_url")]
+    public string DeploymentCallbackUrl { get; init; } = null!;
+
+    [JsonPropertyName("deployment")]
+    public Models.DeploymentEvent.Deployment Deployment { get; init; } = null!;
+
+    [JsonPropertyName("pull_requests")]
+    public IEnumerable<Models.PullRequestEvent.PullRequest> PullRequests { get; init; } = null!;
+}


### PR DESCRIPTION
There is only one action, `requested`, for the `deployment_protection_rule` event. So we can't know which properties are common between different actions. Moving them all to the base, abstract, class makes the properties easier to access for now.

Resolves #546

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* You need to cast `DeploymentProtectionRuleEvent` to `DeploymentProtectionRuleRequestedEvent`

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* Common properties are available without a cast

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

