### PR TITLE
chore: bump from .net 6 to .net 8

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -3,6 +3,7 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))"/>
 
   <PropertyGroup Label="Build">
+    <TargetFramework>net8.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>

--- a/src/Octokit.Webhooks.AspNetCore/Octokit.Webhooks.AspNetCore.csproj
+++ b/src/Octokit.Webhooks.AspNetCore/Octokit.Webhooks.AspNetCore.csproj
@@ -1,9 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup Label="Build">
-    <TargetFramework>net6.0</TargetFramework>
-  </PropertyGroup>
-
   <PropertyGroup Label="Package">
     <Product>Octokit.Webhooks.AspNetCore</Product>
     <Description>GitHub webhook events toolset for .NET</Description>

--- a/src/Octokit.Webhooks.AzureFunctions/Octokit.Webhooks.AzureFunctions.csproj
+++ b/src/Octokit.Webhooks.AzureFunctions/Octokit.Webhooks.AzureFunctions.csproj
@@ -1,9 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-  </PropertyGroup>
-
   <PropertyGroup Label="Package">
     <Product>Octokit.Webhooks.AzureFunctions</Product>
     <Description>GitHub webhook events toolset for Azure Functions</Description>

--- a/src/Octokit.Webhooks/Octokit.Webhooks.csproj
+++ b/src/Octokit.Webhooks/Octokit.Webhooks.csproj
@@ -1,9 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup Label="Build">
-    <TargetFramework>net6.0</TargetFramework>
-  </PropertyGroup>
-
   <PropertyGroup Label="Package">
     <Product>Octokit.Webhooks</Product>
     <Description>GitHub webhook events definitions for .NET</Description>


### PR DESCRIPTION
Preparing for a major version bump I'm increasing the supported version of .NET from 6 to 8. This is inline with the new Octokit SDK

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* .NET 6+ supported

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* .NET 8+ supported

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [x] Yes
- [ ] No

----

