### PR TITLE
fix: AlertRule Tags are IEnumerable<string>

### DIFF
--- a/src/Octokit.Webhooks/Events/SubIssues/SubIssuesAction.cs
+++ b/src/Octokit.Webhooks/Events/SubIssues/SubIssuesAction.cs
@@ -1,0 +1,18 @@
+namespace Octokit.Webhooks.Events.SubIssues;
+
+[PublicAPI]
+public sealed record SubIssuesAction : WebhookEventAction
+{
+    public static readonly SubIssuesAction ParentIssueAdded = new(SubIssuesActionValue.ParentIssueAdded);
+
+    public static readonly SubIssuesAction ParentIssueRemoved = new(SubIssuesActionValue.ParentIssueRemoved);
+
+    public static readonly SubIssuesAction SubIssueAdded = new(SubIssuesActionValue.SubIssueAdded);
+
+    public static readonly SubIssuesAction SubIssueRemoved = new(SubIssuesActionValue.SubIssueRemoved);
+
+    private SubIssuesAction(string value)
+        : base(value)
+    {
+    }
+}

--- a/src/Octokit.Webhooks/Events/SubIssues/SubIssuesActionValue.cs
+++ b/src/Octokit.Webhooks/Events/SubIssues/SubIssuesActionValue.cs
@@ -1,0 +1,12 @@
+namespace Octokit.Webhooks.Events.SubIssues;
+
+public static class SubIssuesActionValue
+{
+    public const string ParentIssueAdded = "parent_issue_added";
+
+    public const string ParentIssueRemoved = "parent_issue_removed";
+
+    public const string SubIssueAdded = "sub_issue_added";
+
+    public const string SubIssueRemoved = "sub_issue_removed";
+}

--- a/src/Octokit.Webhooks/Events/SubIssues/SubIssuesParentIssueAddedEvent.cs
+++ b/src/Octokit.Webhooks/Events/SubIssues/SubIssuesParentIssueAddedEvent.cs
@@ -1,0 +1,9 @@
+namespace Octokit.Webhooks.Events.SubIssues;
+
+[PublicAPI]
+[WebhookActionType(SubIssuesActionValue.ParentIssueAdded)]
+public sealed record SubIssuesParentIssueAddedEvent : SubIssuesEvent
+{
+    [JsonPropertyName("action")]
+    public override string Action => SubIssuesAction.ParentIssueAdded;
+}

--- a/src/Octokit.Webhooks/Events/SubIssues/SubIssuesParentIssueRemovedEvent.cs
+++ b/src/Octokit.Webhooks/Events/SubIssues/SubIssuesParentIssueRemovedEvent.cs
@@ -1,0 +1,9 @@
+namespace Octokit.Webhooks.Events.SubIssues;
+
+[PublicAPI]
+[WebhookActionType(SubIssuesActionValue.ParentIssueRemoved)]
+public sealed record SubIssuesParentIssueRemovedEvent : SubIssuesEvent
+{
+    [JsonPropertyName("action")]
+    public override string Action => SubIssuesAction.ParentIssueRemoved;
+}

--- a/src/Octokit.Webhooks/Events/SubIssues/SubIssuesSubIssueAddedEvent.cs
+++ b/src/Octokit.Webhooks/Events/SubIssues/SubIssuesSubIssueAddedEvent.cs
@@ -1,0 +1,9 @@
+namespace Octokit.Webhooks.Events.SubIssues;
+
+[PublicAPI]
+[WebhookActionType(SubIssuesActionValue.SubIssueAdded)]
+public sealed record SubIssuesSubIssueAddedEvent : SubIssuesEvent
+{
+    [JsonPropertyName("action")]
+    public override string Action => SubIssuesAction.SubIssueAdded;
+}

--- a/src/Octokit.Webhooks/Events/SubIssues/SubIssuesSubIssueRemovedEvent.cs
+++ b/src/Octokit.Webhooks/Events/SubIssues/SubIssuesSubIssueRemovedEvent.cs
@@ -1,0 +1,9 @@
+namespace Octokit.Webhooks.Events.SubIssues;
+
+[PublicAPI]
+[WebhookActionType(SubIssuesActionValue.SubIssueRemoved)]
+public sealed record SubIssuesSubIssueRemovedEvent : SubIssuesEvent
+{
+    [JsonPropertyName("action")]
+    public override string Action => SubIssuesAction.SubIssueRemoved;
+}

--- a/src/Octokit.Webhooks/Events/SubIssuesEvent.cs
+++ b/src/Octokit.Webhooks/Events/SubIssuesEvent.cs
@@ -1,0 +1,25 @@
+namespace Octokit.Webhooks.Events;
+
+[PublicAPI]
+[WebhookEventType(WebhookEventType.SubIssues)]
+[JsonConverter(typeof(WebhookConverter<SubIssuesEvent>))]
+public abstract record SubIssuesEvent : WebhookEvent
+{
+    [JsonPropertyName("parent_issue_id")]
+    public long ParentIssueId { get; init; }
+
+    [JsonPropertyName("parent_issue")]
+    public Issue ParentIssue { get; init; } = null!;
+
+    [JsonPropertyName("parent_issue_repo")]
+    public Models.Repository? ParentIssueRepo { get; init; } = null!;
+
+    [JsonPropertyName("sub_issue_id")]
+    public long SubIssueId { get; init; }
+
+    [JsonPropertyName("sub_issue")]
+    public Issue SubIssue { get; init; } = null!;
+
+    [JsonPropertyName("sub_issue_repo")]
+    public Models.Repository? SubIssueRepo { get; init; }
+}

--- a/src/Octokit.Webhooks/Models/CodeScanningAlertEvent/AlertRule.cs
+++ b/src/Octokit.Webhooks/Models/CodeScanningAlertEvent/AlertRule.cs
@@ -17,7 +17,7 @@ public sealed record AlertRule
     public string FullDescription { get; init; } = null!;
 
     [JsonPropertyName("tags")]
-    public string Tags { get; init; } = null!;
+    public IEnumerable<string> Tags { get; init; } = null!;
 
     [JsonPropertyName("help")]
     public string Help { get; init; } = null!;

--- a/src/Octokit.Webhooks/WebHookEventType.cs
+++ b/src/Octokit.Webhooks/WebHookEventType.cs
@@ -66,6 +66,7 @@ public static class WebhookEventType
     public const string Sponsorship = "sponsorship";
     public const string Star = "star";
     public const string Status = "status";
+    public const string SubIssues = "sub_issues";
     public const string Team = "team";
     public const string TeamAdd = "team_add";
     public const string Watch = "watch";

--- a/src/Octokit.Webhooks/WebhookEventProcessor.cs
+++ b/src/Octokit.Webhooks/WebhookEventProcessor.cs
@@ -57,6 +57,7 @@ using Octokit.Webhooks.Events.SecretScanningAlertLocation;
 using Octokit.Webhooks.Events.SecurityAdvisory;
 using Octokit.Webhooks.Events.Sponsorship;
 using Octokit.Webhooks.Events.Star;
+using Octokit.Webhooks.Events.SubIssues;
 using Octokit.Webhooks.Events.Team;
 using Octokit.Webhooks.Events.Watch;
 using Octokit.Webhooks.Events.WorkflowJob;
@@ -154,6 +155,7 @@ public abstract class WebhookEventProcessor
             SponsorshipEvent sponsorshipEvent => this.ProcessSponsorshipWebhookAsync(headers, sponsorshipEvent, cancellationToken),
             StarEvent starEvent => this.ProcessStarWebhookAsync(headers, starEvent, cancellationToken),
             StatusEvent statusEvent => this.ProcessStatusWebhookAsync(headers, statusEvent, cancellationToken),
+            SubIssuesEvent subIssuesEvent => this.ProcessSubIssuesWebhookAsync(headers, subIssuesEvent, cancellationToken),
             TeamEvent teamEvent => this.ProcessTeamWebhookAsync(headers, teamEvent, cancellationToken),
             TeamAddEvent teamAddEvent => this.ProcessTeamAddWebhookAsync(headers, teamAddEvent, cancellationToken),
             WatchEvent watchEvent => this.ProcessWatchWebhookAsync(headers, watchEvent, cancellationToken),
@@ -229,6 +231,7 @@ public abstract class WebhookEventProcessor
             WebhookEventType.Sponsorship => JsonSerializer.Deserialize<SponsorshipEvent>(body)!,
             WebhookEventType.Star => JsonSerializer.Deserialize<StarEvent>(body)!,
             WebhookEventType.Status => JsonSerializer.Deserialize<StatusEvent>(body)!,
+            WebhookEventType.SubIssues => JsonSerializer.Deserialize<SubIssuesEvent>(body)!,
             WebhookEventType.Team => JsonSerializer.Deserialize<TeamEvent>(body)!,
             WebhookEventType.TeamAdd => JsonSerializer.Deserialize<TeamAddEvent>(body)!,
             WebhookEventType.Watch => JsonSerializer.Deserialize<WatchEvent>(body)!,
@@ -1352,6 +1355,23 @@ public abstract class WebhookEventProcessor
 
     [PublicAPI]
     protected virtual ValueTask ProcessStatusWebhookAsync(WebhookHeaders headers, StatusEvent statusEvent, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+
+    private ValueTask ProcessSubIssuesWebhookAsync(WebhookHeaders headers, SubIssuesEvent subIssuesEvent, CancellationToken cancellationToken = default) =>
+        subIssuesEvent.Action switch
+        {
+            SubIssuesActionValue.ParentIssueAdded => this.ProcessSubIssuesWebhookAsync(headers, subIssuesEvent, SubIssuesAction.ParentIssueAdded, cancellationToken),
+            SubIssuesActionValue.ParentIssueRemoved => this.ProcessSubIssuesWebhookAsync(headers, subIssuesEvent, SubIssuesAction.ParentIssueRemoved, cancellationToken),
+            SubIssuesActionValue.SubIssueAdded => this.ProcessSubIssuesWebhookAsync(headers, subIssuesEvent, SubIssuesAction.SubIssueAdded, cancellationToken),
+            SubIssuesActionValue.SubIssueRemoved => this.ProcessSubIssuesWebhookAsync(headers, subIssuesEvent, SubIssuesAction.SubIssueRemoved, cancellationToken),
+            _ => ValueTask.CompletedTask,
+        };
+
+    [PublicAPI]
+    protected virtual ValueTask ProcessSubIssuesWebhookAsync(
+        WebhookHeaders headers,
+        SubIssuesEvent subIssuesEvent,
+        SubIssuesAction action,
+        CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
 
     private ValueTask ProcessTeamWebhookAsync(WebhookHeaders headers, TeamEvent teamEvent, CancellationToken cancellationToken = default) =>
         teamEvent.Action switch


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #751

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* `AlertRule.Tags` was incorrectly a `string` instead of `IEnumerable<string>`
* No support for `SubIssues` events

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* Correct types for `AlertRule.Tags`
* Support for `SubIssues` events

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [ ] No

----

