### PR TITLE
target dotnet 9.0 for test and sample projects

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,9 +3,7 @@
   "image": "mcr.microsoft.com/devcontainers/dotnet:dev-9.0",
   "postCreateCommand": "dotnet restore",
   "features": {
-    "ghcr.io/devcontainers/features/dotnet": {
-      "dotnetRuntimeVersions": "6.0"
-    }
+    "ghcr.io/devcontainers/features/dotnet": {}
   },
   "customizations": {
     "vscode": {

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,10 +39,6 @@ jobs:
           fetch-depth: 0
       - name: 'Install .NET Core SDK'
         uses: actions/setup-dotnet@3e891b0cb619bf60e2c25674b222b8940e2c1c25 # v4.1.0
-        with:
-          dotnet-version: |
-            6.0.x
-            9.0.x
       - name: 'Dotnet Tool Restore'
         run: dotnet tool restore
         shell: pwsh

--- a/samples/AspNetCore/AspNetCore.csproj
+++ b/samples/AspNetCore/AspNetCore.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);CA1848;IDE0021;IDE0053;VSTHRD111</NoWarn>
   </PropertyGroup>

--- a/samples/AzureFunctions/AzureFunctions.csproj
+++ b/samples/AzureFunctions/AzureFunctions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <AzureFunctionsVersion>V4</AzureFunctionsVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);CA1848;IDE0021;IDE0053;VSTHRD111</NoWarn>

--- a/test/Octokit.Webhooks.AzureFunctions.Test/Octokit.Webhooks.AzureFunctions.Test.csproj
+++ b/test/Octokit.Webhooks.AzureFunctions.Test/Octokit.Webhooks.AzureFunctions.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup Label="Build">
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup Label="Project References">

--- a/test/Octokit.Webhooks.Test/Octokit.Webhooks.Test.csproj
+++ b/test/Octokit.Webhooks.Test/Octokit.Webhooks.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup Label="Build">
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup Label="Project References">

--- a/test/Octokit.Webhooks.TestUtils/Octokit.Webhooks.TestUtils.csproj
+++ b/test/Octokit.Webhooks.TestUtils/Octokit.Webhooks.TestUtils.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup Label="Build">
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
.NET 6 is now end-of-life. This change retargets sample and test projects to use .NET 9, while leaving the libraries targeting .NET 6.

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* All projects target .NET 6

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* Test and sample projects target .NET 9

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->
No

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [ ] No

----

