### PR TITLE
Add webhook processor for projects_v2_item and more payload schema

### DIFF
--- a/src/Octokit.Webhooks/Models/ProjectsV2ItemEvent/ChangesFieldValue.cs
+++ b/src/Octokit.Webhooks/Models/ProjectsV2ItemEvent/ChangesFieldValue.cs
@@ -9,4 +9,16 @@ public sealed record ChangesFieldValue
 
     [JsonPropertyName("field_node_id")]
     public string FieldNodeId { get; init; } = null!;
+
+    [JsonPropertyName("field_name")]
+    public string FieldName { get; init; } = null!;
+
+    [JsonPropertyName("project_number")]
+    public long ProjectNumber { get; init; }
+
+    [JsonPropertyName("from")]
+    public ChangesFieldValueChange From { get; init; } = null!;
+
+    [JsonPropertyName("to")]
+    public ChangesFieldValueChange To { get; init; } = null!;
 }

--- a/src/Octokit.Webhooks/Models/ProjectsV2ItemEvent/ChangesFieldValueChange.cs
+++ b/src/Octokit.Webhooks/Models/ProjectsV2ItemEvent/ChangesFieldValueChange.cs
@@ -1,0 +1,17 @@
+namespace Octokit.Webhooks.Models.ProjectsV2ItemEvent;
+
+[PublicAPI]
+public sealed record ChangesFieldValueChange
+{
+    [JsonPropertyName("id")]
+    public string Id { get; init; } = null!;
+
+    [JsonPropertyName("name")]
+    public string Name { get; init; } = null!;
+
+    [JsonPropertyName("color")]
+    public string Color { get; init; } = null!;
+
+    [JsonPropertyName("description")]
+    public string Description { get; init; } = null!;
+}

--- a/src/Octokit.Webhooks/WebhookEventProcessor.cs
+++ b/src/Octokit.Webhooks/WebhookEventProcessor.cs
@@ -39,6 +39,7 @@ using Octokit.Webhooks.Events.Package;
 using Octokit.Webhooks.Events.Project;
 using Octokit.Webhooks.Events.ProjectCard;
 using Octokit.Webhooks.Events.ProjectColumn;
+using Octokit.Webhooks.Events.ProjectsV2Item;
 using Octokit.Webhooks.Events.PullRequest;
 using Octokit.Webhooks.Events.PullRequestReview;
 using Octokit.Webhooks.Events.PullRequestReviewComment;
@@ -124,6 +125,7 @@ public abstract class WebhookEventProcessor
             ProjectEvent projectEvent => this.ProcessProjectWebhookAsync(headers, projectEvent),
             ProjectCardEvent projectCardEvent => this.ProcessProjectCardWebhookAsync(headers, projectCardEvent),
             ProjectColumnEvent projectColumnEvent => this.ProcessProjectColumnWebhookAsync(headers, projectColumnEvent),
+            ProjectsV2ItemEvent projectsV2ItemEvent => this.ProcessProjectsV2ItemWebhookAsync(headers, projectsV2ItemEvent),
             PublicEvent publicEvent => this.ProcessPublicWebhookAsync(headers, publicEvent),
             PullRequestEvent pullRequestEvent => this.ProcessPullRequestWebhookAsync(headers, pullRequestEvent),
             PullRequestReviewEvent pullRequestReviewEvent => this.ProcessPullRequestReviewWebhookAsync(headers, pullRequestReviewEvent),
@@ -884,6 +886,23 @@ public abstract class WebhookEventProcessor
         WebhookHeaders headers,
         ProjectColumnEvent projectColumnEvent,
         ProjectColumnAction action) => Task.CompletedTask;
+
+    [PublicAPI]
+    protected virtual Task ProcessProjectsV2ItemWebhookAsync(WebhookHeaders headers, ProjectsV2ItemEvent projectsV2ItemEvent, ProjectsV2ItemAction action)
+        => Task.CompletedTask;
+
+    private Task ProcessProjectsV2ItemWebhookAsync(WebhookHeaders headers, ProjectsV2ItemEvent projectsV2ItemEvent) =>
+        projectsV2ItemEvent.Action switch
+        {
+            ProjectsV2ItemActionValue.Created => this.ProcessProjectsV2ItemWebhookAsync(headers, projectsV2ItemEvent, ProjectsV2ItemAction.Created),
+            ProjectsV2ItemActionValue.Deleted => this.ProcessProjectsV2ItemWebhookAsync(headers, projectsV2ItemEvent, ProjectsV2ItemAction.Deleted),
+            ProjectsV2ItemActionValue.Edited => this.ProcessProjectsV2ItemWebhookAsync(headers, projectsV2ItemEvent, ProjectsV2ItemAction.Edited),
+            ProjectsV2ItemActionValue.Archived => this.ProcessProjectsV2ItemWebhookAsync(headers, projectsV2ItemEvent, ProjectsV2ItemAction.Archived),
+            ProjectsV2ItemActionValue.Converted => this.ProcessProjectsV2ItemWebhookAsync(headers, projectsV2ItemEvent, ProjectsV2ItemAction.Converted),
+            ProjectsV2ItemActionValue.Restored => this.ProcessProjectsV2ItemWebhookAsync(headers, projectsV2ItemEvent, ProjectsV2ItemAction.Restored),
+            ProjectsV2ItemActionValue.Reordered => this.ProcessProjectsV2ItemWebhookAsync(headers, projectsV2ItemEvent, ProjectsV2ItemAction.Reordered),
+            _ => Task.CompletedTask,
+        };
 
     [PublicAPI]
     protected virtual Task ProcessPublicWebhookAsync(WebhookHeaders headers, PublicEvent publicEvent) => Task.CompletedTask;

--- a/test/Octokit.Webhooks.Test/Resources/projects_v2_item/edited.payload.json
+++ b/test/Octokit.Webhooks.Test/Resources/projects_v2_item/edited.payload.json
@@ -33,7 +33,21 @@
   "changes": {
     "field_value": {
       "field_node_id": "PVTF_lADOAWcTxs07G84AAali",
-      "field_type": "single_select"
+      "field_type": "single_select",
+      "field_name": "Status",
+      "project_number": 18,
+      "from": {
+        "id": "f75ad846",
+        "name": "Todo",
+        "color": "GREEN",
+        "description": "This item hasn't been started"
+      },
+      "to": {
+        "id": "47fc9ee4",
+        "name": "In Progress",
+        "color": "YELLOW",
+        "description": "This is actively being worked on"
+      }
     }
   },
   "organization": {


### PR DESCRIPTION
Resolves #657

----

### Before the change?

* There is no method on WebhookEventProcessor to override to handle projects_v2_item events.
* The ProjectsV2ItemEvent.Changes does not contain the field name or other new fields: https://github.blog/changelog/2024-06-27-github-issues-projects-graphql-and-webhook-support-for-project-status-updates-and-more/#using-webhooks-for-project-custom-field-changes

### After the change?

* There is a new ProcessProjectsV2ItemWebhookAsync method on WebhookeventProcessor which can be overridden to handle projects_v2_item events.
* The ProjectsV2ItemEvent.Changes now contains FieldName and other new schema

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
- [ ] Yes
- [x] No

----

