### PR TITLE
Return 400 for empty or missing X-GitHub-Event header

### DIFF
--- a/src/Octokit.Webhooks.AspNetCore/GitHubWebhookExtensions.cs
+++ b/src/Octokit.Webhooks.AspNetCore/GitHubWebhookExtensions.cs
@@ -40,6 +40,13 @@ public static partial class GitHubWebhookExtensions
                     return;
                 }
 
+                // Verify event type
+                if (!VerifyEventType(context))
+                {
+                    Log.MissingEventType(logger);
+                    return;
+                }
+
                 try
                 {
                     // Get body
@@ -96,6 +103,19 @@ public static partial class GitHubWebhookExtensions
     {
         using var reader = new StreamReader(context.Request.Body);
         return await reader.ReadToEndAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    private static bool VerifyEventType(HttpContext context)
+    {
+        if (!context.Request.Headers.TryGetValue("X-GitHub-Event", out var eventType)
+            || eventType.Count != 1
+            || string.IsNullOrWhiteSpace(eventType.ToString()))
+        {
+            context.Response.StatusCode = 400;
+            return false;
+        }
+
+        return true;
     }
 
     private static async Task<bool> VerifySignatureAsync(HttpContext context, string? secret, string body)
@@ -169,5 +189,11 @@ public static partial class GitHubWebhookExtensions
             Level = LogLevel.Warning,
             Message = "GitHub event request was cancelled.")]
         public static partial void RequestCancelled(ILogger logger);
+
+        [LoggerMessage(
+            EventId = 5,
+            Level = LogLevel.Error,
+            Message = "GitHub event has a missing or invalid event type header.")]
+        public static partial void MissingEventType(ILogger logger);
     }
 }

--- a/src/Octokit.Webhooks.AzureFunctions/GitHubWebhooksHttpFunction.cs
+++ b/src/Octokit.Webhooks.AzureFunctions/GitHubWebhooksHttpFunction.cs
@@ -36,7 +36,13 @@ public sealed partial class GitHubWebhooksHttpFunction(IOptions<GitHubWebhooksOp
             return req.CreateResponse(HttpStatusCode.BadRequest);
         }
 
-        // Get body and process
+        // Verify event type
+        if (!VerifyEventType(req))
+        {
+            Log.MissingEventType(logger);
+            return req.CreateResponse(HttpStatusCode.BadRequest);
+        }
+
         try
         {
             var body = await GetBodyAsync(req, ctx.CancellationToken).ConfigureAwait(false);
@@ -86,6 +92,17 @@ public sealed partial class GitHubWebhooksHttpFunction(IOptions<GitHubWebhooksOp
     {
         using var reader = new StreamReader(req.Body);
         return await reader.ReadToEndAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    private static bool VerifyEventType(HttpRequestData req)
+    {
+        if (!req.Headers.TryGetValues("X-GitHub-Event", out var eventValues))
+        {
+            return false;
+        }
+
+        var values = eventValues.ToList();
+        return values.Count == 1 && !string.IsNullOrWhiteSpace(values[0]);
     }
 
     private static bool VerifySignature(HttpRequestData req, string? secret, string body)
@@ -149,5 +166,11 @@ public sealed partial class GitHubWebhooksHttpFunction(IOptions<GitHubWebhooksOp
             Level = LogLevel.Warning,
             Message = "GitHub event request was cancelled.")]
         public static partial void RequestCancelled(ILogger logger);
+
+        [LoggerMessage(
+            EventId = 5,
+            Level = LogLevel.Error,
+            Message = "GitHub event has a missing or invalid event type header.")]
+        public static partial void MissingEventType(ILogger logger);
     }
 }

--- a/src/Octokit.Webhooks/WebhookEventProcessor.cs
+++ b/src/Octokit.Webhooks/WebhookEventProcessor.cs
@@ -72,6 +72,12 @@ public abstract class WebhookEventProcessor
         ArgumentNullException.ThrowIfNull(body);
 
         var webhookHeaders = WebhookHeaders.Parse(headers);
+
+        if (string.IsNullOrWhiteSpace(webhookHeaders.Event))
+        {
+            throw new ArgumentException("X-GitHub-Event header is missing or empty.", nameof(headers));
+        }
+
         var webhookEvent = this.DeserializeWebhookEvent(webhookHeaders, body);
 
         return this.ProcessWebhookAsync(webhookHeaders, webhookEvent, cancellationToken);
@@ -238,7 +244,7 @@ public abstract class WebhookEventProcessor
             WebhookEventType.WorkflowDispatch => JsonSerializer.Deserialize<WorkflowDispatchEvent>(body)!,
             WebhookEventType.WorkflowJob => JsonSerializer.Deserialize<WorkflowJobEvent>(body)!,
             WebhookEventType.WorkflowRun => JsonSerializer.Deserialize<WorkflowRunEvent>(body)!,
-            _ => throw new JsonException("Unable to deserialize event"),
+            _ => throw new JsonException($"Unable to deserialize event: '{headers.Event}'"),
         };
 
     private ValueTask ProcessBranchProtectionRuleWebhookAsync(WebhookHeaders headers, BranchProtectionRuleEvent branchProtectionRuleEvent, CancellationToken cancellationToken = default) =>

--- a/test/Octokit.Webhooks.Test/WebhookEventProcessorTests.cs
+++ b/test/Octokit.Webhooks.Test/WebhookEventProcessorTests.cs
@@ -1,7 +1,11 @@
 namespace Octokit.Webhooks.Test;
 
 using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Threading.Tasks;
 using AwesomeAssertions;
+using Microsoft.Extensions.Primitives;
 using Xunit;
 
 public class WebhookEventProcessorTests
@@ -20,5 +24,61 @@ public class WebhookEventProcessorTests
         };
         var result = this.webhookEventProcessor.DeserializeWebhookEvent(headers, payload);
         result.Should().BeAssignableTo(expectedType);
+    }
+
+    [Fact]
+    public async Task ProcessWebhookAsync_EmptyEventHeader_ThrowsArgumentException()
+    {
+        var headers = new Dictionary<string, StringValues>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["X-GitHub-Event"] = string.Empty,
+        };
+
+        var act = () => this.webhookEventProcessor.ProcessWebhookAsync(headers, "{}").AsTask();
+
+        await act.Should().ThrowAsync<ArgumentException>()
+            .WithMessage("X-GitHub-Event header is missing or empty.*")
+            .ConfigureAwait(true);
+    }
+
+    [Fact]
+    public async Task ProcessWebhookAsync_WhitespaceEventHeader_ThrowsArgumentException()
+    {
+        var headers = new Dictionary<string, StringValues>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["X-GitHub-Event"] = "   ",
+        };
+
+        var act = () => this.webhookEventProcessor.ProcessWebhookAsync(headers, "{}").AsTask();
+
+        await act.Should().ThrowAsync<ArgumentException>()
+            .WithMessage("X-GitHub-Event header is missing or empty.*")
+            .ConfigureAwait(true);
+    }
+
+    [Fact]
+    public async Task ProcessWebhookAsync_MissingEventHeader_ThrowsArgumentException()
+    {
+        var headers = new Dictionary<string, StringValues>(StringComparer.OrdinalIgnoreCase);
+
+        var act = () => this.webhookEventProcessor.ProcessWebhookAsync(headers, "{}").AsTask();
+
+        await act.Should().ThrowAsync<ArgumentException>()
+            .WithMessage("X-GitHub-Event header is missing or empty.*")
+            .ConfigureAwait(true);
+    }
+
+    [Fact]
+    public void DeserializeWebhookEvent_UnknownEventType_ThrowsJsonExceptionWithEventName()
+    {
+        var headers = new WebhookHeaders
+        {
+            Event = "unknown_event_type",
+        };
+
+        var act = () => this.webhookEventProcessor.DeserializeWebhookEvent(headers, "{}");
+
+        act.Should().Throw<JsonException>()
+            .WithMessage("*'unknown_event_type'*");
     }
 }


### PR DESCRIPTION
Resolves #832

----

### Before the change?

* When GitHub sends a webhook with an empty `X-GitHub-Event` header (which does happen in the wild, see #832), `DeserializeWebhookEvent` can't match any event type and throws `JsonException("Unable to deserialize event")`. The entry points catch this and return 500. The error message doesn't say what went wrong.

### After the change?

* Both the AspNetCore and Azure Functions entry points now check for a missing or empty `X-GitHub-Event` header before calling `ProcessWebhookAsync`. They return 400, same as they already do for bad content types and signature failures.
* `ProcessWebhookAsync` itself throws `ArgumentException` with a clear message if the event header is empty. This covers anyone calling the processor directly without the HTTP layer.
* The `DeserializeWebhookEvent` fallback error now includes the actual event name, so unknown-but-non-empty events are easier to debug.

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

----