### PR TITLE
fix: change StringEnum back to record

### DIFF
--- a/src/Octokit.Webhooks/Converter/StringEnumEnumerableConverter.cs
+++ b/src/Octokit.Webhooks/Converter/StringEnumEnumerableConverter.cs
@@ -33,7 +33,9 @@ public sealed class StringEnumEnumerableConverter<TEnum> : JsonConverter<IEnumer
         {
             if (reader.TokenType != JsonTokenType.StartArray)
             {
-                returnValue.Add(JsonSerializer.Deserialize<StringEnum<TEnum>>(ref reader, Options));
+                var item = JsonSerializer.Deserialize<StringEnum<TEnum>>(ref reader, Options)
+                    ?? throw new JsonException("Unexpected null value in array.");
+                returnValue.Add(item);
             }
 
             _ = reader.Read();

--- a/src/Octokit.Webhooks/Extensions/StringEnum.cs
+++ b/src/Octokit.Webhooks/Extensions/StringEnum.cs
@@ -8,7 +8,7 @@ using System.Runtime.Serialization;
 using JetBrains.Annotations;
 
 [PublicAPI]
-public readonly struct StringEnum<TEnum> : IEquatable<StringEnum<TEnum>>
+public sealed record StringEnum<TEnum> : IEquatable<StringEnum<TEnum>>
     where TEnum : struct, Enum
 {
     private readonly TEnum? parsedValue;
@@ -16,6 +16,7 @@ public readonly struct StringEnum<TEnum> : IEquatable<StringEnum<TEnum>>
 
     public StringEnum(string stringValue)
     {
+        ArgumentNullException.ThrowIfNull(stringValue);
         this.StringValue = stringValue;
         if (TryParseEnum(stringValue, out var enumValue))
         {
@@ -49,23 +50,6 @@ public readonly struct StringEnum<TEnum> : IEquatable<StringEnum<TEnum>>
 
     public static implicit operator StringEnum<TEnum>(TEnum parsedValue) => new(parsedValue);
 
-    public static bool operator ==(StringEnum<TEnum>? left, StringEnum<TEnum>? right)
-    {
-        if (left is null && right is null)
-        {
-            return true;
-        }
-
-        if (left is null || right is null)
-        {
-            return false;
-        }
-
-        return left.Value.Equals(right.Value);
-    }
-
-    public static bool operator !=(StringEnum<TEnum>? left, StringEnum<TEnum>? right) => !(left == right);
-
     public bool TryParse([NotNullWhen(true)] out TEnum? value)
     {
         if (this.isValidEnum && this.parsedValue is not null)
@@ -78,20 +62,25 @@ public readonly struct StringEnum<TEnum> : IEquatable<StringEnum<TEnum>>
         return false;
     }
 
-    public override bool Equals(object? obj) => obj is StringEnum<TEnum> other && this.Equals(other);
-
-    public bool Equals(StringEnum<TEnum> other)
+    public bool Equals(StringEnum<TEnum>? other)
     {
+        if (ReferenceEquals(this, other))
+        {
+            return true;
+        }
+
         var canParseThis = this.TryParse(out var thisValue);
-        var canParseOther = other.TryParse(out var otherValue);
+
+        TEnum? otherValue = null;
+        var canParseOther = other != null && other.TryParse(out otherValue);
 
         return canParseThis switch
         {
             // If both can be parsed to enum values, compare the enum values
-            true when canParseOther => thisValue.Equals(otherValue),
+            true when canParseOther => EqualityComparer<TEnum>.Default.Equals(thisValue!.Value, otherValue!.Value),
 
             // If neither can be parsed, compare string values
-            false when !canParseOther => this.StringValue.Equals(other.StringValue, StringComparison.OrdinalIgnoreCase),
+            false when !canParseOther => string.Equals(this.StringValue, other?.StringValue, StringComparison.OrdinalIgnoreCase),
 
             // If one can parse and one cannot, they're not equal
             _ => false,

--- a/test/Octokit.Webhooks.Test/Converter/StringEnumConverterTests.cs
+++ b/test/Octokit.Webhooks.Test/Converter/StringEnumConverterTests.cs
@@ -23,7 +23,7 @@ public class StringEnumConverterTests
     [InlineData(@"""Organization""", HookType.Organization)]
     public void CanDeserializeKnown(string input, HookType expected)
     {
-        var result = JsonSerializer.Deserialize<StringEnum<HookType>>(input, this.options);
+        var result = JsonSerializer.Deserialize<StringEnum<HookType>>(input, this.options)!;
         result.Value.Should().Be(expected);
     }
 
@@ -34,7 +34,14 @@ public class StringEnumConverterTests
     [InlineData(@"""Unknown""", "Unknown")]
     public void CanDeserializeUnknown(string input, string expected)
     {
-        var result = JsonSerializer.Deserialize<StringEnum<HookType>>(input, this.options);
+        var result = JsonSerializer.Deserialize<StringEnum<HookType>>(input, this.options)!;
         result.StringValue.Should().Be(expected);
+    }
+
+    [Fact]
+    public void DeserializeNullReturnsNull()
+    {
+        var result = JsonSerializer.Deserialize<StringEnum<HookType>>("null", this.options);
+        result.Should().BeNull();
     }
 }

--- a/test/Octokit.Webhooks.Test/Converter/StringEnumEnumerableConverterTests.cs
+++ b/test/Octokit.Webhooks.Test/Converter/StringEnumEnumerableConverterTests.cs
@@ -34,4 +34,11 @@ public class StringEnumEnumerableConverterTests
         var result = JsonSerializer.Deserialize<IEnumerable<StringEnum<HookType>>>(input, this.options);
         result!.Select(r => r.StringValue).Should().BeEquivalentTo(expected.Select(e => e.StringValue));
     }
+
+    [Fact]
+    public void DeserializeThrowsForNullElement()
+    {
+        var act = () => JsonSerializer.Deserialize<IEnumerable<StringEnum<HookType>>>("[null]", this.options);
+        act.Should().Throw<JsonException>();
+    }
 }

--- a/test/Octokit.Webhooks.Test/StringEnumTests.cs
+++ b/test/Octokit.Webhooks.Test/StringEnumTests.cs
@@ -3,6 +3,8 @@ namespace Octokit.Webhooks.Test;
 using System;
 using System.Linq;
 using AwesomeAssertions;
+using Octokit.Webhooks.Extensions;
+using Octokit.Webhooks.Models.PingEvent;
 using Xunit;
 
 public class StringEnumTests
@@ -21,5 +23,70 @@ public class StringEnumTests
                 property.PropertyType.IsEnum.Should().BeFalse();
             }
         }
+    }
+
+    [Fact]
+    public void EqualityOperator_SameEnumValues_ReturnsTrue()
+    {
+        StringEnum<HookType> a = HookType.App;
+        StringEnum<HookType> b = HookType.App;
+
+        (a == b).Should().BeTrue();
+        (a != b).Should().BeFalse();
+    }
+
+    [Fact]
+    public void EqualityOperator_DifferentEnumValues_ReturnsFalse()
+    {
+        StringEnum<HookType> a = HookType.App;
+        StringEnum<HookType> b = HookType.Repository;
+
+        (a == b).Should().BeFalse();
+        (a != b).Should().BeTrue();
+    }
+
+    [Fact]
+    public void EqualityOperator_NullComparisons()
+    {
+        StringEnum<HookType> a = HookType.App;
+        StringEnum<HookType>? b = null;
+
+        (a == b).Should().BeFalse();
+        (a != b).Should().BeTrue();
+        (b == a).Should().BeFalse();
+        (b != a).Should().BeTrue();
+    }
+
+    [Fact]
+    public void EqualityOperator_SameInstance_ReturnsTrue()
+    {
+        StringEnum<HookType> a = HookType.App;
+#pragma warning disable CS1718 // Comparison made to same variable
+        (a == a).Should().BeTrue();
+        (a != a).Should().BeFalse();
+#pragma warning restore CS1718
+    }
+
+    [Fact]
+    public void EqualityOperator_UnknownValues()
+    {
+        StringEnum<HookType> a = "Unknown";
+        StringEnum<HookType> b = "Unknown";
+        StringEnum<HookType> c = "Other";
+
+        (a == b).Should().BeTrue();
+        (a != b).Should().BeFalse();
+        (a == c).Should().BeFalse();
+        (a != c).Should().BeTrue();
+    }
+
+    [Fact]
+    public void EqualityOperator_KnownVsUnknown_ReturnsFalse()
+    {
+        StringEnum<HookType> a = HookType.App;
+        StringEnum<HookType> b = "Unknown";
+
+        (a == b).Should().BeFalse();
+        (a != b).Should().BeTrue();
     }
 }


### PR DESCRIPTION
Resolves #766

----

### Before the change?

* Change `StringEnum<T>` back to a `sealed record` to mitigate the performance regression reported in #766. My guess would be that `readonly struct` copy-by-value to happen when values are passed around, where as before they would be passed by reference.

### After the change?

* Doesn't fully restore the previous performance, but there's a noticable improvement in https://github.com/martincostello/costellobot/pull/2742.
  <img width="700" height="450" alt="image" src="https://github.com/user-attachments/assets/6b968c86-4b82-4792-9fcc-89f26d3c258b" />

### Pull request checklist

- [ ] ~~Tests for the changes have been added (for bug fixes / features)~~
- [ ] ~~Docs have been reviewed and added / updated if needed (for bug fixes / features)~~

### Does this introduce a breaking change?

_Technically_, this is a breaking change from a non-reference type to a reference type (but puts things back as they were before 3.0.0, so you could argue it isn't as 3.1.0 wasn't).

- [x] Yes
- [ ] No

----
