### PR TITLE
Fix audit issues: SecurityAndAnalysis, naming, types

### DIFF
--- a/src/Octokit.Webhooks/Events/PullRequest/PullRequestDemilestonedEvent.cs
+++ b/src/Octokit.Webhooks/Events/PullRequest/PullRequestDemilestonedEvent.cs
@@ -3,11 +3,11 @@ namespace Octokit.Webhooks.Events.PullRequest;
 using Milestone = Octokit.Webhooks.Models.Milestone;
 
 [PublicAPI]
-[WebhookActionType(PullRequestActionValue.Milestoned)]
-public sealed record PullRequestMilestoned : PullRequestEvent
+[WebhookActionType(PullRequestActionValue.Demilestoned)]
+public sealed record PullRequestDemilestonedEvent : PullRequestEvent
 {
     [JsonPropertyName("action")]
-    public override string Action => PullRequestAction.Milestoned;
+    public override string Action => PullRequestAction.Demilestoned;
 
     [JsonPropertyName("milestone")]
     public Milestone Milestone { get; init; } = null!;

--- a/src/Octokit.Webhooks/Events/PullRequest/PullRequestMilestonedEvent.cs
+++ b/src/Octokit.Webhooks/Events/PullRequest/PullRequestMilestonedEvent.cs
@@ -3,11 +3,11 @@ namespace Octokit.Webhooks.Events.PullRequest;
 using Milestone = Octokit.Webhooks.Models.Milestone;
 
 [PublicAPI]
-[WebhookActionType(PullRequestActionValue.Demilestoned)]
-public sealed record PullRequestDemilestoned : PullRequestEvent
+[WebhookActionType(PullRequestActionValue.Milestoned)]
+public sealed record PullRequestMilestonedEvent : PullRequestEvent
 {
     [JsonPropertyName("action")]
-    public override string Action => PullRequestAction.Demilestoned;
+    public override string Action => PullRequestAction.Milestoned;
 
     [JsonPropertyName("milestone")]
     public Milestone Milestone { get; init; } = null!;

--- a/src/Octokit.Webhooks/Events/RepositoryRuleset/RepositoryRulesetAction.cs
+++ b/src/Octokit.Webhooks/Events/RepositoryRuleset/RepositoryRulesetAction.cs
@@ -1,5 +1,6 @@
 namespace Octokit.Webhooks.Events.RepositoryRuleset;
 
+[PublicAPI]
 public sealed record RepositoryRulesetAction : WebhookEventAction
 {
     public static readonly RepositoryRulesetAction Created = new(RepositoryRulesetActionValue.Created);

--- a/src/Octokit.Webhooks/Events/SecurityAndAnalysisEvent.cs
+++ b/src/Octokit.Webhooks/Events/SecurityAndAnalysisEvent.cs
@@ -1,0 +1,9 @@
+namespace Octokit.Webhooks.Events;
+
+[PublicAPI]
+[WebhookEventType(WebhookEventType.SecurityAndAnalysis)]
+public sealed record SecurityAndAnalysisEvent : WebhookEvent
+{
+    [JsonPropertyName("changes")]
+    public Models.SecurityAndAnalysisEvent.Changes Changes { get; init; } = null!;
+}

--- a/src/Octokit.Webhooks/Models/SecurityAndAnalysisEvent/Changes.cs
+++ b/src/Octokit.Webhooks/Models/SecurityAndAnalysisEvent/Changes.cs
@@ -1,0 +1,8 @@
+namespace Octokit.Webhooks.Models.SecurityAndAnalysisEvent;
+
+[PublicAPI]
+public sealed record Changes
+{
+    [JsonPropertyName("from")]
+    public ChangesFrom From { get; init; } = null!;
+}

--- a/src/Octokit.Webhooks/Models/SecurityAndAnalysisEvent/ChangesFrom.cs
+++ b/src/Octokit.Webhooks/Models/SecurityAndAnalysisEvent/ChangesFrom.cs
@@ -1,0 +1,8 @@
+namespace Octokit.Webhooks.Models.SecurityAndAnalysisEvent;
+
+[PublicAPI]
+public sealed record ChangesFrom
+{
+    [JsonPropertyName("security_and_analysis")]
+    public SecurityAndAnalysis? SecurityAndAnalysis { get; init; }
+}

--- a/src/Octokit.Webhooks/Models/SecurityAndAnalysisEvent/SecurityAndAnalysis.cs
+++ b/src/Octokit.Webhooks/Models/SecurityAndAnalysisEvent/SecurityAndAnalysis.cs
@@ -1,0 +1,32 @@
+namespace Octokit.Webhooks.Models.SecurityAndAnalysisEvent;
+
+[PublicAPI]
+public sealed record SecurityAndAnalysis
+{
+    [JsonPropertyName("advanced_security")]
+    public SecurityFeature? AdvancedSecurity { get; init; }
+
+    [JsonPropertyName("code_security")]
+    public SecurityFeature? CodeSecurity { get; init; }
+
+    [JsonPropertyName("dependabot_security_updates")]
+    public SecurityFeature? DependabotSecurityUpdates { get; init; }
+
+    [JsonPropertyName("secret_scanning")]
+    public SecurityFeature? SecretScanning { get; init; }
+
+    [JsonPropertyName("secret_scanning_push_protection")]
+    public SecurityFeature? SecretScanningPushProtection { get; init; }
+
+    [JsonPropertyName("secret_scanning_non_provider_patterns")]
+    public SecurityFeature? SecretScanningNonProviderPatterns { get; init; }
+
+    [JsonPropertyName("secret_scanning_ai_detection")]
+    public SecurityFeature? SecretScanningAiDetection { get; init; }
+
+    [JsonPropertyName("secret_scanning_delegated_alert_dismissal")]
+    public SecurityFeature? SecretScanningDelegatedAlertDismissal { get; init; }
+
+    [JsonPropertyName("secret_scanning_delegated_bypass")]
+    public SecurityFeature? SecretScanningDelegatedBypass { get; init; }
+}

--- a/src/Octokit.Webhooks/Models/SecurityAndAnalysisEvent/SecurityFeature.cs
+++ b/src/Octokit.Webhooks/Models/SecurityAndAnalysisEvent/SecurityFeature.cs
@@ -1,0 +1,8 @@
+namespace Octokit.Webhooks.Models.SecurityAndAnalysisEvent;
+
+[PublicAPI]
+public sealed record SecurityFeature
+{
+    [JsonPropertyName("status")]
+    public string? Status { get; init; }
+}

--- a/src/Octokit.Webhooks/Models/Workflow.cs
+++ b/src/Octokit.Webhooks/Models/Workflow.cs
@@ -26,7 +26,8 @@ public sealed record Workflow
     public string Path { get; init; } = null!;
 
     [JsonPropertyName("state")]
-    public string State { get; init; } = null!;
+    [JsonConverter(typeof(StringEnumConverter<WorkflowState>))]
+    public StringEnum<WorkflowState> State { get; init; } = null!;
 
     [JsonPropertyName("updated_at")]
     [JsonConverter(typeof(DateTimeOffsetConverter))]

--- a/src/Octokit.Webhooks/Models/WorkflowState.cs
+++ b/src/Octokit.Webhooks/Models/WorkflowState.cs
@@ -1,0 +1,16 @@
+namespace Octokit.Webhooks.Models;
+
+[PublicAPI]
+public enum WorkflowState
+{
+    [EnumMember(Value = "active")]
+    Active,
+    [EnumMember(Value = "deleted")]
+    Deleted,
+    [EnumMember(Value = "disabled_fork")]
+    DisabledFork,
+    [EnumMember(Value = "disabled_inactivity")]
+    DisabledInactivity,
+    [EnumMember(Value = "disabled_manually")]
+    DisabledManually,
+}

--- a/src/Octokit.Webhooks/WebhookEventProcessor.cs
+++ b/src/Octokit.Webhooks/WebhookEventProcessor.cs
@@ -165,6 +165,7 @@ public abstract class WebhookEventProcessor
             SecretScanningAlertLocationEvent secretScanningAlertLocationEvent
                 => this.ProcessSecretScanningAlertLocationWebhookAsync(headers, secretScanningAlertLocationEvent, cancellationToken),
             SecurityAdvisoryEvent securityAdvisoryEvent => this.ProcessSecurityAdvisoryWebhookAsync(headers, securityAdvisoryEvent, cancellationToken),
+            SecurityAndAnalysisEvent securityAndAnalysisEvent => this.ProcessSecurityAndAnalysisWebhookAsync(headers, securityAndAnalysisEvent, cancellationToken),
             SponsorshipEvent sponsorshipEvent => this.ProcessSponsorshipWebhookAsync(headers, sponsorshipEvent, cancellationToken),
             StarEvent starEvent => this.ProcessStarWebhookAsync(headers, starEvent, cancellationToken),
             StatusEvent statusEvent => this.ProcessStatusWebhookAsync(headers, statusEvent, cancellationToken),
@@ -247,7 +248,9 @@ public abstract class WebhookEventProcessor
             WebhookEventType.RepositoryRuleset => JsonSerializer.Deserialize<RepositoryRulesetEvent>(body)!,
             WebhookEventType.RepositoryVulnerabilityAlert => JsonSerializer.Deserialize<RepositoryVulnerabilityAlertEvent>(body)!,
             WebhookEventType.SecretScanningAlert => JsonSerializer.Deserialize<SecretScanningAlertEvent>(body)!,
+            WebhookEventType.SecretScanningAlertLocation => JsonSerializer.Deserialize<SecretScanningAlertLocationEvent>(body)!,
             WebhookEventType.SecurityAdvisory => JsonSerializer.Deserialize<SecurityAdvisoryEvent>(body)!,
+            WebhookEventType.SecurityAndAnalysis => JsonSerializer.Deserialize<SecurityAndAnalysisEvent>(body)!,
             WebhookEventType.Sponsorship => JsonSerializer.Deserialize<SponsorshipEvent>(body)!,
             WebhookEventType.Star => JsonSerializer.Deserialize<StarEvent>(body)!,
             WebhookEventType.Status => JsonSerializer.Deserialize<StatusEvent>(body)!,
@@ -1378,6 +1381,9 @@ public abstract class WebhookEventProcessor
         SecurityAdvisoryEvent securityAdvisoryEvent,
         SecurityAdvisoryAction action,
         CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+
+    [PublicAPI]
+    protected virtual ValueTask ProcessSecurityAndAnalysisWebhookAsync(WebhookHeaders headers, SecurityAndAnalysisEvent securityAndAnalysisEvent, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
 
     private ValueTask ProcessSponsorshipWebhookAsync(WebhookHeaders headers, SponsorshipEvent sponsorshipEvent, CancellationToken cancellationToken = default) =>
         sponsorshipEvent.Action switch

--- a/test/Octokit.Webhooks.Test/Resources/security_and_analysis/payload.json
+++ b/test/Octokit.Webhooks.Test/Resources/security_and_analysis/payload.json
@@ -1,0 +1,44 @@
+{
+  "changes": {
+    "from": {
+      "security_and_analysis": {
+        "advanced_security": {
+          "status": "disabled"
+        },
+        "secret_scanning": {
+          "status": "disabled"
+        },
+        "secret_scanning_push_protection": {
+          "status": "disabled"
+        }
+      }
+    }
+  },
+  "repository": {
+    "id": 123456789,
+    "node_id": "MDEwOlJlcG9zaXRvcnkxMjM0NTY3ODk=",
+    "name": "Hello-World",
+    "full_name": "octocat/Hello-World",
+    "private": false,
+    "owner": {
+      "login": "octocat",
+      "id": 1,
+      "node_id": "MDQ6VXNlcjE=",
+      "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+      "url": "https://api.github.com/users/octocat",
+      "type": "User",
+      "site_admin": false
+    },
+    "html_url": "https://github.com/octocat/Hello-World",
+    "url": "https://api.github.com/repos/octocat/Hello-World"
+  },
+  "sender": {
+    "login": "octocat",
+    "id": 1,
+    "node_id": "MDQ6VXNlcjE=",
+    "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+    "url": "https://api.github.com/users/octocat",
+    "type": "User",
+    "site_admin": false
+  }
+}


### PR DESCRIPTION
### Before the change?

* `SecurityAndAnalysis` had a constant in `WebHookEventType.cs` but no event class or processor entry — receiving this webhook threw `JsonException`
* `SecretScanningAlertLocation` was missing its deserialization case, same problem
* `PullRequestMilestoned` and `PullRequestDemilestoned` were the only action-specific events not following the `*Event` naming convention
* `RepositoryRulesetAction` was missing `[PublicAPI]`, every other `*Action` has it
* `Workflow.State` was a raw `string` while the OpenAPI spec defines an enum (`active`, `deleted`, `disabled_fork`, `disabled_inactivity`, `disabled_manually`)

### After the change?

* Added `SecurityAndAnalysisEvent` with models for the `changes.from.security_and_analysis` payload and test resource
* Added missing `SecretScanningAlertLocation` deserialization case
* Renamed to `PullRequestMilestonedEvent` / `PullRequestDemilestonedEvent`
* Added `[PublicAPI]` to `RepositoryRulesetAction`
* Added `WorkflowState` enum, `Workflow.State` now uses `StringEnum<WorkflowState>`

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?

- [x] Yes
- [ ] No

* `PullRequestMilestoned` renamed to `PullRequestMilestonedEvent` (same for `Demilestoned`)
* `Workflow.State` changed from `string` to `StringEnum<WorkflowState>`
