### PR TITLE
fix: correctness fixes and performance improvements to custom json converters

### DIFF
--- a/src/Octokit.Webhooks/Converter/DateTimeOffsetConverter.cs
+++ b/src/Octokit.Webhooks/Converter/DateTimeOffsetConverter.cs
@@ -22,7 +22,13 @@ public class DateTimeOffsetConverter : JsonConverter<DateTimeOffset>
     {
         var stringValue = reader.GetString() ?? throw new InvalidOperationException("Cannot parse a String JsonToken with a null value");
 
-        return DateTimeOffset.Parse(stringValue, CultureInfo.InvariantCulture);
+        var span = stringValue.AsSpan();
+        if (!DateTimeOffset.TryParse(span, CultureInfo.InvariantCulture, DateTimeStyles.None, out var result))
+        {
+            throw new JsonException($"Unable to parse '{stringValue}' as DateTimeOffset");
+        }
+
+        return result;
     }
 
     private static DateTimeOffset HandleNumber(Utf8JsonReader reader) => DateTimeOffset.FromUnixTimeSeconds(reader.GetInt64());

--- a/src/Octokit.Webhooks/Converter/StringEnumConverter.cs
+++ b/src/Octokit.Webhooks/Converter/StringEnumConverter.cs
@@ -11,7 +11,12 @@ public sealed class StringEnumConverter<TEnum> : JsonConverter<StringEnum<TEnum>
     public override StringEnum<TEnum> Read(
         ref Utf8JsonReader reader,
         Type typeToConvert,
-        JsonSerializerOptions options) => new(reader.GetString()!);
+        JsonSerializerOptions options)
+    {
+        var stringValue = reader.GetString() ?? throw new JsonException("Unexpected null value when deserializing StringEnum.");
+
+        return new(stringValue);
+    }
 
     public override void Write(Utf8JsonWriter writer, StringEnum<TEnum> value, JsonSerializerOptions options) =>
         JsonSerializer.Serialize(writer, value.StringValue, options);

--- a/src/Octokit.Webhooks/Converter/StringEnumEnumerableConverter.cs
+++ b/src/Octokit.Webhooks/Converter/StringEnumEnumerableConverter.cs
@@ -27,16 +27,16 @@ public sealed class StringEnumEnumerableConverter<TEnum> : JsonConverter<IEnumer
             throw new JsonException("Unexpected null value.");
         }
 
+        if (reader.TokenType != JsonTokenType.StartArray)
+        {
+            throw new JsonException("Expected JSON array.");
+        }
+
         var returnValue = new List<StringEnum<TEnum>>();
 
-        while (reader.TokenType != JsonTokenType.EndArray)
+        while (reader.Read() && reader.TokenType != JsonTokenType.EndArray)
         {
-            if (reader.TokenType != JsonTokenType.StartArray)
-            {
-                returnValue.Add(JsonSerializer.Deserialize<StringEnum<TEnum>>(ref reader, Options)!);
-            }
-
-            _ = reader.Read();
+            returnValue.Add(JsonSerializer.Deserialize<StringEnum<TEnum>>(ref reader, Options)!);
         }
 
         return returnValue;


### PR DESCRIPTION
- Correctness
	- Corrected the `StringEnumEnumerableConverter.ReadInternal` method to properly handle JSON array start/end tokens.
	- Used `DateTimeOffset.TryParse` instead of `DateTimeOffset.Parse` for more robust error handling.
	- Added explicit null checks in `StringEnumConverter` instead of relying on null-forgiving operators.
	- Added better validation for repository dispatch events and more descriptive error messages.
- Performance
	- Added static `ConcurrentDictionary` to cache reflection-based type lookups, preventing expensive reflection operations on every converter instantiation.
	- Added static caching for `EnumMemberAttribute` lookups in both `ToEnumString` and `ToEnum` methods, dramatically reducing reflection overhead.
	- Used `ReadOnlySpan<char>` in `DateTimeOffsetConverter` for more efficient string parsing.

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* 

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* 

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

