### PR TITLE
Add BenchmarkDotNet project for perf regression testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,5 +25,8 @@ artifacts/
 *.coverage
 *.coveragexml
 
+# Benchmark results
+BenchmarkDotNet.Artifacts/
+
 # C# Dev Kit language server cache
 *.lscache

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,6 +6,7 @@
 
   <ItemGroup>
     <PackageVersion Include="AwesomeAssertions" Version="9.4.0"/>
+    <PackageVersion Include="BenchmarkDotNet" Version="0.15.8"/>
     <PackageVersion Include="CaseExtensions" Version="1.1.0"/>
     <PackageVersion Include="coverlet.collector" Version="8.0.1"/>
     <PackageVersion Include="JetBrains.Annotations" Version="2025.2.4"/>

--- a/Octokit.Webhooks.slnx
+++ b/Octokit.Webhooks.slnx
@@ -32,6 +32,10 @@
     <File Path=".github/workflows/codeql-analysis.yml" />
     <File Path=".github/workflows/release-drafter.yml" />
   </Folder>
+  <Folder Name="/benchmarks/">
+    <File Path="benchmarks/Directory.Build.props" />
+    <Project Path="benchmarks/Octokit.Webhooks.Benchmarks/Octokit.Webhooks.Benchmarks.csproj" />
+  </Folder>
   <Folder Name="/src/">
     <File Path="src/Directory.Build.props" />
     <Project Path="src/Octokit.Webhooks.AspNetCore/Octokit.Webhooks.AspNetCore.csproj" />

--- a/benchmarks/Directory.Build.props
+++ b/benchmarks/Directory.Build.props
@@ -1,0 +1,11 @@
+<Project>
+
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))"/>
+
+  <PropertyGroup Label="Build">
+    <TargetFramework>net10.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <NoWarn>$(NoWarn);SA0001</NoWarn>
+  </PropertyGroup>
+
+</Project>

--- a/benchmarks/Octokit.Webhooks.Benchmarks/BenchmarkWebhookEventProcessor.cs
+++ b/benchmarks/Octokit.Webhooks.Benchmarks/BenchmarkWebhookEventProcessor.cs
@@ -1,0 +1,3 @@
+namespace Octokit.Webhooks.Benchmarks;
+
+public sealed class BenchmarkWebhookEventProcessor : WebhookEventProcessor;

--- a/benchmarks/Octokit.Webhooks.Benchmarks/Octokit.Webhooks.Benchmarks.csproj
+++ b/benchmarks/Octokit.Webhooks.Benchmarks/Octokit.Webhooks.Benchmarks.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup Label="Build">
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+
+  <ItemGroup Label="Package References">
+    <PackageReference Include="BenchmarkDotNet" />
+  </ItemGroup>
+
+  <ItemGroup Label="Project References">
+    <ProjectReference Include="..\..\src\Octokit.Webhooks\Octokit.Webhooks.csproj" />
+    <ProjectReference Include="..\..\test\Octokit.Webhooks.TestUtils\Octokit.Webhooks.TestUtils.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="..\..\test\Octokit.Webhooks.Test\Resources\**">
+      <Link>Resources\%(RecursiveDir)%(Filename)%(Extension)</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
+</Project>

--- a/benchmarks/Octokit.Webhooks.Benchmarks/Program.cs
+++ b/benchmarks/Octokit.Webhooks.Benchmarks/Program.cs
@@ -1,0 +1,3 @@
+using BenchmarkDotNet.Running;
+
+BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);

--- a/benchmarks/Octokit.Webhooks.Benchmarks/WebhookDeserializationBenchmarks.cs
+++ b/benchmarks/Octokit.Webhooks.Benchmarks/WebhookDeserializationBenchmarks.cs
@@ -1,0 +1,36 @@
+namespace Octokit.Webhooks.Benchmarks;
+
+using System.Text.Json;
+using BenchmarkDotNet.Attributes;
+using Octokit.Webhooks.Events;
+using Octokit.Webhooks.Events.Issues;
+using Octokit.Webhooks.Events.PullRequest;
+using Octokit.Webhooks.TestUtils;
+
+[MemoryDiagnoser]
+public class WebhookDeserializationBenchmarks
+{
+    private string pushBody = null!;
+    private string pullRequestBody = null!;
+    private string issuesBody = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        this.pushBody = ResourceUtils.ReadResource("push/payload.json");
+        this.pullRequestBody = ResourceUtils.ReadResource("pull_request/opened.payload.json");
+        this.issuesBody = ResourceUtils.ReadResource("issues/opened.payload.json");
+    }
+
+    [Benchmark]
+    public PushEvent? DeserializePushEvent()
+        => JsonSerializer.Deserialize<PushEvent>(this.pushBody);
+
+    [Benchmark]
+    public PullRequestEvent? DeserializePullRequestEvent()
+        => JsonSerializer.Deserialize<PullRequestEvent>(this.pullRequestBody);
+
+    [Benchmark]
+    public IssuesEvent? DeserializeIssuesEvent()
+        => JsonSerializer.Deserialize<IssuesEvent>(this.issuesBody);
+}

--- a/benchmarks/Octokit.Webhooks.Benchmarks/WebhookEventProcessorBenchmarks.cs
+++ b/benchmarks/Octokit.Webhooks.Benchmarks/WebhookEventProcessorBenchmarks.cs
@@ -1,0 +1,58 @@
+namespace Octokit.Webhooks.Benchmarks;
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using Microsoft.Extensions.Primitives;
+using Octokit.Webhooks.TestUtils;
+
+[MemoryDiagnoser]
+public class WebhookEventProcessorBenchmarks
+{
+    private BenchmarkWebhookEventProcessor processor = null!;
+
+    private IDictionary<string, StringValues> pushHeaders = null!;
+    private string pushBody = null!;
+
+    private IDictionary<string, StringValues> pullRequestHeaders = null!;
+    private string pullRequestBody = null!;
+
+    private IDictionary<string, StringValues> issuesHeaders = null!;
+    private string issuesBody = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        this.processor = new BenchmarkWebhookEventProcessor();
+
+        this.pushBody = ResourceUtils.ReadResource("push/payload.json");
+        this.pushHeaders = CreateHeaders("push");
+
+        this.pullRequestBody = ResourceUtils.ReadResource("pull_request/opened.payload.json");
+        this.pullRequestHeaders = CreateHeaders("pull_request");
+
+        this.issuesBody = ResourceUtils.ReadResource("issues/opened.payload.json");
+        this.issuesHeaders = CreateHeaders("issues");
+    }
+
+    [Benchmark]
+    public async Task ProcessPushWebhookAsync()
+        => await this.processor.ProcessWebhookAsync(this.pushHeaders, this.pushBody).ConfigureAwait(false);
+
+    [Benchmark]
+    public async Task ProcessPullRequestWebhookAsync()
+        => await this.processor.ProcessWebhookAsync(this.pullRequestHeaders, this.pullRequestBody).ConfigureAwait(false);
+
+    [Benchmark]
+    public async Task ProcessIssuesWebhookAsync()
+        => await this.processor.ProcessWebhookAsync(this.issuesHeaders, this.issuesBody).ConfigureAwait(false);
+
+    private static Dictionary<string, StringValues> CreateHeaders(string eventName) =>
+        new()
+        {
+            ["X-GitHub-Event"] = eventName,
+            ["X-GitHub-Delivery"] = Guid.NewGuid().ToString(),
+            ["X-GitHub-Hook-ID"] = "12345",
+        };
+}

--- a/benchmarks/Octokit.Webhooks.Benchmarks/WebhookSignatureValidatorBenchmarks.cs
+++ b/benchmarks/Octokit.Webhooks.Benchmarks/WebhookSignatureValidatorBenchmarks.cs
@@ -1,0 +1,45 @@
+namespace Octokit.Webhooks.Benchmarks;
+
+using System;
+using System.Security.Cryptography;
+using System.Text;
+using BenchmarkDotNet.Attributes;
+using Octokit.Webhooks.TestUtils;
+
+[MemoryDiagnoser]
+public class WebhookSignatureValidatorBenchmarks
+{
+    private const string Secret = "benchmark-webhook-secret";
+
+    private string smallBody = null!;
+    private string smallSignature = null!;
+
+    private string largeBody = null!;
+    private string largeSignature = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        this.smallBody = ResourceUtils.ReadResource("issues/opened.payload.json");
+        this.smallSignature = ComputeSignature(Secret, this.smallBody);
+
+        this.largeBody = ResourceUtils.ReadResource("pull_request/opened.payload.json");
+        this.largeSignature = ComputeSignature(Secret, this.largeBody);
+    }
+
+    [Benchmark(Description = "Verify (small payload)")]
+    public WebhookSignatureValidationResult VerifySmallPayload()
+        => WebhookSignatureValidator.Verify(this.smallSignature, Secret, this.smallBody);
+
+    [Benchmark(Description = "Verify (large payload)")]
+    public WebhookSignatureValidationResult VerifyLargePayload()
+        => WebhookSignatureValidator.Verify(this.largeSignature, Secret, this.largeBody);
+
+    private static string ComputeSignature(string secret, string body)
+    {
+        var keyBytes = Encoding.UTF8.GetBytes(secret);
+        var bodyBytes = Encoding.UTF8.GetBytes(body);
+        var hash = HMACSHA256.HashData(keyBytes, bodyBytes);
+        return $"sha256={Convert.ToHexString(hash).ToLowerInvariant()}";
+    }
+}


### PR DESCRIPTION
Resolves #766

----

### Before the change?

* No way to measure performance impact of changes locally. The StringEnum struct regression (#766) was only caught by external benchmarks.

### After the change?

* A `benchmarks/Octokit.Webhooks.Benchmarks` project using BenchmarkDotNet. Covers three areas:
  - Full webhook processing pipeline (push, pull_request, issues)
  - JSON deserialization in isolation
  - Signature validation with small and large payloads
* All benchmarks include `[MemoryDiagnoser]` for allocation tracking
* Reuses existing test payloads from `test/Octokit.Webhooks.Test/Resources/` (linked, not copied)
* Run with: `dotnet run --project benchmarks/Octokit.Webhooks.Benchmarks -c Release`

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?

- [ ] Yes
- [x] No