### PR TITLE
Remove Activator from enum converter

### DIFF
--- a/src/Octokit.Webhooks/Converter/StringEnumEnumerableConverter.cs
+++ b/src/Octokit.Webhooks/Converter/StringEnumEnumerableConverter.cs
@@ -11,7 +11,7 @@ public sealed class StringEnumEnumerableConverter<TEnum> : JsonConverter<IEnumer
 {
     private static readonly JsonSerializerOptions Options = new()
     {
-        Converters = { Activator.CreateInstance<StringEnumConverter<TEnum>>() },
+        Converters = { new StringEnumConverter<TEnum>() },
     };
 
     public override IEnumerable<StringEnum<TEnum>> Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) =>


### PR DESCRIPTION
Checking https://github.com/octokit/webhooks.net/pull/98 it seems Activator is not needed, or did I miss something?

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* Use Activator

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* Doesn't

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

