### PR TITLE
Remove GitHub Packages publishing from build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,28 +57,6 @@ jobs:
           name: ${{matrix.os}}
           path: './artifacts'
 
-  push-github-packages:
-    name: 'Push GitHub Packages'
-    needs: build
-    if: github.ref == 'refs/heads/main' || github.event_name == 'release'
-    environment:
-      name: 'GitHub Packages'
-      url: https://github.com/octokit/webhooks.net/packages
-    permissions:
-      packages: write
-    runs-on: windows-latest
-    steps:
-      - name: 'Download artifact'
-        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
-        with:
-          name: 'windows-latest'
-      - name: 'Dotnet NuGet Add Source'
-        run: dotnet nuget add source https://nuget.pkg.github.com/octokit/index.json --name GitHub --username octokit --password ${{secrets.GITHUB_TOKEN}}
-        shell: pwsh
-      - name: 'Dotnet NuGet Push'
-        run: dotnet nuget push .\*.nupkg --api-key ${{ github.token }} --source GitHub --skip-duplicate
-        shell: pwsh
-
   push-nuget:
     name: 'Push NuGet Packages'
     needs: build


### PR DESCRIPTION
## Summary
- Removes the unused `push-github-packages` job from the build workflow
- This job has had 0 downloads in 4 years according to issue #764
- Simplifies the workflow by removing unnecessary complexity
- Preserves NuGet publishing functionality

## Changes Made
- Removed the entire `push-github-packages` job (lines 60-80) from `.github/workflows/build.yml`
- No other functionality is affected

## Test Plan
- [x] Verified the workflow syntax is correct after removal
- [x] Confirmed NuGet publishing job remains intact
- [ ] Workflow will be tested on next push to main branch

This change reduces maintenance overhead and simplifies the CI/CD pipeline without affecting any actively used functionality.

Fixes #764