### PR TITLE
Support projects_v2_item changes of scalar values like strings/dates/numbers

### DIFF
--- a/src/Octokit.Webhooks/Models/ProjectsV2ItemEvent/ChangesFieldValue.cs
+++ b/src/Octokit.Webhooks/Models/ProjectsV2ItemEvent/ChangesFieldValue.cs
@@ -17,8 +17,8 @@ public sealed record ChangesFieldValue
     public long ProjectNumber { get; init; }
 
     [JsonPropertyName("from")]
-    public ChangesFieldValueChange From { get; init; } = null!;
+    public ChangesFieldValueChangeBase From { get; init; } = null!;
 
     [JsonPropertyName("to")]
-    public ChangesFieldValueChange To { get; init; } = null!;
+    public ChangesFieldValueChangeBase To { get; init; } = null!;
 }

--- a/src/Octokit.Webhooks/Models/ProjectsV2ItemEvent/ChangesFieldValueChange.cs
+++ b/src/Octokit.Webhooks/Models/ProjectsV2ItemEvent/ChangesFieldValueChange.cs
@@ -1,7 +1,7 @@
 namespace Octokit.Webhooks.Models.ProjectsV2ItemEvent;
 
 [PublicAPI]
-public sealed record ChangesFieldValueChange
+public sealed record ChangesFieldValueChange : ChangesFieldValueChangeBase
 {
     [JsonPropertyName("id")]
     public string Id { get; init; } = null!;

--- a/src/Octokit.Webhooks/Models/ProjectsV2ItemEvent/ChangesFieldValueChangeBase.cs
+++ b/src/Octokit.Webhooks/Models/ProjectsV2ItemEvent/ChangesFieldValueChangeBase.cs
@@ -1,0 +1,6 @@
+namespace Octokit.Webhooks.Models.ProjectsV2ItemEvent;
+
+[JsonConverter(typeof(ChangesFieldValueChangeConverter))]
+public abstract record ChangesFieldValueChangeBase
+{
+}

--- a/src/Octokit.Webhooks/Models/ProjectsV2ItemEvent/ChangesFieldValueChangeConverter.cs
+++ b/src/Octokit.Webhooks/Models/ProjectsV2ItemEvent/ChangesFieldValueChangeConverter.cs
@@ -1,0 +1,32 @@
+namespace Octokit.Webhooks.Models.ProjectsV2ItemEvent;
+
+public class ChangesFieldValueChangeConverter : JsonConverter<ChangesFieldValueChangeBase>
+{
+    public override ChangesFieldValueChangeBase? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        switch (reader.TokenType)
+        {
+            case JsonTokenType.StartObject:
+                var changeObject = JsonSerializer.Deserialize<ChangesFieldValueChange>(ref reader, options);
+                return changeObject;
+            case JsonTokenType.String:
+            case JsonTokenType.True:
+            case JsonTokenType.False:
+                return new ChangesFieldValueScalarChange { StringValue = reader.GetString() };
+            case JsonTokenType.Null:
+                return null;
+            case JsonTokenType.Number:
+                return new ChangesFieldValueScalarChange { NumericValue = reader.GetDecimal() };
+            case JsonTokenType.None:
+            case JsonTokenType.EndObject:
+            case JsonTokenType.StartArray:
+            case JsonTokenType.EndArray:
+            case JsonTokenType.PropertyName:
+            case JsonTokenType.Comment:
+            default:
+                throw new InvalidOperationException($"Invalid JsonTokenType {reader.TokenType}");
+        }
+    }
+
+    public override void Write(Utf8JsonWriter writer, ChangesFieldValueChangeBase value, JsonSerializerOptions options) => throw new NotImplementedException();
+}

--- a/src/Octokit.Webhooks/Models/ProjectsV2ItemEvent/ChangesFieldValueScalarChange.cs
+++ b/src/Octokit.Webhooks/Models/ProjectsV2ItemEvent/ChangesFieldValueScalarChange.cs
@@ -1,0 +1,9 @@
+namespace Octokit.Webhooks.Models.ProjectsV2ItemEvent;
+
+[PublicAPI]
+public sealed record ChangesFieldValueScalarChange : ChangesFieldValueChangeBase
+{
+    public string? StringValue { get; init; }
+
+    public decimal? NumericValue { get; init; }
+}

--- a/test/Octokit.Webhooks.Test/Resources/projects_v2_item/edited.with-date.payload.json
+++ b/test/Octokit.Webhooks.Test/Resources/projects_v2_item/edited.with-date.payload.json
@@ -1,0 +1,77 @@
+{
+  "action": "edited",
+  "projects_v2_item": {
+    "id": 5678510,
+    "node_id": "PVTI_lADOAWcTxs07G84AVqWu",
+    "project_node_id": "PVT_kwDOAWcTxs07Gw",
+    "content_node_id": "DI_lADOAWcTxs07G84AIjOy",
+    "content_type": "DraftIssue",
+    "creator": {
+      "login": "wolfy1339",
+      "id": 4595477,
+      "node_id": "MDQ6VXNlcjQ1OTU0Nzc=",
+      "avatar_url": "https://avatars.githubusercontent.com/u/4595477?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/wolfy1339",
+      "html_url": "https://github.com/wolfy1339",
+      "followers_url": "https://api.github.com/users/wolfy1339/followers",
+      "following_url": "https://api.github.com/users/wolfy1339/following{/other_user}",
+      "gists_url": "https://api.github.com/users/wolfy1339/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/wolfy1339/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/wolfy1339/subscriptions",
+      "organizations_url": "https://api.github.com/users/wolfy1339/orgs",
+      "repos_url": "https://api.github.com/users/wolfy1339/repos",
+      "events_url": "https://api.github.com/users/wolfy1339/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/wolfy1339/received_events",
+      "type": "User",
+      "site_admin": false
+    },
+    "created_at": "2022-06-08T20:34:26Z",
+    "updated_at": "2022-06-08T20:34:26Z",
+    "archived_at": null
+  },
+  "changes": {
+    "field_value": {
+      "field_node_id": "PVTF_lADOAEzhac4AjFojzgbzsKM",
+      "field_type": "date",
+      "field_name": "Start Date",
+      "project_number": 233,
+      "from": null,
+      "to": "2025-08-01T00:00:00+00:00"
+    }
+  },
+  "organization": {
+    "login": "Octocoders",
+    "id": 38302899,
+    "node_id": "MDEyOk9yZ2FuaXphdGlvbjM4MzAyODk5",
+    "url": "https://api.github.com/orgs/Octocoders",
+    "repos_url": "https://api.github.com/orgs/Octocoders/repos",
+    "events_url": "https://api.github.com/orgs/Octocoders/events",
+    "hooks_url": "https://api.github.com/orgs/Octocoders/hooks",
+    "issues_url": "https://api.github.com/orgs/Octocoders/issues",
+    "members_url": "https://api.github.com/orgs/Octocoders/members{/member}",
+    "public_members_url": "https://api.github.com/orgs/Octocoders/public_members{/member}",
+    "avatar_url": "https://avatars1.githubusercontent.com/u/38302899?v=4",
+    "description": ""
+  },
+  "sender": {
+    "login": "wolfy1339",
+    "id": 4595477,
+    "node_id": "MDQ6VXNlcjQ1OTU0Nzc=",
+    "avatar_url": "https://avatars.githubusercontent.com/u/4595477?v=4",
+    "gravatar_id": "",
+    "url": "https://api.github.com/users/wolfy1339",
+    "html_url": "https://github.com/wolfy1339",
+    "followers_url": "https://api.github.com/users/wolfy1339/followers",
+    "following_url": "https://api.github.com/users/wolfy1339/following{/other_user}",
+    "gists_url": "https://api.github.com/users/wolfy1339/gists{/gist_id}",
+    "starred_url": "https://api.github.com/users/wolfy1339/starred{/owner}{/repo}",
+    "subscriptions_url": "https://api.github.com/users/wolfy1339/subscriptions",
+    "organizations_url": "https://api.github.com/users/wolfy1339/orgs",
+    "repos_url": "https://api.github.com/users/wolfy1339/repos",
+    "events_url": "https://api.github.com/users/wolfy1339/events{/privacy}",
+    "received_events_url": "https://api.github.com/users/wolfy1339/received_events",
+    "type": "User",
+    "site_admin": false
+  }
+}

--- a/test/Octokit.Webhooks.Test/Resources/projects_v2_item/edited.with-number.payload.json
+++ b/test/Octokit.Webhooks.Test/Resources/projects_v2_item/edited.with-number.payload.json
@@ -1,0 +1,77 @@
+{
+  "action": "edited",
+  "projects_v2_item": {
+    "id": 5678510,
+    "node_id": "PVTI_lADOAWcTxs07G84AVqWu",
+    "project_node_id": "PVT_kwDOAWcTxs07Gw",
+    "content_node_id": "DI_lADOAWcTxs07G84AIjOy",
+    "content_type": "DraftIssue",
+    "creator": {
+      "login": "wolfy1339",
+      "id": 4595477,
+      "node_id": "MDQ6VXNlcjQ1OTU0Nzc=",
+      "avatar_url": "https://avatars.githubusercontent.com/u/4595477?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/wolfy1339",
+      "html_url": "https://github.com/wolfy1339",
+      "followers_url": "https://api.github.com/users/wolfy1339/followers",
+      "following_url": "https://api.github.com/users/wolfy1339/following{/other_user}",
+      "gists_url": "https://api.github.com/users/wolfy1339/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/wolfy1339/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/wolfy1339/subscriptions",
+      "organizations_url": "https://api.github.com/users/wolfy1339/orgs",
+      "repos_url": "https://api.github.com/users/wolfy1339/repos",
+      "events_url": "https://api.github.com/users/wolfy1339/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/wolfy1339/received_events",
+      "type": "User",
+      "site_admin": false
+    },
+    "created_at": "2022-06-08T20:34:26Z",
+    "updated_at": "2022-06-08T20:34:26Z",
+    "archived_at": null
+  },
+  "changes": {
+    "field_value": {
+      "field_node_id": "PVTF_lADOAEzhac4AjFojzgyEIsU",
+      "field_type": "number",
+      "field_name": "tempNumber",
+      "project_number": 233,
+      "from": null,
+      "to": 123.456
+    }
+  },
+  "organization": {
+    "login": "Octocoders",
+    "id": 38302899,
+    "node_id": "MDEyOk9yZ2FuaXphdGlvbjM4MzAyODk5",
+    "url": "https://api.github.com/orgs/Octocoders",
+    "repos_url": "https://api.github.com/orgs/Octocoders/repos",
+    "events_url": "https://api.github.com/orgs/Octocoders/events",
+    "hooks_url": "https://api.github.com/orgs/Octocoders/hooks",
+    "issues_url": "https://api.github.com/orgs/Octocoders/issues",
+    "members_url": "https://api.github.com/orgs/Octocoders/members{/member}",
+    "public_members_url": "https://api.github.com/orgs/Octocoders/public_members{/member}",
+    "avatar_url": "https://avatars1.githubusercontent.com/u/38302899?v=4",
+    "description": ""
+  },
+  "sender": {
+    "login": "wolfy1339",
+    "id": 4595477,
+    "node_id": "MDQ6VXNlcjQ1OTU0Nzc=",
+    "avatar_url": "https://avatars.githubusercontent.com/u/4595477?v=4",
+    "gravatar_id": "",
+    "url": "https://api.github.com/users/wolfy1339",
+    "html_url": "https://github.com/wolfy1339",
+    "followers_url": "https://api.github.com/users/wolfy1339/followers",
+    "following_url": "https://api.github.com/users/wolfy1339/following{/other_user}",
+    "gists_url": "https://api.github.com/users/wolfy1339/gists{/gist_id}",
+    "starred_url": "https://api.github.com/users/wolfy1339/starred{/owner}{/repo}",
+    "subscriptions_url": "https://api.github.com/users/wolfy1339/subscriptions",
+    "organizations_url": "https://api.github.com/users/wolfy1339/orgs",
+    "repos_url": "https://api.github.com/users/wolfy1339/repos",
+    "events_url": "https://api.github.com/users/wolfy1339/events{/privacy}",
+    "received_events_url": "https://api.github.com/users/wolfy1339/received_events",
+    "type": "User",
+    "site_admin": false
+  }
+}

--- a/test/Octokit.Webhooks.Test/WebhookEventProcessorTests.cs
+++ b/test/Octokit.Webhooks.Test/WebhookEventProcessorTests.cs
@@ -10,8 +10,10 @@ public class WebhookEventProcessorTests
 
     [Theory]
     [ClassData(typeof(WebhookEventProcessorTestsData))]
-    public void CanDeserialize(string @event, string payload, Type expectedType)
+    public void CanDeserialize(string @event, string testName, string payload, Type expectedType)
     {
+        // Only used to make it easier to differentiate test cases for the same event without looking at whole payload
+        _ = testName;
         var headers = new WebhookHeaders
         {
             Event = @event,

--- a/test/Octokit.Webhooks.Test/WebhookEventProcessorTestsData.cs
+++ b/test/Octokit.Webhooks.Test/WebhookEventProcessorTestsData.cs
@@ -8,9 +8,9 @@ using CaseExtensions;
 using Octokit.Webhooks.TestUtils;
 using Xunit;
 
-public class WebhookEventProcessorTestsData : IEnumerable<TheoryDataRow<string, string, Type>>
+public class WebhookEventProcessorTestsData : IEnumerable<TheoryDataRow<string, string, string, Type>>
 {
-    public IEnumerator<TheoryDataRow<string, string, Type>> GetEnumerator()
+    public IEnumerator<TheoryDataRow<string, string, string, Type>> GetEnumerator()
     {
         var resourcesDirectory = ResourceUtils.GetResources();
         var files = Directory.GetFiles(resourcesDirectory, "*.json", SearchOption.AllDirectories);
@@ -20,7 +20,7 @@ public class WebhookEventProcessorTestsData : IEnumerable<TheoryDataRow<string, 
             var parts = relativeResource.Split(Path.DirectorySeparatorChar);
             var expectedType = ClassUtils.GetEventTypeByName(parts[0].ToPascalCase());
             var content = ResourceUtils.ReadResource(relativeResource);
-            yield return new TheoryDataRow<string, string, Type>(parts[0], content, expectedType);
+            yield return new TheoryDataRow<string, string, string, Type>(parts[0], parts[1], content, expectedType);
         }
     }
 


### PR DESCRIPTION
Fixes a bug that prevents deserialization of `projects_v2_item` events with action `edited` when the field mentioned in `changes` is not a `single_select` but is instead a scalar value like a string, date, or number.

<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
* Resolves https://github.com/octokit/webhooks.net/issues/724

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

All changes were assumed to be of a `single_select` field with a particular structure, but the `from` and `to` fields aren't always strings, according to the [documentation](https://docs.github.com/en/webhooks/webhook-events-and-payloads?actionType=edited#projects_v2_item) they can also be strings, dates (as strings), or numbers. All of these options will cause deserialization of the event to fail.

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Unfortunately, this might be a breaking change:

* In `ChangesFieldValue`, I changed the type on `From` and `To` from `ChangesFieldValueChange` to a new abstract base class `ChangesFieldValueChangeBase` (I am not in love with the name) which `ChangesFieldValueChange` now inherits from. This covers the object use case.
* I added a type `ChangesFieldValueSclaarChange` that also inherits from the base and contains a `StringValue` and `NumericValue` property to contain whatever scalar value might be contained.
* I added a JsonConverter on `ChangesFieldValueChangeBase` so that the deserializer could decide if it was looking at an object or not and return whichever derived type was appropriate.

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [x] Yes
- [ ] No

Unfortunately, changing the type on `From` and `To` to an abstract base class that contains no properties of its own constitutes a breaking change for anyone already using these properties.

Anyone handling any of the `ProjectV2{Action}Event` classes and accessing that object's `evt.Changes.FieldValue.From` or `evt.Changes.FieldValue.To` will now get an abstract type with no properties. This instance must be tested to see if it is a `ChangesFieldValueScalarChange` or a `ChangesFieldValueChange` and then cast appropriately before being able to use (assuming existing working code) the `Id`, `Name`, `Color`, or `Description` properties.

----

