### PR TITLE
Update Azure Functions README to use IHostApplicationBuilder

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,20 +85,20 @@ Libraries to handle GitHub Webhooks in .NET applications.
 4. Configure the webhook function:
 
     ```C#
-    new HostBuilder()
+    var builder = FunctionsApplication.CreateBuilder(args);
     ...
-    .ConfigureGitHubWebhooks()
+    builder.ConfigureGitHubWebhooks();
     ...
-    .Build();
+    builder.Build().Run();
     ```
 
-`ConfigureGitHubWebhooks()` either takes an optional parameter:
+`ConfigureGitHubWebhooks()` takes an optional parameter:
 
 * `secret`. The secret you have configured in GitHub, if you have set this up.
 
-or:
+Alternatively, you can pass a function that resolves the secret from configuration:
 
-* `configure`. A function that takes an IConfiguration instance and expects the secret you have configured in GitHub in return.
+* `configure`. A function that takes an `IConfiguration` instance and returns the secret.
 
 The function is available on the `/api/github/webhooks` endpoint.
 

--- a/README.md
+++ b/README.md
@@ -71,34 +71,21 @@ Libraries to handle GitHub Webhooks in .NET applications.
     }
     ```
 
-3. Register your implementation of `WebhookEventProcessor`:
-
-    ```C#
-    .ConfigureServices(collection =>
-    {
-        ...
-        collection.AddSingleton<WebhookEventProcessor, MyWebhookEventProcessor>();
-        ...
-    })
-    ```
-
-4. Configure the webhook function:
+3. Register your implementation of `WebhookEventProcessor` and configure the webhook function:
 
     ```C#
     var builder = FunctionsApplication.CreateBuilder(args);
-    ...
+
+    builder.Services.AddSingleton<WebhookEventProcessor, MyWebhookEventProcessor>();
     builder.ConfigureGitHubWebhooks();
-    ...
+
     builder.Build().Run();
     ```
 
-`ConfigureGitHubWebhooks()` takes an optional parameter:
+`ConfigureGitHubWebhooks` has two overloads:
 
-* `secret`. The secret you have configured in GitHub, if you have set this up.
-
-Alternatively, you can pass a function that resolves the secret from configuration:
-
-* `configure`. A function that takes an `IConfiguration` instance and returns the secret.
+* `ConfigureGitHubWebhooks(string? secret = null)`. Pass the secret you have configured in GitHub, if you have set this up.
+* `ConfigureGitHubWebhooks(Func<IConfiguration, string> configure)`. Resolve the secret from configuration at runtime.
 
 The function is available on the `/api/github/webhooks` endpoint.
 


### PR DESCRIPTION
### Before the change?

* Azure Functions example showed the old `IHostBuilder` pattern (`new HostBuilder().ConfigureGitHubWebhooks().Build()`) which does not match the current sample or recommended approach

### After the change?

* Updated to `FunctionsApplication.CreateBuilder` pattern matching the actual sample code
* Clarified secret configuration options

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?

- [ ] Yes
- [x] No
