### PR TITLE
Add DisplayTitle and Path to WorkflowRun

### DIFF
--- a/src/Octokit.Webhooks/Models/WorkflowRun.cs
+++ b/src/Octokit.Webhooks/Models/WorkflowRun.cs
@@ -26,6 +26,9 @@ public sealed record WorkflowRun
     [JsonConverter(typeof(DateTimeOffsetConverter))]
     public DateTimeOffset CreatedAt { get; init; }
 
+    [JsonPropertyName("display_title")]
+    public string DisplayTitle { get; init; } = null!;
+
     [JsonPropertyName("event")]
     public string Event { get; init; } = null!;
 
@@ -58,6 +61,9 @@ public sealed record WorkflowRun
 
     [JsonPropertyName("name")]
     public string Name { get; init; } = null!;
+
+    [JsonPropertyName("path")]
+    public string Path { get; init; } = null!;
 
     [JsonPropertyName("pull_requests")]
     public IEnumerable<WorkflowPullRequest> PullRequests { get; init; } = null!;


### PR DESCRIPTION
Resolves #803

----

### Before the change?

* `WorkflowRun` was missing `display_title` and `path`, both of which GitHub includes in `workflow_run` webhook payloads. The fields got silently dropped during deserialization.

### After the change?

* Two new properties on `WorkflowRun`: `DisplayTitle` (`display_title`) and `Path` (`path`). Both are required strings, same as every other URL/name property on the model.
* No new tests needed. The existing test JSON fixtures already contain both fields, so the `CanDeserialize` theory covers them.

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

----