### PR TITLE
feat: add support for `IHostApplicationBuilder`

### DIFF
--- a/samples/AzureFunctions/Program.cs
+++ b/samples/AzureFunctions/Program.cs
@@ -1,16 +1,15 @@
 #pragma warning disable CA1852
 using AzureFunctions;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Builder;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Octokit.Webhooks;
 using Octokit.Webhooks.AzureFunctions;
 
-new HostBuilder()
-    .ConfigureServices(collection =>
-    {
-        collection.AddSingleton<WebhookEventProcessor, MyWebhookEventProcessor>();
-    })
-    .ConfigureGitHubWebhooks()
-    .ConfigureFunctionsWorkerDefaults()
-    .Build()
-    .Run();
+var builder = FunctionsApplication.CreateBuilder(args);
+
+builder.Services.AddSingleton<WebhookEventProcessor, MyWebhookEventProcessor>();
+builder.ConfigureGitHubWebhooks();
+
+builder.Build().Run();

--- a/src/Octokit.Webhooks.AzureFunctions/GithubWebhookHostBuilderExtensions.cs
+++ b/src/Octokit.Webhooks.AzureFunctions/GithubWebhookHostBuilderExtensions.cs
@@ -30,4 +30,30 @@ public static class GithubWebhookHostBuilderExtensions
         return hostBuilder.ConfigureServices((context, services) =>
             services.AddOptions<GitHubWebhooksOptions>().Configure(options => options.Secret = configure(context.Configuration)));
     }
+
+    /// <summary>
+    /// Configures GitHub webhook function.
+    /// </summary>
+    /// <param name="builder"><see cref="IHostApplicationBuilder" /> instance.</param>
+    /// <param name="secret">The secret you have configured in GitHub, if you have set this up.</param>
+    /// <returns>Returns <see cref="IHostApplicationBuilder" /> instance.</returns>
+    public static IHostApplicationBuilder ConfigureGitHubWebhooks(this IHostApplicationBuilder builder, string? secret = null)
+    {
+        builder.Services.AddOptions<GitHubWebhooksOptions>().Configure(options => options.Secret = secret);
+        return builder;
+    }
+
+    /// <summary>
+    /// Configures GitHub webhook function.
+    /// </summary>
+    /// <param name="builder"><see cref="IHostApplicationBuilder" /> instance.</param>
+    /// <param name="configure">A function that takes an <see cref="IConfiguration" /> instance and expects the secret you have configured in GitHub in return.</param>
+    /// <returns>Returns <see cref="IHostApplicationBuilder" /> instance.</returns>
+    public static IHostApplicationBuilder ConfigureGitHubWebhooks(this IHostApplicationBuilder builder, Func<IConfiguration, string> configure)
+    {
+        ArgumentNullException.ThrowIfNull(configure);
+
+        builder.Services.AddOptions<GitHubWebhooksOptions>().Configure(options => options.Secret = configure(builder.Configuration));
+        return builder;
+    }
 }


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #727

`IHostBuilder` configuration is now considered legacy, with `IHostApplicationBuilder` being its replacement.

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* `Octokit.Webhooks.AzureFunctions` only supports `IHostBuilder` configuration

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* `Octokit.Webhooks.AzureFunctions` supports both `IHostBuilder` _and_ `IHostApplicationBuilder` configuration

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

