### PR TITLE
Move package versions to Directory.Packages.props

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -23,9 +23,9 @@
   </PropertyGroup>
 
   <ItemGroup Label="Package References">
-    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" PrivateAssets="all" Version="17.14.15"/>
-    <PackageReference Include="MinVer" PrivateAssets="all" Version="7.0.0"/>
-    <PackageReference Include="StyleCop.Analyzers" PrivateAssets="all" Version="1.2.0-beta.556"/>
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" PrivateAssets="all"/>
+    <PackageReference Include="MinVer" PrivateAssets="all"/>
+    <PackageReference Include="StyleCop.Analyzers" PrivateAssets="all"/>
   </ItemGroup>
 
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,29 @@
+<Project>
+
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageVersion Include="AwesomeAssertions" Version="9.4.0"/>
+    <PackageVersion Include="CaseExtensions" Version="1.1.0"/>
+    <PackageVersion Include="coverlet.collector" Version="8.0.1"/>
+    <PackageVersion Include="JetBrains.Annotations" Version="2025.2.4"/>
+    <PackageVersion Include="Macross.Json.Extensions" Version="3.0.0"/>
+    <PackageVersion Include="Microsoft.Azure.Functions.Worker" Version="2.51.0"/>
+    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Core" Version="2.51.0"/>
+    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Abstractions" Version="1.3.0"/>
+    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.3.0"/>
+    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.7"/>
+    <PackageVersion Include="Microsoft.Extensions.Primitives" Version="10.0.5"/>
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.4.0"/>
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.201"/>
+    <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.14.15"/>
+    <PackageVersion Include="MinVer" Version="7.0.0"/>
+    <PackageVersion Include="Moq" Version="4.20.72"/>
+    <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.556"/>
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5"/>
+    <PackageVersion Include="xunit.v3" Version="3.2.2"/>
+  </ItemGroup>
+
+</Project>

--- a/samples/AzureFunctions/AzureFunctions.csproj
+++ b/samples/AzureFunctions/AzureFunctions.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.7" OutputItemType="Analyzer" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.51.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" OutputItemType="Analyzer" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -28,7 +28,7 @@
   </PropertyGroup>
 
   <ItemGroup Label="Package References">
-    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="all" Version="10.0.201"/>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="all"/>
   </ItemGroup>
 
   <ItemGroup Label="Files">

--- a/src/Octokit.Webhooks.AzureFunctions/Octokit.Webhooks.AzureFunctions.csproj
+++ b/src/Octokit.Webhooks.AzureFunctions/Octokit.Webhooks.AzureFunctions.csproj
@@ -15,9 +15,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Core" Version="2.51.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Abstractions" Version="1.3.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.3.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Core" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Abstractions" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" />
   </ItemGroup>
 
 </Project>

--- a/src/Octokit.Webhooks/Octokit.Webhooks.csproj
+++ b/src/Octokit.Webhooks/Octokit.Webhooks.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="JetBrains.Annotations" Version="2025.2.4" PrivateAssets="all" />
-    <PackageReference Include="Macross.Json.Extensions" Version="3.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Primitives" Version="10.0.5" />
+    <PackageReference Include="JetBrains.Annotations" PrivateAssets="all" />
+    <PackageReference Include="Macross.Json.Extensions" />
+    <PackageReference Include="Microsoft.Extensions.Primitives" />
   </ItemGroup>
 
 </Project>

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -8,15 +8,15 @@
   </PropertyGroup>
 
   <ItemGroup Label="Package References" Condition="'$(OutputType)' == 'Exe'">
-    <PackageReference Include="CaseExtensions" Version="1.1.0"/>
-    <PackageReference Include="coverlet.collector" PrivateAssets="all" Version="8.0.1">
+    <PackageReference Include="CaseExtensions"/>
+    <PackageReference Include="coverlet.collector" PrivateAssets="all">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="AwesomeAssertions" Version="9.4.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0"/>
-    <PackageReference Include="Moq" Version="4.20.72"/>
-    <PackageReference Include="xunit.v3" Version="3.2.2"/>
-    <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="all" Version="3.1.5">
+    <PackageReference Include="AwesomeAssertions" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk"/>
+    <PackageReference Include="Moq"/>
+    <PackageReference Include="xunit.v3"/>
+    <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="all">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
   </ItemGroup>


### PR DESCRIPTION
### Before the change?

* Package versions are scattered across `Directory.Build.props`, `src/Directory.Build.props`, `test/Directory.Build.props`, and individual `.csproj` files. Updating a shared dependency means hunting through multiple files.

### After the change?

* All 19 package versions live in a single `Directory.Packages.props` at the repo root. Individual `PackageReference` entries no longer carry `Version` attributes. NuGet central package management handles the rest.

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?

- [ ] Yes
- [x] No