### PR TITLE
Make signature verification a public API

### DIFF
--- a/src/Octokit.Webhooks.AspNetCore/GitHubWebhookExtensions.cs
+++ b/src/Octokit.Webhooks.AspNetCore/GitHubWebhookExtensions.cs
@@ -1,11 +1,8 @@
 namespace Octokit.Webhooks.AspNetCore;
 
 using System;
-using System.Globalization;
 using System.IO;
 using System.Net.Mime;
-using System.Security.Cryptography;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
@@ -122,42 +119,27 @@ public static partial class GitHubWebhookExtensions
     {
         _ = context.Request.Headers.TryGetValue("X-Hub-Signature-256", out var signatureSha256);
 
-        var isSigned = signatureSha256.Count > 0;
-        var isSignatureExpected = !string.IsNullOrEmpty(secret);
+        var result = WebhookSignatureValidator.Verify(signatureSha256.ToString(), secret, body);
 
-        if (!isSigned && !isSignatureExpected)
+        switch (result)
         {
-            // Nothing to do.
-            return true;
+            case WebhookSignatureValidationResult.Valid:
+                return true;
+            case WebhookSignatureValidationResult.MissingSignature:
+                context.Response.StatusCode = 400;
+                return false;
+            case WebhookSignatureValidationResult.MissingSecret:
+                context.Response.StatusCode = 400;
+                await context.Response.WriteAsync("Payload includes a secret, so the webhook receiver must configure a secret.")
+                    .ConfigureAwait(false);
+                return false;
+            case WebhookSignatureValidationResult.SignatureMismatch:
+                context.Response.StatusCode = 400;
+                return false;
+            default:
+                context.Response.StatusCode = 400;
+                return false;
         }
-
-        if (!isSigned && isSignatureExpected)
-        {
-            context.Response.StatusCode = 400;
-            return false;
-        }
-
-        if (isSigned && !isSignatureExpected)
-        {
-            context.Response.StatusCode = 400;
-            await context.Response.WriteAsync("Payload includes a secret, so the webhook receiver must configure a secret.")
-                .ConfigureAwait(false);
-            return false;
-        }
-
-        var keyBytes = Encoding.UTF8.GetBytes(secret!);
-        var bodyBytes = Encoding.UTF8.GetBytes(body);
-
-        var hash = HMACSHA256.HashData(keyBytes, bodyBytes);
-        var hashHex = Convert.ToHexString(hash);
-        var expectedHeader = $"sha256={hashHex.ToLower(CultureInfo.InvariantCulture)}";
-        if (signatureSha256.ToString() != expectedHeader)
-        {
-            context.Response.StatusCode = 400;
-            return false;
-        }
-
-        return true;
     }
 
     /// <summary>

--- a/src/Octokit.Webhooks.AspNetCore/GitHubWebhookExtensions.cs
+++ b/src/Octokit.Webhooks.AspNetCore/GitHubWebhookExtensions.cs
@@ -127,14 +127,18 @@ public static partial class GitHubWebhookExtensions
                 return true;
             case WebhookSignatureValidationResult.MissingSignature:
                 context.Response.StatusCode = 400;
+                await context.Response.WriteAsync("Expected an X-Hub-Signature-256 header but none was provided. Configure a webhook secret on the sender, or remove the secret from the receiver.")
+                    .ConfigureAwait(false);
                 return false;
             case WebhookSignatureValidationResult.MissingSecret:
                 context.Response.StatusCode = 400;
-                await context.Response.WriteAsync("Request includes a signature header, so the webhook receiver must configure a secret.")
+                await context.Response.WriteAsync("Request includes an X-Hub-Signature-256 header but no secret is configured on the receiver.")
                     .ConfigureAwait(false);
                 return false;
             case WebhookSignatureValidationResult.SignatureMismatch:
                 context.Response.StatusCode = 400;
+                await context.Response.WriteAsync("X-Hub-Signature-256 does not match the expected signature. Verify that the webhook secret matches on both sender and receiver.")
+                    .ConfigureAwait(false);
                 return false;
             default:
                 context.Response.StatusCode = 400;

--- a/src/Octokit.Webhooks.AspNetCore/GitHubWebhookExtensions.cs
+++ b/src/Octokit.Webhooks.AspNetCore/GitHubWebhookExtensions.cs
@@ -130,7 +130,7 @@ public static partial class GitHubWebhookExtensions
                 return false;
             case WebhookSignatureValidationResult.MissingSecret:
                 context.Response.StatusCode = 400;
-                await context.Response.WriteAsync("Payload includes a secret, so the webhook receiver must configure a secret.")
+                await context.Response.WriteAsync("Request includes a signature header, so the webhook receiver must configure a secret.")
                     .ConfigureAwait(false);
                 return false;
             case WebhookSignatureValidationResult.SignatureMismatch:

--- a/src/Octokit.Webhooks.AzureFunctions/GitHubWebhooksHttpFunction.cs
+++ b/src/Octokit.Webhooks.AzureFunctions/GitHubWebhooksHttpFunction.cs
@@ -1,13 +1,10 @@
 namespace Octokit.Webhooks.AzureFunctions;
 
 using System;
-using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Mime;
-using System.Security.Cryptography;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.Functions.Worker;
@@ -110,31 +107,8 @@ public sealed partial class GitHubWebhooksHttpFunction(IOptions<GitHubWebhooksOp
         var isSigned = req.Headers.TryGetValues("X-Hub-Signature-256", out var signatureHeader);
         var signature = signatureHeader?.FirstOrDefault();
 
-        var isSignatureExpected = !string.IsNullOrEmpty(secret);
-
-        if (!isSigned && !isSignatureExpected)
-        {
-            // Nothing to do.
-            return true;
-        }
-
-        if (!isSigned && isSignatureExpected)
-        {
-            return false;
-        }
-
-        if (isSigned && !isSignatureExpected)
-        {
-            return false;
-        }
-
-        var keyBytes = Encoding.UTF8.GetBytes(secret!);
-        var bodyBytes = Encoding.UTF8.GetBytes(body);
-
-        var hash = HMACSHA256.HashData(keyBytes, bodyBytes);
-        var hashHex = Convert.ToHexString(hash);
-        var expectedHeader = $"sha256={hashHex.ToLower(CultureInfo.InvariantCulture)}";
-        return signature == expectedHeader;
+        var result = WebhookSignatureValidator.Verify(signature, secret, body);
+        return result == WebhookSignatureValidationResult.Valid;
     }
 
     /// <summary>

--- a/src/Octokit.Webhooks.AzureFunctions/GitHubWebhooksHttpFunction.cs
+++ b/src/Octokit.Webhooks.AzureFunctions/GitHubWebhooksHttpFunction.cs
@@ -45,10 +45,23 @@ public sealed partial class GitHubWebhooksHttpFunction(IOptions<GitHubWebhooksOp
             var body = await GetBodyAsync(req, ctx.CancellationToken).ConfigureAwait(false);
 
             // Verify signature
-            if (!VerifySignature(req, options.Value.Secret, body))
+            var signatureResult = VerifySignature(req, options.Value.Secret, body);
+            if (signatureResult != WebhookSignatureValidationResult.Valid)
             {
                 Log.SignatureValidationFailed(logger);
-                return req.CreateResponse(HttpStatusCode.BadRequest);
+                var response = req.CreateResponse(HttpStatusCode.BadRequest);
+                var message = signatureResult switch
+                {
+                    WebhookSignatureValidationResult.MissingSignature =>
+                        "Expected an X-Hub-Signature-256 header but none was provided. Configure a webhook secret on the sender, or remove the secret from the receiver.",
+                    WebhookSignatureValidationResult.MissingSecret =>
+                        "Request includes an X-Hub-Signature-256 header but no secret is configured on the receiver.",
+                    WebhookSignatureValidationResult.SignatureMismatch =>
+                        "X-Hub-Signature-256 does not match the expected signature. Verify that the webhook secret matches on both sender and receiver.",
+                    _ => "Signature validation failed.",
+                };
+                await response.WriteStringAsync(message).ConfigureAwait(false);
+                return response;
             }
 
             // Process body
@@ -102,13 +115,12 @@ public sealed partial class GitHubWebhooksHttpFunction(IOptions<GitHubWebhooksOp
         return values.Count == 1 && !string.IsNullOrWhiteSpace(values[0]);
     }
 
-    private static bool VerifySignature(HttpRequestData req, string? secret, string body)
+    private static WebhookSignatureValidationResult VerifySignature(HttpRequestData req, string? secret, string body)
     {
         _ = req.Headers.TryGetValues("X-Hub-Signature-256", out var signatureHeader);
         var signature = signatureHeader?.FirstOrDefault();
 
-        var result = WebhookSignatureValidator.Verify(signature, secret, body);
-        return result == WebhookSignatureValidationResult.Valid;
+        return WebhookSignatureValidator.Verify(signature, secret, body);
     }
 
     /// <summary>

--- a/src/Octokit.Webhooks.AzureFunctions/GitHubWebhooksHttpFunction.cs
+++ b/src/Octokit.Webhooks.AzureFunctions/GitHubWebhooksHttpFunction.cs
@@ -104,7 +104,7 @@ public sealed partial class GitHubWebhooksHttpFunction(IOptions<GitHubWebhooksOp
 
     private static bool VerifySignature(HttpRequestData req, string? secret, string body)
     {
-        var isSigned = req.Headers.TryGetValues("X-Hub-Signature-256", out var signatureHeader);
+        _ = req.Headers.TryGetValues("X-Hub-Signature-256", out var signatureHeader);
         var signature = signatureHeader?.FirstOrDefault();
 
         var result = WebhookSignatureValidator.Verify(signature, secret, body);

--- a/src/Octokit.Webhooks/WebhookHeaders.cs
+++ b/src/Octokit.Webhooks/WebhookHeaders.cs
@@ -16,6 +16,8 @@ public sealed class WebhookHeaders
 
     public string? HookInstallationTargetType { get; init; }
 
+    public string? Signature256 { get; init; }
+
     public static WebhookHeaders Parse(IDictionary<string, StringValues> headers)
     {
         ArgumentNullException.ThrowIfNull(headers);
@@ -26,6 +28,7 @@ public sealed class WebhookHeaders
         headers.TryGetValue("X-GitHub-Hook-ID", out var hookId);
         headers.TryGetValue("X-GitHub-Hook-Installation-Target-ID", out var hookInstallationTargetId);
         headers.TryGetValue("X-GitHub-Hook-Installation-Target-Type", out var hookInstallationTargetType);
+        headers.TryGetValue("X-Hub-Signature-256", out var signature256);
 
         return new WebhookHeaders
         {
@@ -35,6 +38,7 @@ public sealed class WebhookHeaders
             HookId = hookId.ToString(),
             HookInstallationTargetId = hookInstallationTargetId.ToString(),
             HookInstallationTargetType = hookInstallationTargetType.ToString(),
+            Signature256 = signature256.ToString(),
         };
     }
 }

--- a/src/Octokit.Webhooks/WebhookSignatureValidationResult.cs
+++ b/src/Octokit.Webhooks/WebhookSignatureValidationResult.cs
@@ -1,0 +1,27 @@
+namespace Octokit.Webhooks;
+
+/// <summary>
+/// The result of validating a GitHub webhook signature.
+/// </summary>
+public enum WebhookSignatureValidationResult
+{
+    /// <summary>
+    /// The signature is valid, or no signature was expected or provided.
+    /// </summary>
+    Valid,
+
+    /// <summary>
+    /// The payload was not signed, but a secret is configured and a signature was expected.
+    /// </summary>
+    MissingSignature,
+
+    /// <summary>
+    /// The payload was signed, but no secret is configured to verify against.
+    /// </summary>
+    MissingSecret,
+
+    /// <summary>
+    /// The payload was signed and a secret is configured, but the signature does not match.
+    /// </summary>
+    SignatureMismatch,
+}

--- a/src/Octokit.Webhooks/WebhookSignatureValidator.cs
+++ b/src/Octokit.Webhooks/WebhookSignatureValidator.cs
@@ -1,7 +1,6 @@
 namespace Octokit.Webhooks;
 
 using System;
-using System.Globalization;
 using System.Security.Cryptography;
 using System.Text;
 
@@ -10,6 +9,8 @@ using System.Text;
 /// </summary>
 public static class WebhookSignatureValidator
 {
+    private const string Prefix = "sha256=";
+
     /// <summary>
     /// Verifies the signature of a GitHub webhook payload.
     /// </summary>
@@ -39,17 +40,33 @@ public static class WebhookSignatureValidator
             return WebhookSignatureValidationResult.MissingSecret;
         }
 
+        if (!signatureHeader!.StartsWith(Prefix, StringComparison.OrdinalIgnoreCase))
+        {
+            return WebhookSignatureValidationResult.SignatureMismatch;
+        }
+
+        var signatureHex = signatureHeader![Prefix.Length..];
+
+        byte[] signatureBytes;
+        try
+        {
+            signatureBytes = Convert.FromHexString(signatureHex);
+        }
+        catch (FormatException)
+        {
+            return WebhookSignatureValidationResult.SignatureMismatch;
+        }
+
+        if (signatureBytes.Length != 32)
+        {
+            return WebhookSignatureValidationResult.SignatureMismatch;
+        }
+
         var keyBytes = Encoding.UTF8.GetBytes(secret!);
         var bodyBytes = Encoding.UTF8.GetBytes(body);
+        var expectedHash = HMACSHA256.HashData(keyBytes, bodyBytes);
 
-        var hash = HMACSHA256.HashData(keyBytes, bodyBytes);
-        var hashHex = Convert.ToHexString(hash);
-        var expectedHeader = $"sha256={hashHex.ToLower(CultureInfo.InvariantCulture)}";
-
-        var expectedBytes = Encoding.UTF8.GetBytes(expectedHeader);
-        var actualBytes = Encoding.UTF8.GetBytes(signatureHeader!);
-
-        if (!CryptographicOperations.FixedTimeEquals(expectedBytes, actualBytes))
+        if (!CryptographicOperations.FixedTimeEquals(expectedHash, signatureBytes))
         {
             return WebhookSignatureValidationResult.SignatureMismatch;
         }

--- a/src/Octokit.Webhooks/WebhookSignatureValidator.cs
+++ b/src/Octokit.Webhooks/WebhookSignatureValidator.cs
@@ -1,0 +1,59 @@
+namespace Octokit.Webhooks;
+
+using System;
+using System.Globalization;
+using System.Security.Cryptography;
+using System.Text;
+
+/// <summary>
+/// Provides methods to verify GitHub webhook payload signatures.
+/// </summary>
+public static class WebhookSignatureValidator
+{
+    /// <summary>
+    /// Verifies the signature of a GitHub webhook payload.
+    /// </summary>
+    /// <param name="signatureHeader">The value of the <c>X-Hub-Signature-256</c> header, or <see langword="null"/> if not present.</param>
+    /// <param name="secret">The configured webhook secret, or <see langword="null"/> if not configured.</param>
+    /// <param name="body">The raw request body.</param>
+    /// <returns>A <see cref="WebhookSignatureValidationResult"/> indicating the outcome of the validation.</returns>
+    public static WebhookSignatureValidationResult Verify(string? signatureHeader, string? secret, string body)
+    {
+        ArgumentNullException.ThrowIfNull(body);
+
+        var isSigned = !string.IsNullOrEmpty(signatureHeader);
+        var isSignatureExpected = !string.IsNullOrEmpty(secret);
+
+        if (!isSigned && !isSignatureExpected)
+        {
+            return WebhookSignatureValidationResult.Valid;
+        }
+
+        if (!isSigned && isSignatureExpected)
+        {
+            return WebhookSignatureValidationResult.MissingSignature;
+        }
+
+        if (isSigned && !isSignatureExpected)
+        {
+            return WebhookSignatureValidationResult.MissingSecret;
+        }
+
+        var keyBytes = Encoding.UTF8.GetBytes(secret!);
+        var bodyBytes = Encoding.UTF8.GetBytes(body);
+
+        var hash = HMACSHA256.HashData(keyBytes, bodyBytes);
+        var hashHex = Convert.ToHexString(hash);
+        var expectedHeader = $"sha256={hashHex.ToLower(CultureInfo.InvariantCulture)}";
+
+        var expectedBytes = Encoding.UTF8.GetBytes(expectedHeader);
+        var actualBytes = Encoding.UTF8.GetBytes(signatureHeader!);
+
+        if (!CryptographicOperations.FixedTimeEquals(expectedBytes, actualBytes))
+        {
+            return WebhookSignatureValidationResult.SignatureMismatch;
+        }
+
+        return WebhookSignatureValidationResult.Valid;
+    }
+}

--- a/src/Octokit.Webhooks/WebhookSignatureValidator.cs
+++ b/src/Octokit.Webhooks/WebhookSignatureValidator.cs
@@ -13,8 +13,8 @@ public static class WebhookSignatureValidator
     /// <summary>
     /// Verifies the signature of a GitHub webhook payload.
     /// </summary>
-    /// <param name="signatureHeader">The value of the <c>X-Hub-Signature-256</c> header, or <see langword="null"/> if not present.</param>
-    /// <param name="secret">The configured webhook secret, or <see langword="null"/> if not configured.</param>
+    /// <param name="signatureHeader">The value of the <c>X-Hub-Signature-256</c> header, or <see langword="null"/> or an empty string if not present.</param>
+    /// <param name="secret">The configured webhook secret, or <see langword="null"/> or an empty string if not configured.</param>
     /// <param name="body">The raw request body.</param>
     /// <returns>A <see cref="WebhookSignatureValidationResult"/> indicating the outcome of the validation.</returns>
     public static WebhookSignatureValidationResult Verify(string? signatureHeader, string? secret, string body)

--- a/test/Octokit.Webhooks.Test/WebhookSignatureValidatorTests.cs
+++ b/test/Octokit.Webhooks.Test/WebhookSignatureValidatorTests.cs
@@ -1,0 +1,108 @@
+namespace Octokit.Webhooks.Test;
+
+using System;
+using System.Globalization;
+using System.Security.Cryptography;
+using System.Text;
+using AwesomeAssertions;
+using Xunit;
+
+public class WebhookSignatureValidatorTests
+{
+    [Fact]
+    public void NoSignatureAndNoSecret_ReturnsValid()
+    {
+        var result = WebhookSignatureValidator.Verify(null, null, "{}");
+
+        result.Should().Be(WebhookSignatureValidationResult.Valid);
+    }
+
+    [Fact]
+    public void EmptySignatureAndEmptySecret_ReturnsValid()
+    {
+        var result = WebhookSignatureValidator.Verify(string.Empty, string.Empty, "{}");
+
+        result.Should().Be(WebhookSignatureValidationResult.Valid);
+    }
+
+    [Fact]
+    public void NoSignatureButSecretExpected_ReturnsMissingSignature()
+    {
+        var result = WebhookSignatureValidator.Verify(null, "my-secret", "{}");
+
+        result.Should().Be(WebhookSignatureValidationResult.MissingSignature);
+    }
+
+    [Fact]
+    public void EmptySignatureButSecretExpected_ReturnsMissingSignature()
+    {
+        var result = WebhookSignatureValidator.Verify(string.Empty, "my-secret", "{}");
+
+        result.Should().Be(WebhookSignatureValidationResult.MissingSignature);
+    }
+
+    [Fact]
+    public void SignedButNoSecretConfigured_ReturnsMissingSecret()
+    {
+        var signature = ComputeSignature("my-secret", "{}");
+
+        var result = WebhookSignatureValidator.Verify(signature, null, "{}");
+
+        result.Should().Be(WebhookSignatureValidationResult.MissingSecret);
+    }
+
+    [Fact]
+    public void SignedButEmptySecretConfigured_ReturnsMissingSecret()
+    {
+        var signature = ComputeSignature("my-secret", "{}");
+
+        var result = WebhookSignatureValidator.Verify(signature, string.Empty, "{}");
+
+        result.Should().Be(WebhookSignatureValidationResult.MissingSecret);
+    }
+
+    [Fact]
+    public void ValidSignature_ReturnsValid()
+    {
+        var signature = ComputeSignature("my-secret", "{}");
+
+        var result = WebhookSignatureValidator.Verify(signature, "my-secret", "{}");
+
+        result.Should().Be(WebhookSignatureValidationResult.Valid);
+    }
+
+    [Fact]
+    public void InvalidSignature_ReturnsSignatureMismatch()
+    {
+        var signature = ComputeSignature("wrong-secret", "{}");
+
+        var result = WebhookSignatureValidator.Verify(signature, "my-secret", "{}");
+
+        result.Should().Be(WebhookSignatureValidationResult.SignatureMismatch);
+    }
+
+    [Fact]
+    public void MalformedSignature_ReturnsSignatureMismatch()
+    {
+        var result = WebhookSignatureValidator.Verify("not-a-valid-signature", "my-secret", "{}");
+
+        result.Should().Be(WebhookSignatureValidationResult.SignatureMismatch);
+    }
+
+    [Fact]
+    public void NullBody_ThrowsArgumentNullException()
+    {
+        var act = () => WebhookSignatureValidator.Verify(null, null, null!);
+
+        act.Should().Throw<ArgumentNullException>().WithMessage("*body*");
+    }
+
+    private static string ComputeSignature(string secret, string body)
+    {
+        var keyBytes = Encoding.UTF8.GetBytes(secret);
+        var bodyBytes = Encoding.UTF8.GetBytes(body);
+        var hash = HMACSHA256.HashData(keyBytes, bodyBytes);
+        var hashHex = Convert.ToHexString(hash);
+        return $"sha256={hashHex.ToLower(CultureInfo.InvariantCulture)}";
+    }
+}


### PR DESCRIPTION
Resolves #24, resolves #709

----

### Before the change?

* `VerifySignatureAsync` / `VerifySignature` were private methods, duplicated independently in both `Octokit.Webhooks.AspNetCore` and `Octokit.Webhooks.AzureFunctions`. Anyone not using those hosting packages (RabbitMQ consumers, custom middleware, etc.) had to copy-paste the HMAC logic.
* Both copies compared the HMAC hash with plain string equality (`==` / `!=`), which leaks timing information.
* `WebhookHeaders` didn't parse `X-Hub-Signature-256`.

### After the change?

* New public `WebhookSignatureValidator.Verify(signatureHeader, secret, body)` in the core `Octokit.Webhooks` package. Returns a `WebhookSignatureValidationResult` enum so callers can map results to their own error handling.
* Both hosting packages delegate to the shared method. External HTTP behavior is unchanged.
* HMAC comparison now uses `CryptographicOperations.FixedTimeEquals`.
* `WebhookHeaders.Signature256` exposes the raw `X-Hub-Signature-256` header value.

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

New public API only. Existing behavior is preserved.