### PR TITLE
Use long for numeric dates

### DIFF
--- a/src/Octokit.Webhooks/Converter/DateTimeOffsetConverter.cs
+++ b/src/Octokit.Webhooks/Converter/DateTimeOffsetConverter.cs
@@ -25,5 +25,5 @@ public class DateTimeOffsetConverter : JsonConverter<DateTimeOffset>
         return DateTimeOffset.Parse(stringValue, CultureInfo.InvariantCulture);
     }
 
-    private static DateTimeOffset HandleNumber(Utf8JsonReader reader) => DateTimeOffset.FromUnixTimeSeconds(reader.GetInt32());
+    private static DateTimeOffset HandleNumber(Utf8JsonReader reader) => DateTimeOffset.FromUnixTimeSeconds(reader.GetInt64());
 }

--- a/test/Octokit.Webhooks.Test/Converter/DateTimeOffsetConverterTests.cs
+++ b/test/Octokit.Webhooks.Test/Converter/DateTimeOffsetConverterTests.cs
@@ -17,6 +17,7 @@ public class DateTimeOffsetConverterTests
     };
 
     private readonly DateTimeOffset expected = new(2019, 05, 15, 15, 20, 40, default);
+    private readonly DateTimeOffset expectedY2038 = DateTimeOffset.FromUnixTimeSeconds(int.MaxValue + 1L);
 
     [Theory]
     [InlineData(@"""2019-05-15T15:20:40Z""")]
@@ -27,17 +28,33 @@ public class DateTimeOffsetConverterTests
         result.Should().Be(this.expected);
     }
 
+    [Theory]
+    [InlineData(@"""2038-01-19T03:14:08Z""")]
+    [InlineData(@"""2038-01-19T03:14:08.000+00:00""")]
+    public void CanDeserializeStringY2038(string input)
+    {
+        var result = JsonSerializer.Deserialize<DateTimeOffset>(input, this.options);
+        result.Should().Be(this.expectedY2038);
+    }
+
     [Fact]
     public void CanDeserializeNumber()
     {
-        var result = JsonSerializer.Deserialize<DateTimeOffset>(@"1557933640", this.options);
+        var result = JsonSerializer.Deserialize<DateTimeOffset>("1557933640", this.options);
         result.Should().Be(this.expected);
+    }
+
+    [Fact]
+    public void CanDeserializeNumberY2038()
+    {
+        var result = JsonSerializer.Deserialize<DateTimeOffset>("2147483648", this.options);
+        result.Should().Be(this.expectedY2038);
     }
 
     [Fact]
     public void DeserializeThrowsForNull()
     {
-        var result = () => JsonSerializer.Deserialize<DateTimeOffset>(@"null", this.options);
+        var result = () => JsonSerializer.Deserialize<DateTimeOffset>("null", this.options);
         result.Should().Throw<JsonException>();
     }
 


### PR DESCRIPTION
Use `long` instead of `int` to avoid an implicit conversion and the Y2038 bug.

Resolves #590.

----

### Before the change?

* An implicit conversion from `int` to `long` occurs when creating a `DateTimeOffset` from a JSON number.
* Numeric timestamps beyond `2038-01-19T03:14:07Z` cannot be deserialized:

```text
System.Text.Json.JsonException : The JSON value could not be converted to System.DateTimeOffset. Path: $ | LineNumber: 0 | BytePositionInLine: 10.
---- System.FormatException : Either the JSON value is not in a supported format, or is out of bounds for an Int32.

ThrowHelper.ReThrowWithPath(ReadStack& state, Utf8JsonReader& reader, Exception ex)
JsonConverter`1.ReadCore(Utf8JsonReader& reader, JsonSerializerOptions options, ReadStack& state)
JsonSerializer.ReadFromSpan[TValue](ReadOnlySpan`1 utf8Json, JsonTypeInfo jsonTypeInfo, Nullable`1 actualByteCount)
JsonSerializer.ReadFromSpan[TValue](ReadOnlySpan`1 json, JsonTypeInfo jsonTypeInfo)
JsonSerializer.Deserialize[TValue](String json, JsonSerializerOptions options)
DateTimeOffsetConverterTests.CanDeserializeNumberY2038() line 50
----- Inner Stack Trace -----
Utf8JsonReader.GetInt32()
DateTimeOffsetConverter.HandleNumber(Utf8JsonReader reader) line 28
DateTimeOffsetConverter.ReadInternal(Utf8JsonReader& reader) line 14
DateTimeOffsetConverter.Read(Utf8JsonReader& reader, Type typeToConvert, JsonSerializerOptions options) line 6
JsonConverter`1.TryRead(Utf8JsonReader& reader, Type typeToConvert, JsonSerializerOptions options, ReadStack& state, T& value)
JsonConverter`1.ReadCore(Utf8JsonReader& reader, JsonSerializerOptions options, ReadStack& state)
```

### After the change?

* No implicit conversion occurs.
* Values after `2038-01-19T03:14:07Z` can be deserialized

### Pull request checklist

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

----
