### PR TITLE
Fix NuGet publishing step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,10 +95,10 @@ jobs:
         with:
           name: 'windows-latest'
       - name: 'NuGet login'
-        uses: NuGet/login@269a1094e6b6e88a3856400d7171adf9b7a546f7 # v1.1.0
+        uses: NuGet/login@035d2cc2260e5666c56c76e25982d1a7d3afacb7 # v1.1.0
         id: nuget-login
         with:
-          user: GitHub
+          user: ${{ secrets.NUGET_USER }}
       - name: 'Dotnet NuGet Push'
         run: |
           Get-ChildItem .\ -Filter *.nupkg |


### PR DESCRIPTION
Fast follow from #760

The `v1.1.0` tag for `NuGet/login` changed, because they forgot to include the compiled JavaScript, and the `user` input should be the NuGet username of the user that configured trusted publishing, not the NuGet organization name.
