### PR TITLE
Catch exceptions from GetBodyAsync when the client disconnects

### DIFF
--- a/src/Octokit.Webhooks.AspNetCore/GitHubWebhookExtensions.cs
+++ b/src/Octokit.Webhooks.AspNetCore/GitHubWebhookExtensions.cs
@@ -63,7 +63,7 @@ public static partial class GitHubWebhookExtensions
                         .ConfigureAwait(false);
                     context.Response.StatusCode = 200;
                 }
-                catch (OperationCanceledException)
+                catch (OperationCanceledException) when (context.RequestAborted.IsCancellationRequested)
                 {
                     Log.RequestCancelled(logger);
                 }

--- a/src/Octokit.Webhooks.AspNetCore/GitHubWebhookExtensions.cs
+++ b/src/Octokit.Webhooks.AspNetCore/GitHubWebhookExtensions.cs
@@ -40,28 +40,32 @@ public static partial class GitHubWebhookExtensions
                     return;
                 }
 
-                // Get body
-                var body = await GetBodyAsync(context).ConfigureAwait(false);
-
-                if (secret is null && options is not null)
-                {
-                    secret = options.CurrentValue.Secret;
-                }
-
-                // Verify signature
-                if (!await VerifySignatureAsync(context, secret, body).ConfigureAwait(false))
-                {
-                    Log.SignatureValidationFailed(logger);
-                    return;
-                }
-
-                // Process body
                 try
                 {
+                    // Get body
+                    var body = await GetBodyAsync(context, context.RequestAborted).ConfigureAwait(false);
+
+                    if (secret is null && options is not null)
+                    {
+                        secret = options.CurrentValue.Secret;
+                    }
+
+                    // Verify signature
+                    if (!await VerifySignatureAsync(context, secret, body).ConfigureAwait(false))
+                    {
+                        Log.SignatureValidationFailed(logger);
+                        return;
+                    }
+
+                    // Process body
                     var service = context.RequestServices.GetRequiredService<WebhookEventProcessor>();
                     await service.ProcessWebhookAsync(context.Request.Headers, body, context.RequestAborted)
                         .ConfigureAwait(false);
                     context.Response.StatusCode = 200;
+                }
+                catch (OperationCanceledException)
+                {
+                    Log.RequestCancelled(logger);
                 }
                 catch (Exception ex)
                 {
@@ -88,10 +92,10 @@ public static partial class GitHubWebhookExtensions
         return true;
     }
 
-    private static async Task<string> GetBodyAsync(HttpContext context)
+    private static async Task<string> GetBodyAsync(HttpContext context, CancellationToken cancellationToken)
     {
         using var reader = new StreamReader(context.Request.Body);
-        return await reader.ReadToEndAsync().ConfigureAwait(false);
+        return await reader.ReadToEndAsync(cancellationToken).ConfigureAwait(false);
     }
 
     private static async Task<bool> VerifySignatureAsync(HttpContext context, string? secret, string body)
@@ -159,5 +163,11 @@ public static partial class GitHubWebhookExtensions
             Level = LogLevel.Error,
             Message = "Exception processing GitHub event.")]
         public static partial void ProcessingFailed(ILogger logger, Exception exception);
+
+        [LoggerMessage(
+            EventId = 4,
+            Level = LogLevel.Warning,
+            Message = "GitHub event request was cancelled.")]
+        public static partial void RequestCancelled(ILogger logger);
     }
 }

--- a/src/Octokit.Webhooks.AzureFunctions/GitHubWebhooksHttpFunction.cs
+++ b/src/Octokit.Webhooks.AzureFunctions/GitHubWebhooksHttpFunction.cs
@@ -58,7 +58,7 @@ public sealed partial class GitHubWebhooksHttpFunction(IOptions<GitHubWebhooksOp
                 .ConfigureAwait(false);
             return req.CreateResponse(HttpStatusCode.OK);
         }
-        catch (OperationCanceledException)
+        catch (OperationCanceledException) when (ctx.CancellationToken.IsCancellationRequested)
         {
             Log.RequestCancelled(logger);
             return null;

--- a/src/Octokit.Webhooks.AzureFunctions/GitHubWebhooksHttpFunction.cs
+++ b/src/Octokit.Webhooks.AzureFunctions/GitHubWebhooksHttpFunction.cs
@@ -8,6 +8,7 @@ using System.Net;
 using System.Net.Mime;
 using System.Security.Cryptography;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
@@ -35,19 +36,19 @@ public sealed partial class GitHubWebhooksHttpFunction(IOptions<GitHubWebhooksOp
             return req.CreateResponse(HttpStatusCode.BadRequest);
         }
 
-        // Get body
-        var body = await GetBodyAsync(req).ConfigureAwait(false);
-
-        // Verify signature
-        if (!VerifySignature(req, options.Value.Secret, body))
-        {
-            Log.SignatureValidationFailed(logger);
-            return req.CreateResponse(HttpStatusCode.BadRequest);
-        }
-
-        // Process body
+        // Get body and process
         try
         {
+            var body = await GetBodyAsync(req, ctx.CancellationToken).ConfigureAwait(false);
+
+            // Verify signature
+            if (!VerifySignature(req, options.Value.Secret, body))
+            {
+                Log.SignatureValidationFailed(logger);
+                return req.CreateResponse(HttpStatusCode.BadRequest);
+            }
+
+            // Process body
             var service = ctx.InstanceServices.GetRequiredService<WebhookEventProcessor>();
             var headers = req.Headers.ToDictionary(
                 kv => kv.Key,
@@ -56,6 +57,11 @@ public sealed partial class GitHubWebhooksHttpFunction(IOptions<GitHubWebhooksOp
             await service.ProcessWebhookAsync(headers, body, ctx.CancellationToken)
                 .ConfigureAwait(false);
             return req.CreateResponse(HttpStatusCode.OK);
+        }
+        catch (OperationCanceledException)
+        {
+            Log.RequestCancelled(logger);
+            return null;
         }
         catch (Exception ex)
         {
@@ -76,10 +82,10 @@ public sealed partial class GitHubWebhooksHttpFunction(IOptions<GitHubWebhooksOp
         return contentType.MediaType == expectedContentType;
     }
 
-    private static async Task<string> GetBodyAsync(HttpRequestData req)
+    private static async Task<string> GetBodyAsync(HttpRequestData req, CancellationToken cancellationToken)
     {
         using var reader = new StreamReader(req.Body);
-        return await reader.ReadToEndAsync().ConfigureAwait(false);
+        return await reader.ReadToEndAsync(cancellationToken).ConfigureAwait(false);
     }
 
     private static bool VerifySignature(HttpRequestData req, string? secret, string body)
@@ -137,5 +143,11 @@ public sealed partial class GitHubWebhooksHttpFunction(IOptions<GitHubWebhooksOp
             Level = LogLevel.Error,
             Message = "Exception processing GitHub event.")]
         public static partial void ProcessingFailed(ILogger logger, Exception exception);
+
+        [LoggerMessage(
+            EventId = 4,
+            Level = LogLevel.Warning,
+            Message = "GitHub event request was cancelled.")]
+        public static partial void RequestCancelled(ILogger logger);
     }
 }


### PR DESCRIPTION
Resolves #619

----

### Before the change?

* `GetBodyAsync` sits outside the try/catch in both the ASP.NET Core and Azure Functions integrations. If GitHub closes the connection mid-read (their 10-second webhook timeout), `ReadToEndAsync` throws a `BadHttpRequestException` or `OperationCanceledException` that nobody catches. The request blows up with an unhandled exception.
* `ReadToEndAsync` is called without a `CancellationToken`, so there's no cooperative cancellation when the client disconnects.

### After the change?

* `GetBodyAsync` (and signature verification) are now inside the existing try/catch block, so connection-closed exceptions are handled instead of propagating.
* `GetBodyAsync` accepts a `CancellationToken` and passes it to `ReadToEndAsync`. The ASP.NET Core path uses `context.RequestAborted`; the Azure Functions path uses `ctx.CancellationToken`.
* `OperationCanceledException` gets its own catch block. It logs at Warning level (not Error) since GitHub closing the connection after 10 seconds is normal, and it skips writing to the response since the connection is already dead.
* Both `GitHubWebhookExtensions` and `GitHubWebhooksHttpFunction` get the same treatment.

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----