### PR TITLE
Use required keyword and IReadOnlyList<T> across models

### DIFF
--- a/src/Octokit.Webhooks/Events/BranchProtectionRuleEvent.cs
+++ b/src/Octokit.Webhooks/Events/BranchProtectionRuleEvent.cs
@@ -6,5 +6,5 @@ namespace Octokit.Webhooks.Events;
 public abstract record BranchProtectionRuleEvent : WebhookEvent
 {
     [JsonPropertyName("rule")]
-    public Models.BranchProtectionRule Rule { get; init; } = null!;
+    public required Models.BranchProtectionRule Rule { get; init; }
 }

--- a/src/Octokit.Webhooks/Events/CheckRunEvent.cs
+++ b/src/Octokit.Webhooks/Events/CheckRunEvent.cs
@@ -8,7 +8,7 @@ using Octokit.Webhooks.Models.CheckRunEvent;
 public abstract record CheckRunEvent : WebhookEvent
 {
     [JsonPropertyName("check_run")]
-    public Models.CheckRunEvent.CheckRun CheckRun { get; init; } = null!;
+    public required Models.CheckRunEvent.CheckRun CheckRun { get; init; }
 
     [JsonPropertyName("requested_action")]
     public RequestedAction? RequestedAction { get; init; }

--- a/src/Octokit.Webhooks/Events/CheckSuiteEvent.cs
+++ b/src/Octokit.Webhooks/Events/CheckSuiteEvent.cs
@@ -6,5 +6,5 @@ namespace Octokit.Webhooks.Events;
 public abstract record CheckSuiteEvent : WebhookEvent
 {
     [JsonPropertyName("check_suite")]
-    public Models.CheckSuiteEvent.CheckSuite CheckSuite { get; init; } = null!;
+    public required Models.CheckSuiteEvent.CheckSuite CheckSuite { get; init; }
 }

--- a/src/Octokit.Webhooks/Events/CodeScanningAlertEvent.cs
+++ b/src/Octokit.Webhooks/Events/CodeScanningAlertEvent.cs
@@ -8,11 +8,11 @@ using Octokit.Webhooks.Models.CodeScanningAlertEvent;
 public abstract record CodeScanningAlertEvent : WebhookEvent
 {
     [JsonPropertyName("alert")]
-    public Alert Alert { get; init; } = null!;
+    public required Alert Alert { get; init; }
 
     [JsonPropertyName("ref")]
-    public string Ref { get; init; } = null!;
+    public required string Ref { get; init; }
 
     [JsonPropertyName("commit_oid")]
-    public string CommitOid { get; init; } = null!;
+    public required string CommitOid { get; init; }
 }

--- a/src/Octokit.Webhooks/Events/CommitCommentEvent.cs
+++ b/src/Octokit.Webhooks/Events/CommitCommentEvent.cs
@@ -8,5 +8,5 @@ using Octokit.Webhooks.Models.CommitCommentEvent;
 public abstract record CommitCommentEvent : WebhookEvent
 {
     [JsonPropertyName("comment")]
-    public Comment Comment { get; init; } = null!;
+    public required Comment Comment { get; init; }
 }

--- a/src/Octokit.Webhooks/Events/ContentReferenceEvent.cs
+++ b/src/Octokit.Webhooks/Events/ContentReferenceEvent.cs
@@ -6,5 +6,5 @@ namespace Octokit.Webhooks.Events;
 public abstract record ContentReferenceEvent : WebhookEvent
 {
     [JsonPropertyName("content_reference")]
-    public Models.ContentReferenceEvent.ContentReference ContentReference { get; init; } = null!;
+    public required Models.ContentReferenceEvent.ContentReference ContentReference { get; init; }
 }

--- a/src/Octokit.Webhooks/Events/CreateEvent.cs
+++ b/src/Octokit.Webhooks/Events/CreateEvent.cs
@@ -5,18 +5,18 @@ namespace Octokit.Webhooks.Events;
 public sealed record CreateEvent : WebhookEvent
 {
     [JsonPropertyName("ref")]
-    public string Ref { get; init; } = null!;
+    public required string Ref { get; init; }
 
     [JsonPropertyName("ref_type")]
     [JsonConverter(typeof(StringEnumConverter<RefType>))]
-    public StringEnum<RefType> RefType { get; init; } = null!;
+    public required StringEnum<RefType> RefType { get; init; }
 
     [JsonPropertyName("master_branch")]
-    public string MasterBranch { get; init; } = null!;
+    public required string MasterBranch { get; init; }
 
     [JsonPropertyName("description")]
     public string? Description { get; init; }
 
     [JsonPropertyName("pusher_type")]
-    public string PusherType { get; init; } = null!;
+    public required string PusherType { get; init; }
 }

--- a/src/Octokit.Webhooks/Events/CustomProperty/CustomPropertyCreatedEvent.cs
+++ b/src/Octokit.Webhooks/Events/CustomProperty/CustomPropertyCreatedEvent.cs
@@ -8,5 +8,5 @@ public sealed record CustomPropertyCreatedEvent : CustomPropertyEvent
     public override string Action => CustomPropertyAction.Created;
 
     [JsonPropertyName("definition")]
-    public Models.CustomPropertyEvent.CustomProperty CustomProperty { get; init; } = null!;
+    public required Models.CustomPropertyEvent.CustomProperty CustomProperty { get; init; }
 }

--- a/src/Octokit.Webhooks/Events/CustomProperty/CustomPropertyDeletedEvent.cs
+++ b/src/Octokit.Webhooks/Events/CustomProperty/CustomPropertyDeletedEvent.cs
@@ -8,5 +8,5 @@ public sealed record CustomPropertyDeletedEvent : CustomPropertyEvent
     public override string Action => CustomPropertyAction.Deleted;
 
     [JsonPropertyName("definition")]
-    public Models.CustomPropertyEvent.CustomPropertyLite CustomProperty { get; init; } = null!;
+    public required Models.CustomPropertyEvent.CustomPropertyLite CustomProperty { get; init; }
 }

--- a/src/Octokit.Webhooks/Events/CustomProperty/CustomPropertyUpdatedEvent.cs
+++ b/src/Octokit.Webhooks/Events/CustomProperty/CustomPropertyUpdatedEvent.cs
@@ -8,5 +8,5 @@ public sealed record CustomPropertyUpdatedEvent : CustomPropertyEvent
     public override string Action => CustomPropertyAction.Updated;
 
     [JsonPropertyName("definition")]
-    public Models.CustomPropertyEvent.CustomProperty CustomProperty { get; init; } = null!;
+    public required Models.CustomPropertyEvent.CustomProperty CustomProperty { get; init; }
 }

--- a/src/Octokit.Webhooks/Events/CustomPropertyPromotedToEnterpriseEvent.cs
+++ b/src/Octokit.Webhooks/Events/CustomPropertyPromotedToEnterpriseEvent.cs
@@ -6,5 +6,5 @@ namespace Octokit.Webhooks.Events;
 public abstract record CustomPropertyPromotedToEnterpriseEvent : WebhookEvent
 {
     [JsonPropertyName("definition")]
-    public Models.CustomPropertyEvent.CustomProperty Definition { get; init; } = null!;
+    public required Models.CustomPropertyEvent.CustomProperty Definition { get; init; }
 }

--- a/src/Octokit.Webhooks/Events/CustomPropertyValues/CustomPropertyValuesUpdatedEvent.cs
+++ b/src/Octokit.Webhooks/Events/CustomPropertyValues/CustomPropertyValuesUpdatedEvent.cs
@@ -8,8 +8,8 @@ public sealed record CustomPropertyValuesUpdatedEvent : CustomPropertyValuesEven
     public override string Action => CustomPropertyValuesAction.Updated;
 
     [JsonPropertyName("new_property_values")]
-    public IEnumerable<Models.CustomPropertyValuesEvent.CustomPropertyValue> NewPropertyValues { get; init; } = null!;
+    public required IReadOnlyList<Models.CustomPropertyValuesEvent.CustomPropertyValue> NewPropertyValues { get; init; }
 
     [JsonPropertyName("old_property_values")]
-    public IEnumerable<Models.CustomPropertyValuesEvent.CustomPropertyValue> OldPropertyValues { get; init; } = null!;
+    public required IReadOnlyList<Models.CustomPropertyValuesEvent.CustomPropertyValue> OldPropertyValues { get; init; }
 }

--- a/src/Octokit.Webhooks/Events/DeleteEvent.cs
+++ b/src/Octokit.Webhooks/Events/DeleteEvent.cs
@@ -5,12 +5,12 @@ namespace Octokit.Webhooks.Events;
 public sealed record DeleteEvent : WebhookEvent
 {
     [JsonPropertyName("ref")]
-    public string Ref { get; init; } = null!;
+    public required string Ref { get; init; }
 
     [JsonPropertyName("ref_type")]
     [JsonConverter(typeof(StringEnumConverter<RefType>))]
-    public StringEnum<RefType> RefType { get; init; } = null!;
+    public required StringEnum<RefType> RefType { get; init; }
 
     [JsonPropertyName("pusher_type")]
-    public string PusherType { get; init; } = null!;
+    public required string PusherType { get; init; }
 }

--- a/src/Octokit.Webhooks/Events/DependabotAlertEvent.cs
+++ b/src/Octokit.Webhooks/Events/DependabotAlertEvent.cs
@@ -6,5 +6,5 @@ namespace Octokit.Webhooks.Events;
 public abstract record DependabotAlertEvent : WebhookEvent
 {
     [JsonPropertyName("alert")]
-    public Models.DependabotEvent.DependabotAlert Alert { get; init; } = null!;
+    public required Models.DependabotEvent.DependabotAlert Alert { get; init; }
 }

--- a/src/Octokit.Webhooks/Events/DeployKeyEvent.cs
+++ b/src/Octokit.Webhooks/Events/DeployKeyEvent.cs
@@ -6,5 +6,5 @@ namespace Octokit.Webhooks.Events;
 public abstract record DeployKeyEvent : WebhookEvent
 {
     [JsonPropertyName("key")]
-    public Models.DeployKeyEvent.DeployKey Key { get; init; } = null!;
+    public required Models.DeployKeyEvent.DeployKey Key { get; init; }
 }

--- a/src/Octokit.Webhooks/Events/DeploymentEvent.cs
+++ b/src/Octokit.Webhooks/Events/DeploymentEvent.cs
@@ -6,7 +6,7 @@ namespace Octokit.Webhooks.Events;
 public abstract record DeploymentEvent : WebhookEvent
 {
     [JsonPropertyName("deployment")]
-    public Models.DeploymentEvent.Deployment Deployment { get; init; } = null!;
+    public required Models.DeploymentEvent.Deployment Deployment { get; init; }
 
     [JsonPropertyName("workflow")]
     public Models.Workflow? Workflow { get; init; }

--- a/src/Octokit.Webhooks/Events/DeploymentProtectionRuleEvent.cs
+++ b/src/Octokit.Webhooks/Events/DeploymentProtectionRuleEvent.cs
@@ -6,17 +6,17 @@ namespace Octokit.Webhooks.Events;
 public abstract record DeploymentProtectionRuleEvent : WebhookEvent
 {
     [JsonPropertyName("environment")]
-    public string Environment { get; init; } = null!;
+    public required string Environment { get; init; }
 
     [JsonPropertyName("event")]
-    public string Event { get; init; } = null!;
+    public required string Event { get; init; }
 
     [JsonPropertyName("deployment_callback_url")]
-    public string DeploymentCallbackUrl { get; init; } = null!;
+    public required string DeploymentCallbackUrl { get; init; }
 
     [JsonPropertyName("deployment")]
-    public Models.DeploymentEvent.Deployment Deployment { get; init; } = null!;
+    public required Models.DeploymentEvent.Deployment Deployment { get; init; }
 
     [JsonPropertyName("pull_requests")]
-    public IEnumerable<Models.PullRequestEvent.PullRequest> PullRequests { get; init; } = null!;
+    public required IReadOnlyList<Models.PullRequestEvent.PullRequest> PullRequests { get; init; }
 }

--- a/src/Octokit.Webhooks/Events/DeploymentReviewEvent.cs
+++ b/src/Octokit.Webhooks/Events/DeploymentReviewEvent.cs
@@ -16,10 +16,10 @@ public abstract record DeploymentReviewEvent : WebhookEvent
     public WorkflowJobRun? WorkflowJobRun { get; init; }
 
     [JsonPropertyName("workflow_job_runs")]
-    public IEnumerable<WorkflowJobRun>? WorkflowJobRuns { get; init; }
+    public IReadOnlyList<WorkflowJobRun>? WorkflowJobRuns { get; init; }
 
     [JsonPropertyName("reviewers")]
-    public IEnumerable<DeploymentReviewReviewer>? Reviewers { get; init; }
+    public IReadOnlyList<DeploymentReviewReviewer>? Reviewers { get; init; }
 
     [JsonPropertyName("approver")]
     public User? Approver { get; init; }

--- a/src/Octokit.Webhooks/Events/DeploymentStatusEvent.cs
+++ b/src/Octokit.Webhooks/Events/DeploymentStatusEvent.cs
@@ -6,10 +6,10 @@ namespace Octokit.Webhooks.Events;
 public abstract record DeploymentStatusEvent : WebhookEvent
 {
     [JsonPropertyName("deployment_status")]
-    public Models.DeploymentStatusEvent.DeploymentStatus DeploymentStatus { get; init; } = null!;
+    public required Models.DeploymentStatusEvent.DeploymentStatus DeploymentStatus { get; init; }
 
     [JsonPropertyName("deployment")]
-    public Models.DeploymentStatusEvent.Deployment Deployment { get; init; } = null!;
+    public required Models.DeploymentStatusEvent.Deployment Deployment { get; init; }
 
     [JsonPropertyName("check_run")]
     public Models.DeploymentEvent.DeploymentCheckRun? CheckRun { get; init; }

--- a/src/Octokit.Webhooks/Events/Discussion/DiscussionAnsweredEvent.cs
+++ b/src/Octokit.Webhooks/Events/Discussion/DiscussionAnsweredEvent.cs
@@ -8,5 +8,5 @@ public sealed record DiscussionAnsweredEvent : DiscussionEvent
     public override string Action => DiscussionAction.Answered;
 
     [JsonPropertyName("answer")]
-    public DiscussionAnswer Answer { get; init; } = null!;
+    public required DiscussionAnswer Answer { get; init; }
 }

--- a/src/Octokit.Webhooks/Events/Discussion/DiscussionCategoryChangedEvent.cs
+++ b/src/Octokit.Webhooks/Events/Discussion/DiscussionCategoryChangedEvent.cs
@@ -10,5 +10,5 @@ public sealed record DiscussionCategoryChangedEvent : DiscussionEvent
     public override string Action => DiscussionAction.CategoryChanged;
 
     [JsonPropertyName("changes")]
-    public Changes Changes { get; init; } = null!;
+    public required Changes Changes { get; init; }
 }

--- a/src/Octokit.Webhooks/Events/Discussion/DiscussionEditedEvent.cs
+++ b/src/Octokit.Webhooks/Events/Discussion/DiscussionEditedEvent.cs
@@ -10,5 +10,5 @@ public sealed record DiscussionEditedEvent : DiscussionEvent
     public override string Action => DiscussionAction.Edited;
 
     [JsonPropertyName("changes")]
-    public Changes Changes { get; init; } = null!;
+    public required Changes Changes { get; init; }
 }

--- a/src/Octokit.Webhooks/Events/Discussion/DiscussionLabeledEvent.cs
+++ b/src/Octokit.Webhooks/Events/Discussion/DiscussionLabeledEvent.cs
@@ -8,5 +8,5 @@ public sealed record DiscussionLabeledEvent : DiscussionEvent
     public override string Action => DiscussionAction.Labeled;
 
     [JsonPropertyName("label")]
-    public Octokit.Webhooks.Models.Label Label { get; init; } = null!;
+    public required Octokit.Webhooks.Models.Label Label { get; init; }
 }

--- a/src/Octokit.Webhooks/Events/Discussion/DiscussionTransferredEvent.cs
+++ b/src/Octokit.Webhooks/Events/Discussion/DiscussionTransferredEvent.cs
@@ -10,5 +10,5 @@ public sealed record DiscussionTransferredEvent : DiscussionEvent
     public override string Action => DiscussionAction.Transferred;
 
     [JsonPropertyName("changes")]
-    public Changes Changes { get; init; } = null!;
+    public required Changes Changes { get; init; }
 }

--- a/src/Octokit.Webhooks/Events/Discussion/DiscussionUnansweredEvent.cs
+++ b/src/Octokit.Webhooks/Events/Discussion/DiscussionUnansweredEvent.cs
@@ -8,5 +8,5 @@ public sealed record DiscussionUnansweredEvent : DiscussionEvent
     public override string Action => DiscussionAction.Unanswered;
 
     [JsonPropertyName("old_answer")]
-    public DiscussionAnswer OldAnswer { get; init; } = null!;
+    public required DiscussionAnswer OldAnswer { get; init; }
 }

--- a/src/Octokit.Webhooks/Events/Discussion/DiscussionUnlabeledEvent.cs
+++ b/src/Octokit.Webhooks/Events/Discussion/DiscussionUnlabeledEvent.cs
@@ -8,5 +8,5 @@ public sealed record DiscussionUnlabeledEvent : DiscussionEvent
     public override string Action => DiscussionAction.Unlabeled;
 
     [JsonPropertyName("label")]
-    public Octokit.Webhooks.Models.Label Label { get; init; } = null!;
+    public required Octokit.Webhooks.Models.Label Label { get; init; }
 }

--- a/src/Octokit.Webhooks/Events/DiscussionComment/DiscussionCommentEditedEvent.cs
+++ b/src/Octokit.Webhooks/Events/DiscussionComment/DiscussionCommentEditedEvent.cs
@@ -10,5 +10,5 @@ public sealed record DiscussionCommentEditedEvent : DiscussionCommentEvent
     public override string Action => DiscussionCommentAction.Edited;
 
     [JsonPropertyName("changes")]
-    public Changes Changes { get; init; } = null!;
+    public required Changes Changes { get; init; }
 }

--- a/src/Octokit.Webhooks/Events/DiscussionCommentEvent.cs
+++ b/src/Octokit.Webhooks/Events/DiscussionCommentEvent.cs
@@ -6,8 +6,8 @@ namespace Octokit.Webhooks.Events;
 public abstract record DiscussionCommentEvent : WebhookEvent
 {
     [JsonPropertyName("comment")]
-    public Models.DiscussionCommentEvent.DiscussionComment Comment { get; init; } = null!;
+    public required Models.DiscussionCommentEvent.DiscussionComment Comment { get; init; }
 
     [JsonPropertyName("discussion")]
-    public Models.Discussion Discussion { get; init; } = null!;
+    public required Models.Discussion Discussion { get; init; }
 }

--- a/src/Octokit.Webhooks/Events/DiscussionEvent.cs
+++ b/src/Octokit.Webhooks/Events/DiscussionEvent.cs
@@ -6,5 +6,5 @@ namespace Octokit.Webhooks.Events;
 public abstract record DiscussionEvent : WebhookEvent
 {
     [JsonPropertyName("discussion")]
-    public Models.Discussion Discussion { get; init; } = null!;
+    public required Models.Discussion Discussion { get; init; }
 }

--- a/src/Octokit.Webhooks/Events/ForkEvent.cs
+++ b/src/Octokit.Webhooks/Events/ForkEvent.cs
@@ -5,5 +5,5 @@ namespace Octokit.Webhooks.Events;
 public sealed record ForkEvent : WebhookEvent
 {
     [JsonPropertyName("forkee")]
-    public Models.Repository Forkee { get; init; } = null!;
+    public required Models.Repository Forkee { get; init; }
 }

--- a/src/Octokit.Webhooks/Events/GollumEvent.cs
+++ b/src/Octokit.Webhooks/Events/GollumEvent.cs
@@ -7,5 +7,5 @@ using Octokit.Webhooks.Models.GollumEvent;
 public sealed record GollumEvent : WebhookEvent
 {
     [JsonPropertyName("pages")]
-    public IEnumerable<Page> Pages { get; init; } = null!;
+    public required IReadOnlyList<Page> Pages { get; init; }
 }

--- a/src/Octokit.Webhooks/Events/InstallationEvent.cs
+++ b/src/Octokit.Webhooks/Events/InstallationEvent.cs
@@ -9,7 +9,7 @@ public abstract record InstallationEvent : WebhookEvent
     public new Models.Installation Installation { get; init; } = null!;
 
     [JsonPropertyName("repositories")]
-    public IEnumerable<Models.InstallationEvent.Repository> Repositories { get; init; } = null!;
+    public IReadOnlyList<Models.InstallationEvent.Repository>? Repositories { get; init; }
 
     [JsonPropertyName("requester")]
     public User? Requester { get; init; }

--- a/src/Octokit.Webhooks/Events/InstallationRepositoriesEvent.cs
+++ b/src/Octokit.Webhooks/Events/InstallationRepositoriesEvent.cs
@@ -10,13 +10,13 @@ public abstract record InstallationRepositoriesEvent : WebhookEvent
 
     [JsonPropertyName("repository_selection")]
     [JsonConverter(typeof(StringEnumConverter<InstallationRepositorySelection>))]
-    public StringEnum<InstallationRepositorySelection> RepositorySelection { get; init; } = null!;
+    public required StringEnum<InstallationRepositorySelection> RepositorySelection { get; init; }
 
     [JsonPropertyName("repositories_added")]
-    public IEnumerable<Models.InstallationRepositoriesEvent.Repository> RepositoriesAdded { get; init; } = null!;
+    public required IReadOnlyList<Models.InstallationRepositoriesEvent.Repository> RepositoriesAdded { get; init; }
 
     [JsonPropertyName("repositories_removed")]
-    public IEnumerable<Models.InstallationRepositoriesEvent.Repository> RepositoriesRemoved { get; init; } = null!;
+    public required IReadOnlyList<Models.InstallationRepositoriesEvent.Repository> RepositoriesRemoved { get; init; }
 
     [JsonPropertyName("requester")]
     public User? Requester { get; init; }

--- a/src/Octokit.Webhooks/Events/InstallationTarget/InstallationTargetRenamedEvent.cs
+++ b/src/Octokit.Webhooks/Events/InstallationTarget/InstallationTargetRenamedEvent.cs
@@ -10,12 +10,12 @@ public sealed record InstallationTargetRenamedEvent : InstallationTargetEvent
     public override string Action => InstallationTargetActionValue.Renamed;
 
     [JsonPropertyName("account")]
-    public User Account { get; init; } = null!;
+    public required User Account { get; init; }
 
     [JsonPropertyName("changes")]
-    public Changes Changes { get; init; } = null!;
+    public required Changes Changes { get; init; }
 
     [JsonPropertyName("target_type")]
     [JsonConverter(typeof(StringEnumConverter<InstallationTargetType>))]
-    public StringEnum<InstallationTargetType> TargetType { get; init; } = null!;
+    public required StringEnum<InstallationTargetType> TargetType { get; init; }
 }

--- a/src/Octokit.Webhooks/Events/IssueComment/IssueCommentEditedEvent.cs
+++ b/src/Octokit.Webhooks/Events/IssueComment/IssueCommentEditedEvent.cs
@@ -10,5 +10,5 @@ public sealed record IssueCommentEditedEvent : IssueCommentEvent
     public override string Action => IssueCommentAction.Edited;
 
     [JsonPropertyName("changes")]
-    public Changes Changes { get; init; } = null!;
+    public required Changes Changes { get; init; }
 }

--- a/src/Octokit.Webhooks/Events/IssueCommentEvent.cs
+++ b/src/Octokit.Webhooks/Events/IssueCommentEvent.cs
@@ -6,8 +6,8 @@ namespace Octokit.Webhooks.Events;
 public abstract record IssueCommentEvent : WebhookEvent
 {
     [JsonPropertyName("issue")]
-    public Issue Issue { get; init; } = null!;
+    public required Issue Issue { get; init; }
 
     [JsonPropertyName("comment")]
-    public Models.IssueComment Comment { get; init; } = null!;
+    public required Models.IssueComment Comment { get; init; }
 }

--- a/src/Octokit.Webhooks/Events/Issues/IssuesDemilestonedEvent.cs
+++ b/src/Octokit.Webhooks/Events/Issues/IssuesDemilestonedEvent.cs
@@ -8,5 +8,5 @@ public sealed record IssuesDemilestonedEvent : IssuesEvent
     public override string Action => IssuesAction.Demilestoned;
 
     [JsonPropertyName("milestone")]
-    public Octokit.Webhooks.Models.Milestone Milestone { get; init; } = null!;
+    public required Octokit.Webhooks.Models.Milestone Milestone { get; init; }
 }

--- a/src/Octokit.Webhooks/Events/Issues/IssuesMilestonedEvent.cs
+++ b/src/Octokit.Webhooks/Events/Issues/IssuesMilestonedEvent.cs
@@ -8,5 +8,5 @@ public sealed record IssuesMilestonedEvent : IssuesEvent
     public override string Action => IssuesAction.Milestoned;
 
     [JsonPropertyName("milestone")]
-    public Octokit.Webhooks.Models.Milestone Milestone { get; init; } = null!;
+    public required Octokit.Webhooks.Models.Milestone Milestone { get; init; }
 }

--- a/src/Octokit.Webhooks/Events/IssuesEvent.cs
+++ b/src/Octokit.Webhooks/Events/IssuesEvent.cs
@@ -6,5 +6,5 @@ namespace Octokit.Webhooks.Events;
 public abstract record IssuesEvent : WebhookEvent
 {
     [JsonPropertyName("issue")]
-    public Issue Issue { get; init; } = null!;
+    public required Issue Issue { get; init; }
 }

--- a/src/Octokit.Webhooks/Events/LabelEvent.cs
+++ b/src/Octokit.Webhooks/Events/LabelEvent.cs
@@ -6,5 +6,5 @@ namespace Octokit.Webhooks.Events;
 public abstract record LabelEvent : WebhookEvent
 {
     [JsonPropertyName("label")]
-    public Models.Label Label { get; init; } = null!;
+    public required Models.Label Label { get; init; }
 }

--- a/src/Octokit.Webhooks/Events/MarketplacePurchaseEvent.cs
+++ b/src/Octokit.Webhooks/Events/MarketplacePurchaseEvent.cs
@@ -6,10 +6,10 @@ namespace Octokit.Webhooks.Events;
 public abstract record MarketplacePurchaseEvent : WebhookEvent
 {
     [JsonPropertyName("effective_date")]
-    public string EffectiveDate { get; init; } = null!;
+    public required string EffectiveDate { get; init; }
 
     [JsonPropertyName("marketplace_purchase")]
-    public Models.MarketplacePurchase MarketplacePurchase { get; init; } = null!;
+    public required Models.MarketplacePurchase MarketplacePurchase { get; init; }
 
     [JsonPropertyName("previous_marketplace_purchase")]
     public Models.MarketplacePurchase? PreviousMarketplacePurchase { get; init; }

--- a/src/Octokit.Webhooks/Events/Member/MemberAddedEvent.cs
+++ b/src/Octokit.Webhooks/Events/Member/MemberAddedEvent.cs
@@ -10,5 +10,5 @@ public sealed record MemberAddedEvent : MemberEvent
     public override string Action => MemberAction.Added;
 
     [JsonPropertyName("changes")]
-    public Changes Changes { get; init; } = null!;
+    public Changes? Changes { get; init; }
 }

--- a/src/Octokit.Webhooks/Events/Member/MemberEditedEvent.cs
+++ b/src/Octokit.Webhooks/Events/Member/MemberEditedEvent.cs
@@ -10,5 +10,5 @@ public sealed record MemberEditedEvent : MemberEvent
     public override string Action => MemberAction.Edited;
 
     [JsonPropertyName("changes")]
-    public Changes Changes { get; init; } = null!;
+    public required Changes Changes { get; init; }
 }

--- a/src/Octokit.Webhooks/Events/MemberEvent.cs
+++ b/src/Octokit.Webhooks/Events/MemberEvent.cs
@@ -6,5 +6,5 @@ namespace Octokit.Webhooks.Events;
 public abstract record MemberEvent : WebhookEvent
 {
     [JsonPropertyName("member")]
-    public User Member { get; init; } = null!;
+    public required User Member { get; init; }
 }

--- a/src/Octokit.Webhooks/Events/MembershipEvent.cs
+++ b/src/Octokit.Webhooks/Events/MembershipEvent.cs
@@ -9,11 +9,11 @@ public abstract record MembershipEvent : WebhookEvent
 {
     [JsonPropertyName("scope")]
     [JsonConverter(typeof(StringEnumConverter<Scope>))]
-    public StringEnum<Scope> Scope { get; init; } = null!;
+    public required StringEnum<Scope> Scope { get; init; }
 
     [JsonPropertyName("member")]
-    public User Member { get; init; } = null!;
+    public required User Member { get; init; }
 
     [JsonPropertyName("team")]
-    public Models.Team Team { get; init; } = null!;
+    public required Models.Team Team { get; init; }
 }

--- a/src/Octokit.Webhooks/Events/MergeGroup/MergeGroupDestroyedEvent.cs
+++ b/src/Octokit.Webhooks/Events/MergeGroup/MergeGroupDestroyedEvent.cs
@@ -8,5 +8,5 @@ public sealed record MergeGroupDestroyedEvent : MergeGroupEvent
     public override string Action => MergeGroupAction.Destroyed;
 
     [JsonPropertyName("reason")]
-    public string Reason { get; init; } = null!;
+    public required string Reason { get; init; }
 }

--- a/src/Octokit.Webhooks/Events/MergeGroupEvent.cs
+++ b/src/Octokit.Webhooks/Events/MergeGroupEvent.cs
@@ -6,5 +6,5 @@ namespace Octokit.Webhooks.Events;
 public abstract record MergeGroupEvent : WebhookEvent
 {
     [JsonPropertyName("merge_group")]
-    public Models.MergeGroupEvent.MergeGroup MergeGroup { get; init; } = null!;
+    public required Models.MergeGroupEvent.MergeGroup MergeGroup { get; init; }
 }

--- a/src/Octokit.Webhooks/Events/MetaEvent.cs
+++ b/src/Octokit.Webhooks/Events/MetaEvent.cs
@@ -11,5 +11,5 @@ public abstract record MetaEvent : WebhookEvent
     public long HookId { get; init; }
 
     [JsonPropertyName("hook")]
-    public Hook Hook { get; init; } = null!;
+    public required Hook Hook { get; init; }
 }

--- a/src/Octokit.Webhooks/Events/Milestone/MilestoneEditedEvent.cs
+++ b/src/Octokit.Webhooks/Events/Milestone/MilestoneEditedEvent.cs
@@ -10,5 +10,5 @@ public sealed record MilestoneEditedEvent : MilestoneEvent
     public override string Action => MilestoneAction.Edited;
 
     [JsonPropertyName("changes")]
-    public Changes Changes { get; init; } = null!;
+    public required Changes Changes { get; init; }
 }

--- a/src/Octokit.Webhooks/Events/MilestoneEvent.cs
+++ b/src/Octokit.Webhooks/Events/MilestoneEvent.cs
@@ -6,5 +6,5 @@ namespace Octokit.Webhooks.Events;
 public abstract record MilestoneEvent : WebhookEvent
 {
     [JsonPropertyName("milestone")]
-    public Models.Milestone Milestone { get; init; } = null!;
+    public required Models.Milestone Milestone { get; init; }
 }

--- a/src/Octokit.Webhooks/Events/OrgBlockEvent.cs
+++ b/src/Octokit.Webhooks/Events/OrgBlockEvent.cs
@@ -6,5 +6,5 @@ namespace Octokit.Webhooks.Events;
 public abstract record OrgBlockEvent : WebhookEvent
 {
     [JsonPropertyName("blocked_user")]
-    public User BlockedUser { get; init; } = null!;
+    public required User BlockedUser { get; init; }
 }

--- a/src/Octokit.Webhooks/Events/Organization/OrganizationMemberAddedEvent.cs
+++ b/src/Octokit.Webhooks/Events/Organization/OrganizationMemberAddedEvent.cs
@@ -8,5 +8,5 @@ public sealed record OrganizationMemberAddedEvent : OrganizationEvent
     public override string Action => OrganizationAction.MemberAdded;
 
     [JsonPropertyName("membership")]
-    public Octokit.Webhooks.Models.Membership Membership { get; init; } = null!;
+    public required Octokit.Webhooks.Models.Membership Membership { get; init; }
 }

--- a/src/Octokit.Webhooks/Events/Organization/OrganizationMemberInvitedEvent.cs
+++ b/src/Octokit.Webhooks/Events/Organization/OrganizationMemberInvitedEvent.cs
@@ -10,8 +10,8 @@ public sealed record OrganizationMemberInvitedEvent : OrganizationEvent
     public override string Action => OrganizationAction.MemberInvited;
 
     [JsonPropertyName("invitation")]
-    public Invitation Invitation { get; init; } = null!;
+    public required Invitation Invitation { get; init; }
 
     [JsonPropertyName("user")]
-    public User User { get; init; } = null!;
+    public required User User { get; init; }
 }

--- a/src/Octokit.Webhooks/Events/Organization/OrganizationMemberRemovedEvent.cs
+++ b/src/Octokit.Webhooks/Events/Organization/OrganizationMemberRemovedEvent.cs
@@ -8,5 +8,5 @@ public sealed record OrganizationMemberRemovedEvent : OrganizationEvent
     public override string Action => OrganizationAction.MemberRemoved;
 
     [JsonPropertyName("membership")]
-    public Octokit.Webhooks.Models.Membership Membership { get; init; } = null!;
+    public required Octokit.Webhooks.Models.Membership Membership { get; init; }
 }

--- a/src/Octokit.Webhooks/Events/Organization/OrganizationRenamedEvent.cs
+++ b/src/Octokit.Webhooks/Events/Organization/OrganizationRenamedEvent.cs
@@ -10,5 +10,5 @@ public sealed record OrganizationRenamedEvent : OrganizationEvent
     public override string Action => OrganizationAction.Renamed;
 
     [JsonPropertyName("changes")]
-    public Changes Changes { get; init; } = null!;
+    public required Changes Changes { get; init; }
 }

--- a/src/Octokit.Webhooks/Events/PackageEvent.cs
+++ b/src/Octokit.Webhooks/Events/PackageEvent.cs
@@ -6,5 +6,5 @@ namespace Octokit.Webhooks.Events;
 public abstract record PackageEvent : WebhookEvent
 {
     [JsonPropertyName("package")]
-    public Models.Package Package { get; init; } = null!;
+    public required Models.Package Package { get; init; }
 }

--- a/src/Octokit.Webhooks/Events/PageBuildEvent.cs
+++ b/src/Octokit.Webhooks/Events/PageBuildEvent.cs
@@ -10,5 +10,5 @@ public sealed record PageBuildEvent : WebhookEvent
     public long Id { get; init; }
 
     [JsonPropertyName("build")]
-    public Build Build { get; init; } = null!;
+    public required Build Build { get; init; }
 }

--- a/src/Octokit.Webhooks/Events/PersonalAccessTokenRequestEvent.cs
+++ b/src/Octokit.Webhooks/Events/PersonalAccessTokenRequestEvent.cs
@@ -6,5 +6,5 @@ namespace Octokit.Webhooks.Events;
 public abstract record PersonalAccessTokenRequestEvent : WebhookEvent
 {
     [JsonPropertyName("personal_access_token_request")]
-    public Models.PersonalAccessTokenRequestEvent.PersonalAccessTokenRequest PersonalAccessTokenRequest { get; init; } = null!;
+    public required Models.PersonalAccessTokenRequestEvent.PersonalAccessTokenRequest PersonalAccessTokenRequest { get; init; }
 }

--- a/src/Octokit.Webhooks/Events/PingEvent.cs
+++ b/src/Octokit.Webhooks/Events/PingEvent.cs
@@ -7,11 +7,11 @@ using Octokit.Webhooks.Models.PingEvent;
 public sealed record PingEvent : WebhookEvent
 {
     [JsonPropertyName("zen")]
-    public string Zen { get; init; } = null!;
+    public required string Zen { get; init; }
 
     [JsonPropertyName("hook_id")]
     public long HookId { get; init; }
 
     [JsonPropertyName("hook")]
-    public Hook Hook { get; init; } = null!;
+    public required Hook Hook { get; init; }
 }

--- a/src/Octokit.Webhooks/Events/Project/ProjectEditedEvent.cs
+++ b/src/Octokit.Webhooks/Events/Project/ProjectEditedEvent.cs
@@ -10,5 +10,5 @@ public sealed record ProjectEditedEvent : ProjectEvent
     public override string Action => ProjectAction.Edited;
 
     [JsonPropertyName("changes")]
-    public Changes Changes { get; init; } = null!;
+    public required Changes Changes { get; init; }
 }

--- a/src/Octokit.Webhooks/Events/ProjectCard/ProjectCardConvertedEvent.cs
+++ b/src/Octokit.Webhooks/Events/ProjectCard/ProjectCardConvertedEvent.cs
@@ -10,5 +10,5 @@ public sealed record ProjectCardConvertedEvent : ProjectCardEvent
     public override string Action => ProjectCardAction.Converted;
 
     [JsonPropertyName("changes")]
-    public Changes Changes { get; init; } = null!;
+    public required Changes Changes { get; init; }
 }

--- a/src/Octokit.Webhooks/Events/ProjectCard/ProjectCardEditedEvent.cs
+++ b/src/Octokit.Webhooks/Events/ProjectCard/ProjectCardEditedEvent.cs
@@ -10,5 +10,5 @@ public sealed record ProjectCardEditedEvent : ProjectCardEvent
     public override string Action => ProjectCardAction.Edited;
 
     [JsonPropertyName("changes")]
-    public Changes Changes { get; init; } = null!;
+    public required Changes Changes { get; init; }
 }

--- a/src/Octokit.Webhooks/Events/ProjectCardEvent.cs
+++ b/src/Octokit.Webhooks/Events/ProjectCardEvent.cs
@@ -6,5 +6,5 @@ namespace Octokit.Webhooks.Events;
 public abstract record ProjectCardEvent : WebhookEvent
 {
     [JsonPropertyName("project_card")]
-    public Models.ProjectCard ProjectCard { get; init; } = null!;
+    public required Models.ProjectCard ProjectCard { get; init; }
 }

--- a/src/Octokit.Webhooks/Events/ProjectColumn/ProjectColumnEditedEvent.cs
+++ b/src/Octokit.Webhooks/Events/ProjectColumn/ProjectColumnEditedEvent.cs
@@ -10,5 +10,5 @@ public sealed record ProjectColumnEditedEvent : ProjectColumnEvent
     public override string Action => ProjectColumnAction.Edited;
 
     [JsonPropertyName("changes")]
-    public Changes Changes { get; init; } = null!;
+    public required Changes Changes { get; init; }
 }

--- a/src/Octokit.Webhooks/Events/ProjectColumnEvent.cs
+++ b/src/Octokit.Webhooks/Events/ProjectColumnEvent.cs
@@ -6,5 +6,5 @@ namespace Octokit.Webhooks.Events;
 public abstract record ProjectColumnEvent : WebhookEvent
 {
     [JsonPropertyName("project_column")]
-    public Models.ProjectColumn ProjectColumn { get; init; } = null!;
+    public required Models.ProjectColumn ProjectColumn { get; init; }
 }

--- a/src/Octokit.Webhooks/Events/ProjectEvent.cs
+++ b/src/Octokit.Webhooks/Events/ProjectEvent.cs
@@ -6,5 +6,5 @@ namespace Octokit.Webhooks.Events;
 public abstract record ProjectEvent : WebhookEvent
 {
     [JsonPropertyName("project")]
-    public Models.Project Project { get; init; } = null!;
+    public required Models.Project Project { get; init; }
 }

--- a/src/Octokit.Webhooks/Events/ProjectsV2Item/ProjectsV2ItemArchivedEvent.cs
+++ b/src/Octokit.Webhooks/Events/ProjectsV2Item/ProjectsV2ItemArchivedEvent.cs
@@ -10,5 +10,5 @@ public sealed record ProjectsV2ItemArchivedEvent : ProjectsV2ItemEvent
     public override string Action => ProjectsV2ItemAction.Archived;
 
     [JsonPropertyName("changes")]
-    public Changes Changes { get; init; } = null!;
+    public required Changes Changes { get; init; }
 }

--- a/src/Octokit.Webhooks/Events/ProjectsV2Item/ProjectsV2ItemConvertedEvent.cs
+++ b/src/Octokit.Webhooks/Events/ProjectsV2Item/ProjectsV2ItemConvertedEvent.cs
@@ -10,5 +10,5 @@ public sealed record ProjectsV2ItemConvertedEvent : ProjectsV2ItemEvent
     public override string Action => ProjectsV2ItemAction.Converted;
 
     [JsonPropertyName("changes")]
-    public Changes Changes { get; init; } = null!;
+    public required Changes Changes { get; init; }
 }

--- a/src/Octokit.Webhooks/Events/ProjectsV2Item/ProjectsV2ItemEditedEvent.cs
+++ b/src/Octokit.Webhooks/Events/ProjectsV2Item/ProjectsV2ItemEditedEvent.cs
@@ -10,5 +10,5 @@ public sealed record ProjectsV2ItemEditedEvent : ProjectsV2ItemEvent
     public override string Action => ProjectsV2ItemAction.Edited;
 
     [JsonPropertyName("changes")]
-    public Changes Changes { get; init; } = null!;
+    public required Changes Changes { get; init; }
 }

--- a/src/Octokit.Webhooks/Events/ProjectsV2Item/ProjectsV2ItemReorderedEvent.cs
+++ b/src/Octokit.Webhooks/Events/ProjectsV2Item/ProjectsV2ItemReorderedEvent.cs
@@ -10,5 +10,5 @@ public sealed record ProjectsV2ItemReorderedEvent : ProjectsV2ItemEvent
     public override string Action => ProjectsV2ItemAction.Reordered;
 
     [JsonPropertyName("changes")]
-    public Changes Changes { get; init; } = null!;
+    public required Changes Changes { get; init; }
 }

--- a/src/Octokit.Webhooks/Events/ProjectsV2Item/ProjectsV2ItemRestoredEvent.cs
+++ b/src/Octokit.Webhooks/Events/ProjectsV2Item/ProjectsV2ItemRestoredEvent.cs
@@ -10,5 +10,5 @@ public sealed record ProjectsV2ItemRestoredEvent : ProjectsV2ItemEvent
     public override string Action => ProjectsV2ItemAction.Restored;
 
     [JsonPropertyName("changes")]
-    public Changes Changes { get; init; } = null!;
+    public required Changes Changes { get; init; }
 }

--- a/src/Octokit.Webhooks/Events/ProjectsV2ItemEvent.cs
+++ b/src/Octokit.Webhooks/Events/ProjectsV2ItemEvent.cs
@@ -6,5 +6,5 @@ namespace Octokit.Webhooks.Events;
 public abstract record ProjectsV2ItemEvent : WebhookEvent
 {
     [JsonPropertyName("projects_v2_item")]
-    public Models.ProjectsV2Item ProjectsV2Item { get; init; } = null!;
+    public required Models.ProjectsV2Item ProjectsV2Item { get; init; }
 }

--- a/src/Octokit.Webhooks/Events/ProjectsV2Project/ProjectsV2ProjectEditedEvent.cs
+++ b/src/Octokit.Webhooks/Events/ProjectsV2Project/ProjectsV2ProjectEditedEvent.cs
@@ -8,5 +8,5 @@ public sealed record ProjectsV2ProjectEditedEvent : ProjectsV2ProjectEvent
     public override string Action => ProjectsV2ProjectAction.Edited;
 
     [JsonPropertyName("changes")]
-    public Models.ProjectsV2ProjectEvent.Changes Changes { get; init; } = null!;
+    public required Models.ProjectsV2ProjectEvent.Changes Changes { get; init; }
 }

--- a/src/Octokit.Webhooks/Events/ProjectsV2ProjectEvent.cs
+++ b/src/Octokit.Webhooks/Events/ProjectsV2ProjectEvent.cs
@@ -6,5 +6,5 @@ namespace Octokit.Webhooks.Events;
 public abstract record ProjectsV2ProjectEvent : WebhookEvent
 {
     [JsonPropertyName("projects_v2")]
-    public Models.ProjectsV2ProjectEvent.ProjectsV2 ProjectsV2 { get; init; } = null!;
+    public required Models.ProjectsV2ProjectEvent.ProjectsV2 ProjectsV2 { get; init; }
 }

--- a/src/Octokit.Webhooks/Events/ProjectsV2StatusUpdate/ProjectsV2StatusUpdateEditedEvent.cs
+++ b/src/Octokit.Webhooks/Events/ProjectsV2StatusUpdate/ProjectsV2StatusUpdateEditedEvent.cs
@@ -8,5 +8,5 @@ public sealed record ProjectsV2StatusUpdateEditedEvent : ProjectsV2StatusUpdateE
     public override string Action => ProjectsV2StatusUpdateAction.Edited;
 
     [JsonPropertyName("changes")]
-    public Models.ProjectsV2StatusUpdateEvent.Changes Changes { get; init; } = null!;
+    public required Models.ProjectsV2StatusUpdateEvent.Changes Changes { get; init; }
 }

--- a/src/Octokit.Webhooks/Events/ProjectsV2StatusUpdateEvent.cs
+++ b/src/Octokit.Webhooks/Events/ProjectsV2StatusUpdateEvent.cs
@@ -6,5 +6,5 @@ namespace Octokit.Webhooks.Events;
 public abstract record ProjectsV2StatusUpdateEvent : WebhookEvent
 {
     [JsonPropertyName("projects_v2_status_update")]
-    public Models.ProjectsV2StatusUpdateEvent.ProjectsV2StatusUpdate ProjectsV2StatusUpdate { get; init; } = null!;
+    public required Models.ProjectsV2StatusUpdateEvent.ProjectsV2StatusUpdate ProjectsV2StatusUpdate { get; init; }
 }

--- a/src/Octokit.Webhooks/Events/PullRequest/PullRequestAssignedEvent.cs
+++ b/src/Octokit.Webhooks/Events/PullRequest/PullRequestAssignedEvent.cs
@@ -8,5 +8,5 @@ public sealed record PullRequestAssignedEvent : PullRequestEvent
     public override string Action => PullRequestAction.Assigned;
 
     [JsonPropertyName("assignee")]
-    public User Assignee { get; init; } = null!;
+    public required User Assignee { get; init; }
 }

--- a/src/Octokit.Webhooks/Events/PullRequest/PullRequestDemilestonedEvent.cs
+++ b/src/Octokit.Webhooks/Events/PullRequest/PullRequestDemilestonedEvent.cs
@@ -10,5 +10,5 @@ public sealed record PullRequestDemilestonedEvent : PullRequestEvent
     public override string Action => PullRequestAction.Demilestoned;
 
     [JsonPropertyName("milestone")]
-    public Milestone Milestone { get; init; } = null!;
+    public required Milestone Milestone { get; init; }
 }

--- a/src/Octokit.Webhooks/Events/PullRequest/PullRequestDequeuedEvent.cs
+++ b/src/Octokit.Webhooks/Events/PullRequest/PullRequestDequeuedEvent.cs
@@ -8,5 +8,5 @@ public sealed record PullRequestDequeuedEvent : PullRequestEvent
     public override string Action => PullRequestAction.Dequeued;
 
     [JsonPropertyName("reason")]
-    public string Reason { get; init; } = null!;
+    public required string Reason { get; init; }
 }

--- a/src/Octokit.Webhooks/Events/PullRequest/PullRequestEditedEvent.cs
+++ b/src/Octokit.Webhooks/Events/PullRequest/PullRequestEditedEvent.cs
@@ -10,5 +10,5 @@ public sealed record PullRequestEditedEvent : PullRequestEvent
     public override string Action => PullRequestAction.Edited;
 
     [JsonPropertyName("changes")]
-    public PullRequestEditedEventChanges Changes { get; init; } = null!;
+    public required PullRequestEditedEventChanges Changes { get; init; }
 }

--- a/src/Octokit.Webhooks/Events/PullRequest/PullRequestLabeledEvent.cs
+++ b/src/Octokit.Webhooks/Events/PullRequest/PullRequestLabeledEvent.cs
@@ -8,5 +8,5 @@ public sealed record PullRequestLabeledEvent : PullRequestEvent
     public override string Action => PullRequestAction.Labeled;
 
     [JsonPropertyName("label")]
-    public Octokit.Webhooks.Models.Label Label { get; init; } = null!;
+    public required Octokit.Webhooks.Models.Label Label { get; init; }
 }

--- a/src/Octokit.Webhooks/Events/PullRequest/PullRequestMilestonedEvent.cs
+++ b/src/Octokit.Webhooks/Events/PullRequest/PullRequestMilestonedEvent.cs
@@ -10,5 +10,5 @@ public sealed record PullRequestMilestonedEvent : PullRequestEvent
     public override string Action => PullRequestAction.Milestoned;
 
     [JsonPropertyName("milestone")]
-    public Milestone Milestone { get; init; } = null!;
+    public required Milestone Milestone { get; init; }
 }

--- a/src/Octokit.Webhooks/Events/PullRequest/PullRequestSynchronizeEvent.cs
+++ b/src/Octokit.Webhooks/Events/PullRequest/PullRequestSynchronizeEvent.cs
@@ -8,8 +8,8 @@ public sealed record PullRequestSynchronizeEvent : PullRequestEvent
     public override string Action => PullRequestAction.Synchronize;
 
     [JsonPropertyName("before")]
-    public string Before { get; init; } = null!;
+    public required string Before { get; init; }
 
     [JsonPropertyName("after")]
-    public string After { get; init; } = null!;
+    public required string After { get; init; }
 }

--- a/src/Octokit.Webhooks/Events/PullRequest/PullRequestUnassignedEvent.cs
+++ b/src/Octokit.Webhooks/Events/PullRequest/PullRequestUnassignedEvent.cs
@@ -8,5 +8,5 @@ public sealed record PullRequestUnassignedEvent : PullRequestEvent
     public override string Action => PullRequestAction.Unassigned;
 
     [JsonPropertyName("assignee")]
-    public User Assignee { get; init; } = null!;
+    public required User Assignee { get; init; }
 }

--- a/src/Octokit.Webhooks/Events/PullRequest/PullRequestUnlabeledEvent.cs
+++ b/src/Octokit.Webhooks/Events/PullRequest/PullRequestUnlabeledEvent.cs
@@ -8,5 +8,5 @@ public sealed record PullRequestUnlabeledEvent : PullRequestEvent
     public override string Action => PullRequestAction.Unlabeled;
 
     [JsonPropertyName("label")]
-    public Octokit.Webhooks.Models.Label Label { get; init; } = null!;
+    public required Octokit.Webhooks.Models.Label Label { get; init; }
 }

--- a/src/Octokit.Webhooks/Events/PullRequestEvent.cs
+++ b/src/Octokit.Webhooks/Events/PullRequestEvent.cs
@@ -9,5 +9,5 @@ public abstract record PullRequestEvent : WebhookEvent
     public long Number { get; init; }
 
     [JsonPropertyName("pull_request")]
-    public Models.PullRequestEvent.PullRequest PullRequest { get; init; } = null!;
+    public required Models.PullRequestEvent.PullRequest PullRequest { get; init; }
 }

--- a/src/Octokit.Webhooks/Events/PullRequestReview/PullRequestReviewEditedEvent.cs
+++ b/src/Octokit.Webhooks/Events/PullRequestReview/PullRequestReviewEditedEvent.cs
@@ -10,5 +10,5 @@ public sealed record PullRequestReviewEditedEvent : PullRequestReviewEvent
     public override string Action => PullRequestReviewAction.Edited;
 
     [JsonPropertyName("changes")]
-    public Changes Changes { get; init; } = null!;
+    public required Changes Changes { get; init; }
 }

--- a/src/Octokit.Webhooks/Events/PullRequestReviewComment/PullRequestReviewCommentEditedEvent.cs
+++ b/src/Octokit.Webhooks/Events/PullRequestReviewComment/PullRequestReviewCommentEditedEvent.cs
@@ -10,5 +10,5 @@ public sealed record PullRequestReviewCommentEditedEvent : PullRequestReviewComm
     public override string Action => PullRequestReviewCommentAction.Edited;
 
     [JsonPropertyName("changes")]
-    public Changes Changes { get; init; } = null!;
+    public required Changes Changes { get; init; }
 }

--- a/src/Octokit.Webhooks/Events/PullRequestReviewCommentEvent.cs
+++ b/src/Octokit.Webhooks/Events/PullRequestReviewCommentEvent.cs
@@ -6,8 +6,8 @@ namespace Octokit.Webhooks.Events;
 public abstract record PullRequestReviewCommentEvent : WebhookEvent
 {
     [JsonPropertyName("comment")]
-    public Models.PullRequestReviewComment Comment { get; init; } = null!;
+    public required Models.PullRequestReviewComment Comment { get; init; }
 
     [JsonPropertyName("pull_request")]
-    public SimplePullRequest PullRequest { get; init; } = null!;
+    public required SimplePullRequest PullRequest { get; init; }
 }

--- a/src/Octokit.Webhooks/Events/PullRequestReviewEvent.cs
+++ b/src/Octokit.Webhooks/Events/PullRequestReviewEvent.cs
@@ -8,8 +8,8 @@ using Octokit.Webhooks.Models.PullRequestReviewEvent;
 public abstract record PullRequestReviewEvent : WebhookEvent
 {
     [JsonPropertyName("review")]
-    public Review Review { get; init; } = null!;
+    public required Review Review { get; init; }
 
     [JsonPropertyName("pull_request")]
-    public SimplePullRequest PullRequest { get; init; } = null!;
+    public required SimplePullRequest PullRequest { get; init; }
 }

--- a/src/Octokit.Webhooks/Events/PullRequestReviewThreadEvent.cs
+++ b/src/Octokit.Webhooks/Events/PullRequestReviewThreadEvent.cs
@@ -8,8 +8,8 @@ using Octokit.Webhooks.Models.PullRequestReviewEvent;
 public abstract record PullRequestReviewThreadEvent : WebhookEvent
 {
     [JsonPropertyName("review")]
-    public Review Review { get; init; } = null!;
+    public Review? Review { get; init; }
 
     [JsonPropertyName("pull_request")]
-    public SimplePullRequest PullRequest { get; init; } = null!;
+    public required SimplePullRequest PullRequest { get; init; }
 }

--- a/src/Octokit.Webhooks/Events/PushEvent.cs
+++ b/src/Octokit.Webhooks/Events/PushEvent.cs
@@ -7,13 +7,13 @@ using Octokit.Webhooks.Models.PushEvent;
 public sealed record PushEvent : WebhookEvent
 {
     [JsonPropertyName("ref")]
-    public string Ref { get; init; } = null!;
+    public required string Ref { get; init; }
 
     [JsonPropertyName("before")]
-    public string Before { get; init; } = null!;
+    public required string Before { get; init; }
 
     [JsonPropertyName("after")]
-    public string After { get; init; } = null!;
+    public required string After { get; init; }
 
     [JsonPropertyName("created")]
     public bool Created { get; init; }
@@ -28,14 +28,14 @@ public sealed record PushEvent : WebhookEvent
     public string? BaseRef { get; init; }
 
     [JsonPropertyName("compare")]
-    public string Compare { get; init; } = null!;
+    public required string Compare { get; init; }
 
     [JsonPropertyName("commits")]
-    public IEnumerable<Commit> Commits { get; init; } = null!;
+    public required IReadOnlyList<Commit> Commits { get; init; }
 
     [JsonPropertyName("head_commit")]
     public Commit? HeadCommit { get; init; }
 
     [JsonPropertyName("pusher")]
-    public Committer Pusher { get; init; } = null!;
+    public required Committer Pusher { get; init; }
 }

--- a/src/Octokit.Webhooks/Events/RegistryPackageEvent.cs
+++ b/src/Octokit.Webhooks/Events/RegistryPackageEvent.cs
@@ -6,5 +6,5 @@ namespace Octokit.Webhooks.Events;
 public abstract record RegistryPackageEvent : WebhookEvent
 {
     [JsonPropertyName("registry_package")]
-    public Models.Package Package { get; init; } = null!;
+    public required Models.Package Package { get; init; }
 }

--- a/src/Octokit.Webhooks/Events/Release/ReleaseEditedEvent.cs
+++ b/src/Octokit.Webhooks/Events/Release/ReleaseEditedEvent.cs
@@ -10,5 +10,5 @@ public sealed record ReleaseEditedEvent : ReleaseEvent
     public override string Action => ReleaseAction.Edited;
 
     [JsonPropertyName("changes")]
-    public Changes Changes { get; init; } = null!;
+    public required Changes Changes { get; init; }
 }

--- a/src/Octokit.Webhooks/Events/ReleaseEvent.cs
+++ b/src/Octokit.Webhooks/Events/ReleaseEvent.cs
@@ -6,5 +6,5 @@ namespace Octokit.Webhooks.Events;
 public abstract record ReleaseEvent : WebhookEvent
 {
     [JsonPropertyName("release")]
-    public Models.Release Release { get; init; } = null!;
+    public required Models.Release Release { get; init; }
 }

--- a/src/Octokit.Webhooks/Events/Repository/RepositoryEditedEvent.cs
+++ b/src/Octokit.Webhooks/Events/Repository/RepositoryEditedEvent.cs
@@ -10,5 +10,5 @@ public sealed record RepositoryEditedEvent : RepositoryEvent
     public override string Action => RepositoryAction.Edited;
 
     [JsonPropertyName("changes")]
-    public Changes Changes { get; init; } = null!;
+    public required Changes Changes { get; init; }
 }

--- a/src/Octokit.Webhooks/Events/Repository/RepositoryRenamedEvent.cs
+++ b/src/Octokit.Webhooks/Events/Repository/RepositoryRenamedEvent.cs
@@ -10,5 +10,5 @@ public sealed record RepositoryRenamedEvent : RepositoryEvent
     public override string Action => RepositoryAction.Renamed;
 
     [JsonPropertyName("changes")]
-    public Changes Changes { get; init; } = null!;
+    public required Changes Changes { get; init; }
 }

--- a/src/Octokit.Webhooks/Events/Repository/RepositoryTransferredEvent.cs
+++ b/src/Octokit.Webhooks/Events/Repository/RepositoryTransferredEvent.cs
@@ -10,5 +10,5 @@ public sealed record RepositoryTransferredEvent : RepositoryEvent
     public override string Action => RepositoryAction.Transferred;
 
     [JsonPropertyName("changes")]
-    public Changes Changes { get; init; } = null!;
+    public required Changes Changes { get; init; }
 }

--- a/src/Octokit.Webhooks/Events/RepositoryAdvisoryEvent.cs
+++ b/src/Octokit.Webhooks/Events/RepositoryAdvisoryEvent.cs
@@ -6,5 +6,5 @@ namespace Octokit.Webhooks.Events;
 public abstract record RepositoryAdvisoryEvent : WebhookEvent
 {
     [JsonPropertyName("repository_advisory")]
-    public Models.RepositoryAdvisoryEvent.RepositoryAdvisory RepositoryAdvisory { get; init; } = null!;
+    public required Models.RepositoryAdvisoryEvent.RepositoryAdvisory RepositoryAdvisory { get; init; }
 }

--- a/src/Octokit.Webhooks/Events/RepositoryDispatchEvent.cs
+++ b/src/Octokit.Webhooks/Events/RepositoryDispatchEvent.cs
@@ -9,5 +9,5 @@ public abstract record RepositoryDispatchEvent : WebhookEvent
     public required string Branch { get; init; }
 
     [JsonPropertyName("client_payload")]
-    public required dynamic ClientPayload { get; init; }
+    public required JsonElement ClientPayload { get; init; }
 }

--- a/src/Octokit.Webhooks/Events/RepositoryDispatchEvent.cs
+++ b/src/Octokit.Webhooks/Events/RepositoryDispatchEvent.cs
@@ -6,8 +6,8 @@ namespace Octokit.Webhooks.Events;
 public abstract record RepositoryDispatchEvent : WebhookEvent
 {
     [JsonPropertyName("branch")]
-    public string Branch { get; init; } = null!;
+    public required string Branch { get; init; }
 
     [JsonPropertyName("client_payload")]
-    public dynamic ClientPayload { get; init; } = null!;
+    public required dynamic ClientPayload { get; init; }
 }

--- a/src/Octokit.Webhooks/Events/RepositoryImportEvent.cs
+++ b/src/Octokit.Webhooks/Events/RepositoryImportEvent.cs
@@ -8,5 +8,5 @@ public sealed record RepositoryImportEvent : WebhookEvent
 {
     [JsonPropertyName("status")]
     [JsonConverter(typeof(StringEnumConverter<Status>))]
-    public StringEnum<Status> Status { get; init; } = null!;
+    public required StringEnum<Status> Status { get; init; }
 }

--- a/src/Octokit.Webhooks/Events/RepositoryVulnerabilityAlertEvent.cs
+++ b/src/Octokit.Webhooks/Events/RepositoryVulnerabilityAlertEvent.cs
@@ -8,5 +8,5 @@ using Octokit.Webhooks.Models.RepositoryVulnerabilityAlertEvent;
 public abstract record RepositoryVulnerabilityAlertEvent : WebhookEvent
 {
     [JsonPropertyName("alert")]
-    public Alert Alert { get; init; } = null!;
+    public required Alert Alert { get; init; }
 }

--- a/src/Octokit.Webhooks/Events/SecretScanningAlertEvent.cs
+++ b/src/Octokit.Webhooks/Events/SecretScanningAlertEvent.cs
@@ -8,5 +8,5 @@ using Octokit.Webhooks.Models.SecretScanningAlertEvent;
 public abstract record SecretScanningAlertEvent : WebhookEvent
 {
     [JsonPropertyName("alert")]
-    public Alert Alert { get; init; } = null!;
+    public required Alert Alert { get; init; }
 }

--- a/src/Octokit.Webhooks/Events/SecretScanningAlertLocationEvent.cs
+++ b/src/Octokit.Webhooks/Events/SecretScanningAlertLocationEvent.cs
@@ -8,5 +8,5 @@ using Octokit.Webhooks.Models.SecretScanningAlertEvent;
 public abstract record SecretScanningAlertLocationEvent : WebhookEvent
 {
     [JsonPropertyName("alert")]
-    public Alert Alert { get; init; } = null!;
+    public required Alert Alert { get; init; }
 }

--- a/src/Octokit.Webhooks/Events/SecretScanningScanEvent.cs
+++ b/src/Octokit.Webhooks/Events/SecretScanningScanEvent.cs
@@ -6,10 +6,10 @@ namespace Octokit.Webhooks.Events;
 public abstract record SecretScanningScanEvent : WebhookEvent
 {
     [JsonPropertyName("type")]
-    public string Type { get; init; } = null!;
+    public required string Type { get; init; }
 
     [JsonPropertyName("source")]
-    public string Source { get; init; } = null!;
+    public required string Source { get; init; }
 
     [JsonPropertyName("started_at")]
     public DateTimeOffset StartedAt { get; init; }
@@ -18,7 +18,7 @@ public abstract record SecretScanningScanEvent : WebhookEvent
     public DateTimeOffset CompletedAt { get; init; }
 
     [JsonPropertyName("secret_types")]
-    public IEnumerable<string>? SecretTypes { get; init; }
+    public IReadOnlyList<string>? SecretTypes { get; init; }
 
     [JsonPropertyName("custom_pattern_name")]
     public string? CustomPatternName { get; init; }

--- a/src/Octokit.Webhooks/Events/SecurityAdvisoryEvent.cs
+++ b/src/Octokit.Webhooks/Events/SecurityAdvisoryEvent.cs
@@ -6,5 +6,5 @@ namespace Octokit.Webhooks.Events;
 public abstract record SecurityAdvisoryEvent : WebhookEvent
 {
     [JsonPropertyName("security_advisory")]
-    public Models.SecurityAdvisoryEvent.SecurityAdvisory SecurityAdvisory { get; init; } = null!;
+    public required Models.SecurityAdvisoryEvent.SecurityAdvisory SecurityAdvisory { get; init; }
 }

--- a/src/Octokit.Webhooks/Events/SecurityAndAnalysisEvent.cs
+++ b/src/Octokit.Webhooks/Events/SecurityAndAnalysisEvent.cs
@@ -5,5 +5,5 @@ namespace Octokit.Webhooks.Events;
 public sealed record SecurityAndAnalysisEvent : WebhookEvent
 {
     [JsonPropertyName("changes")]
-    public Models.SecurityAndAnalysisEvent.Changes Changes { get; init; } = null!;
+    public required Models.SecurityAndAnalysisEvent.Changes Changes { get; init; }
 }

--- a/src/Octokit.Webhooks/Events/Sponsorship/SponsorshipEditedEvent.cs
+++ b/src/Octokit.Webhooks/Events/Sponsorship/SponsorshipEditedEvent.cs
@@ -10,5 +10,5 @@ public sealed record SponsorshipEditedEvent : SponsorshipEvent
     public override string Action => SponsorshipAction.Edited;
 
     [JsonPropertyName("changes")]
-    public Changes Changes { get; init; } = null!;
+    public required Changes Changes { get; init; }
 }

--- a/src/Octokit.Webhooks/Events/Sponsorship/SponsorshipTierChangedEvent.cs
+++ b/src/Octokit.Webhooks/Events/Sponsorship/SponsorshipTierChangedEvent.cs
@@ -10,5 +10,5 @@ public sealed record SponsorshipTierChangedEvent : SponsorshipEvent
     public override string Action => SponsorshipAction.TierChanged;
 
     [JsonPropertyName("changes")]
-    public Changes Changes { get; init; } = null!;
+    public required Changes Changes { get; init; }
 }

--- a/src/Octokit.Webhooks/Events/SponsorshipEvent.cs
+++ b/src/Octokit.Webhooks/Events/SponsorshipEvent.cs
@@ -6,5 +6,5 @@ namespace Octokit.Webhooks.Events;
 public abstract record SponsorshipEvent : WebhookEvent
 {
     [JsonPropertyName("sponsorship")]
-    public Models.SponsorshipEvent.Sponsorship Sponsorship { get; init; } = null!;
+    public required Models.SponsorshipEvent.Sponsorship Sponsorship { get; init; }
 }

--- a/src/Octokit.Webhooks/Events/StatusEvent.cs
+++ b/src/Octokit.Webhooks/Events/StatusEvent.cs
@@ -10,10 +10,10 @@ public sealed record StatusEvent : WebhookEvent
     public long Id { get; init; }
 
     [JsonPropertyName("sha")]
-    public string Sha { get; init; } = null!;
+    public required string Sha { get; init; }
 
     [JsonPropertyName("name")]
-    public string Name { get; init; } = null!;
+    public required string Name { get; init; }
 
     [JsonPropertyName("avatar_url")]
     public string? AvatarUrl { get; init; }
@@ -22,20 +22,20 @@ public sealed record StatusEvent : WebhookEvent
     public string? TargetUrl { get; init; }
 
     [JsonPropertyName("context")]
-    public string Context { get; init; } = null!;
+    public required string Context { get; init; }
 
     [JsonPropertyName("description")]
     public string? Description { get; init; }
 
     [JsonPropertyName("state")]
     [JsonConverter(typeof(StringEnumConverter<StatusState>))]
-    public StringEnum<StatusState> State { get; init; } = null!;
+    public required StringEnum<StatusState> State { get; init; }
 
     [JsonPropertyName("commit")]
-    public Commit Commit { get; init; } = null!;
+    public required Commit Commit { get; init; }
 
     [JsonPropertyName("branch")]
-    public IEnumerable<Branch> Branch { get; init; } = null!;
+    public IReadOnlyList<Branch>? Branch { get; init; }
 
     [JsonPropertyName("created_at")]
     [JsonConverter(typeof(DateTimeOffsetConverter))]

--- a/src/Octokit.Webhooks/Events/StatusEvent.cs
+++ b/src/Octokit.Webhooks/Events/StatusEvent.cs
@@ -34,8 +34,8 @@ public sealed record StatusEvent : WebhookEvent
     [JsonPropertyName("commit")]
     public required Commit Commit { get; init; }
 
-    [JsonPropertyName("branch")]
-    public IReadOnlyList<Branch>? Branch { get; init; }
+    [JsonPropertyName("branches")]
+    public IReadOnlyList<Branch>? Branches { get; init; }
 
     [JsonPropertyName("created_at")]
     [JsonConverter(typeof(DateTimeOffsetConverter))]

--- a/src/Octokit.Webhooks/Events/SubIssuesEvent.cs
+++ b/src/Octokit.Webhooks/Events/SubIssuesEvent.cs
@@ -9,16 +9,16 @@ public abstract record SubIssuesEvent : WebhookEvent
     public long ParentIssueId { get; init; }
 
     [JsonPropertyName("parent_issue")]
-    public Issue ParentIssue { get; init; } = null!;
+    public required Issue ParentIssue { get; init; }
 
     [JsonPropertyName("parent_issue_repo")]
-    public Models.Repository? ParentIssueRepo { get; init; } = null!;
+    public Models.Repository? ParentIssueRepo { get; init; }
 
     [JsonPropertyName("sub_issue_id")]
     public long SubIssueId { get; init; }
 
     [JsonPropertyName("sub_issue")]
-    public Issue SubIssue { get; init; } = null!;
+    public required Issue SubIssue { get; init; }
 
     [JsonPropertyName("sub_issue_repo")]
     public Models.Repository? SubIssueRepo { get; init; }

--- a/src/Octokit.Webhooks/Events/Team/TeamEditedEvent.cs
+++ b/src/Octokit.Webhooks/Events/Team/TeamEditedEvent.cs
@@ -10,5 +10,5 @@ public sealed record TeamEditedEvent : TeamEvent
     public override string Action => TeamAction.Edited;
 
     [JsonPropertyName("changes")]
-    public Changes Changes { get; init; } = null!;
+    public required Changes Changes { get; init; }
 }

--- a/src/Octokit.Webhooks/Events/TeamAddEvent.cs
+++ b/src/Octokit.Webhooks/Events/TeamAddEvent.cs
@@ -5,5 +5,5 @@ namespace Octokit.Webhooks.Events;
 public sealed record TeamAddEvent : WebhookEvent
 {
     [JsonPropertyName("team")]
-    public Models.Team Team { get; init; } = null!;
+    public required Models.Team Team { get; init; }
 }

--- a/src/Octokit.Webhooks/Events/TeamEvent.cs
+++ b/src/Octokit.Webhooks/Events/TeamEvent.cs
@@ -6,5 +6,5 @@ namespace Octokit.Webhooks.Events;
 public abstract record TeamEvent : WebhookEvent
 {
     [JsonPropertyName("team")]
-    public Models.Team Team { get; init; } = null!;
+    public required Models.Team Team { get; init; }
 }

--- a/src/Octokit.Webhooks/Events/WorkflowDispatchEvent.cs
+++ b/src/Octokit.Webhooks/Events/WorkflowDispatchEvent.cs
@@ -8,8 +8,8 @@ public sealed record WorkflowDispatchEvent : WebhookEvent
     public dynamic? Inputs { get; init; }
 
     [JsonPropertyName("ref")]
-    public string Ref { get; init; } = null!;
+    public required string Ref { get; init; }
 
     [JsonPropertyName("workflow")]
-    public string Workflow { get; init; } = null!;
+    public required string Workflow { get; init; }
 }

--- a/src/Octokit.Webhooks/Events/WorkflowDispatchEvent.cs
+++ b/src/Octokit.Webhooks/Events/WorkflowDispatchEvent.cs
@@ -5,7 +5,7 @@ namespace Octokit.Webhooks.Events;
 public sealed record WorkflowDispatchEvent : WebhookEvent
 {
     [JsonPropertyName("inputs")]
-    public JsonElement? Inputs { get; init; }
+    public IDictionary<string, JsonElement>? Inputs { get; init; }
 
     [JsonPropertyName("ref")]
     public required string Ref { get; init; }

--- a/src/Octokit.Webhooks/Events/WorkflowDispatchEvent.cs
+++ b/src/Octokit.Webhooks/Events/WorkflowDispatchEvent.cs
@@ -5,7 +5,7 @@ namespace Octokit.Webhooks.Events;
 public sealed record WorkflowDispatchEvent : WebhookEvent
 {
     [JsonPropertyName("inputs")]
-    public dynamic? Inputs { get; init; }
+    public JsonElement? Inputs { get; init; }
 
     [JsonPropertyName("ref")]
     public required string Ref { get; init; }

--- a/src/Octokit.Webhooks/Events/WorkflowJobEvent.cs
+++ b/src/Octokit.Webhooks/Events/WorkflowJobEvent.cs
@@ -6,7 +6,7 @@ namespace Octokit.Webhooks.Events;
 public abstract record WorkflowJobEvent : WebhookEvent
 {
     [JsonPropertyName("workflow_job")]
-    public Models.WorkflowJobEvent.WorkflowJob WorkflowJob { get; init; } = null!;
+    public required Models.WorkflowJobEvent.WorkflowJob WorkflowJob { get; init; }
 
     [JsonPropertyName("deployment")]
     public Models.DeploymentEvent.Deployment? Deployment { get; init; }

--- a/src/Octokit.Webhooks/Events/WorkflowRunEvent.cs
+++ b/src/Octokit.Webhooks/Events/WorkflowRunEvent.cs
@@ -6,8 +6,8 @@ namespace Octokit.Webhooks.Events;
 public abstract record WorkflowRunEvent : WebhookEvent
 {
     [JsonPropertyName("workflow")]
-    public Workflow Workflow { get; init; } = null!;
+    public required Workflow Workflow { get; init; }
 
     [JsonPropertyName("workflow_run")]
-    public Models.WorkflowRun WorkflowRun { get; init; } = null!;
+    public required Models.WorkflowRun WorkflowRun { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/App.cs
+++ b/src/Octokit.Webhooks/Models/App.cs
@@ -10,22 +10,22 @@ public sealed record App
     public string? Slug { get; init; }
 
     [JsonPropertyName("node_id")]
-    public string NodeId { get; init; } = null!;
+    public required string NodeId { get; init; }
 
     [JsonPropertyName("owner")]
-    public User Owner { get; init; } = null!;
+    public required User Owner { get; init; }
 
     [JsonPropertyName("name")]
-    public string Name { get; init; } = null!;
+    public required string Name { get; init; }
 
     [JsonPropertyName("description")]
     public string? Description { get; init; }
 
     [JsonPropertyName("external_url")]
-    public string ExternalUrl { get; init; } = null!;
+    public required string ExternalUrl { get; init; }
 
     [JsonPropertyName("html_url")]
-    public string HtmlUrl { get; init; } = null!;
+    public required string HtmlUrl { get; init; }
 
     [JsonPropertyName("created_at")]
     [JsonConverter(typeof(DateTimeOffsetConverter))]

--- a/src/Octokit.Webhooks/Models/BranchProtectionRule.cs
+++ b/src/Octokit.Webhooks/Models/BranchProtectionRule.cs
@@ -10,7 +10,7 @@ public sealed record BranchProtectionRule
     public long RepositoryId { get; init; }
 
     [JsonPropertyName("name")]
-    public string Name { get; init; } = null!;
+    public required string Name { get; init; }
 
     [JsonPropertyName("created_at")]
     [JsonConverter(typeof(DateTimeOffsetConverter))]
@@ -28,14 +28,14 @@ public sealed record BranchProtectionRule
 
     [JsonPropertyName("allow_deletions_enforcement_level")]
     [JsonConverter(typeof(StringEnumConverter<EnforcementLevel>))]
-    public StringEnum<EnforcementLevel> AllowDeletionsEnforcementLevel { get; init; } = null!;
+    public required StringEnum<EnforcementLevel> AllowDeletionsEnforcementLevel { get; init; }
 
     [JsonPropertyName("allow_force_pushes_enforcement_level")]
     [JsonConverter(typeof(StringEnumConverter<EnforcementLevel>))]
-    public StringEnum<EnforcementLevel> AllowForcePushesEnforcementLevel { get; init; } = null!;
+    public required StringEnum<EnforcementLevel> AllowForcePushesEnforcementLevel { get; init; }
 
     [JsonPropertyName("authorized_actor_names")]
-    public IEnumerable<string> AuthorizedActorNames { get; init; } = null!;
+    public required IReadOnlyList<string> AuthorizedActorNames { get; init; }
 
     [JsonPropertyName("authorized_actors_only")]
     public bool AuthorizedActorsOnly { get; init; }
@@ -51,15 +51,15 @@ public sealed record BranchProtectionRule
 
     [JsonPropertyName("linear_history_requirement_enforcement_level")]
     [JsonConverter(typeof(StringEnumConverter<EnforcementLevel>))]
-    public StringEnum<EnforcementLevel> LinearHistoryRequirementEnforcementLevel { get; init; } = null!;
+    public required StringEnum<EnforcementLevel> LinearHistoryRequirementEnforcementLevel { get; init; }
 
     [JsonPropertyName("merge_queue_enforcement_level")]
     [JsonConverter(typeof(StringEnumConverter<EnforcementLevel>))]
-    public StringEnum<EnforcementLevel> MergeQueueEnforcementLevel { get; init; } = null!;
+    public required StringEnum<EnforcementLevel> MergeQueueEnforcementLevel { get; init; }
 
     [JsonPropertyName("pull_request_reviews_enforcement_level")]
     [JsonConverter(typeof(StringEnumConverter<EnforcementLevel>))]
-    public StringEnum<EnforcementLevel> PullRequestReviewsEnforcementLevel { get; init; } = null!;
+    public required StringEnum<EnforcementLevel> PullRequestReviewsEnforcementLevel { get; init; }
 
     [JsonPropertyName("require_code_owner_review")]
     public bool RequireCodeOwnerReview { get; init; }
@@ -72,22 +72,22 @@ public sealed record BranchProtectionRule
 
     [JsonPropertyName("required_conversation_resolution_level")]
     [JsonConverter(typeof(StringEnumConverter<EnforcementLevel>))]
-    public StringEnum<EnforcementLevel> RequiredConversationResolutionLevel { get; init; } = null!;
+    public required StringEnum<EnforcementLevel> RequiredConversationResolutionLevel { get; init; }
 
     [JsonPropertyName("required_deployments_enforcement_level")]
     [JsonConverter(typeof(StringEnumConverter<EnforcementLevel>))]
-    public StringEnum<EnforcementLevel> RequiredDeploymentsEnforcementLevel { get; init; } = null!;
+    public required StringEnum<EnforcementLevel> RequiredDeploymentsEnforcementLevel { get; init; }
 
     [JsonPropertyName("required_status_checks")]
-    public IEnumerable<string> RequiredStatusChecks { get; init; } = null!;
+    public required IReadOnlyList<string> RequiredStatusChecks { get; init; }
 
     [JsonPropertyName("required_status_checks_enforcement_level")]
     [JsonConverter(typeof(StringEnumConverter<EnforcementLevel>))]
-    public StringEnum<EnforcementLevel> RequiredStatusChecksEnforcementLevel { get; init; } = null!;
+    public required StringEnum<EnforcementLevel> RequiredStatusChecksEnforcementLevel { get; init; }
 
     [JsonPropertyName("signature_requirement_enforcement_level")]
     [JsonConverter(typeof(StringEnumConverter<EnforcementLevel>))]
-    public StringEnum<EnforcementLevel> SignatureRequirementEnforcementLevel { get; init; } = null!;
+    public required StringEnum<EnforcementLevel> SignatureRequirementEnforcementLevel { get; init; }
 
     [JsonPropertyName("strict_required_status_checks_policy")]
     public bool StrictRequiredStatusChecksPolicy { get; init; }

--- a/src/Octokit.Webhooks/Models/BranchProtectionRuleEvent/ChangesArray.cs
+++ b/src/Octokit.Webhooks/Models/BranchProtectionRuleEvent/ChangesArray.cs
@@ -4,5 +4,5 @@ namespace Octokit.Webhooks.Models.BranchProtectionRuleEvent;
 public sealed record ChangesArray
 {
     [JsonPropertyName("from")]
-    public IEnumerable<string>? From { get; init; }
+    public IReadOnlyList<string>? From { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/CheckRunEvent/CheckRun.cs
+++ b/src/Octokit.Webhooks/Models/CheckRunEvent/CheckRun.cs
@@ -7,26 +7,26 @@ public sealed record CheckRun
     public long Id { get; init; }
 
     [JsonPropertyName("node_id")]
-    public string NodeId { get; init; } = null!;
+    public string? NodeId { get; init; }
 
     [JsonPropertyName("head_sha")]
-    public string HeadSha { get; init; } = null!;
+    public required string HeadSha { get; init; }
 
     [JsonPropertyName("external_id")]
-    public string ExternalId { get; init; } = null!;
+    public required string ExternalId { get; init; }
 
     [JsonPropertyName("url")]
-    public string Url { get; init; } = null!;
+    public required string Url { get; init; }
 
     [JsonPropertyName("html_url")]
-    public string HtmlUrl { get; init; } = null!;
+    public required string HtmlUrl { get; init; }
 
     [JsonPropertyName("details_url")]
-    public string DetailsUrl { get; init; } = null!;
+    public string? DetailsUrl { get; init; }
 
     [JsonPropertyName("status")]
     [JsonConverter(typeof(StringEnumConverter<CheckRunStatus>))]
-    public StringEnum<CheckRunStatus> Status { get; init; } = null!;
+    public required StringEnum<CheckRunStatus> Status { get; init; }
 
     [JsonPropertyName("conclusion")]
     [JsonConverter(typeof(StringEnumConverter<CheckRunConclusion>))]
@@ -41,20 +41,20 @@ public sealed record CheckRun
     public DateTimeOffset? CompletedAt { get; init; }
 
     [JsonPropertyName("output")]
-    public CheckRunOutput Output { get; init; } = null!;
+    public required CheckRunOutput Output { get; init; }
 
     [JsonPropertyName("name")]
-    public string Name { get; init; } = null!;
+    public required string Name { get; init; }
 
     [JsonPropertyName("check_suite")]
-    public CheckSuite CheckSuite { get; init; } = null!;
+    public required CheckSuite CheckSuite { get; init; }
 
     [JsonPropertyName("app")]
-    public App App { get; init; } = null!;
+    public required App App { get; init; }
 
     [JsonPropertyName("pull_requests")]
-    public IEnumerable<CheckRunPullRequest> PullRequests { get; init; } = null!;
+    public required IReadOnlyList<CheckRunPullRequest> PullRequests { get; init; }
 
     [JsonPropertyName("deployment")]
-    public Deployment Deployment { get; init; } = null!;
+    public Deployment? Deployment { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/CheckRunEvent/CheckRunOutput.cs
+++ b/src/Octokit.Webhooks/Models/CheckRunEvent/CheckRunOutput.cs
@@ -16,5 +16,5 @@ public sealed record CheckRunOutput
     public long AnnotationsCount { get; init; }
 
     [JsonPropertyName("annotations_url")]
-    public string AnnotationsUrl { get; init; } = null!;
+    public required string AnnotationsUrl { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/CheckRunEvent/CheckRunPullRequest.cs
+++ b/src/Octokit.Webhooks/Models/CheckRunEvent/CheckRunPullRequest.cs
@@ -4,7 +4,7 @@ namespace Octokit.Webhooks.Models.CheckRunEvent;
 public sealed record CheckRunPullRequest
 {
     [JsonPropertyName("url")]
-    public string Url { get; init; } = null!;
+    public required string Url { get; init; }
 
     [JsonPropertyName("id")]
     public long Id { get; init; }
@@ -13,8 +13,8 @@ public sealed record CheckRunPullRequest
     public long Number { get; init; }
 
     [JsonPropertyName("head")]
-    public CheckRunPullRequestHead Head { get; init; } = null!;
+    public required CheckRunPullRequestHead Head { get; init; }
 
     [JsonPropertyName("base")]
-    public CheckRunPullRequestBase Base { get; init; } = null!;
+    public required CheckRunPullRequestBase Base { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/CheckRunEvent/CheckRunPullRequestBase.cs
+++ b/src/Octokit.Webhooks/Models/CheckRunEvent/CheckRunPullRequestBase.cs
@@ -4,11 +4,11 @@ namespace Octokit.Webhooks.Models.CheckRunEvent;
 public sealed record CheckRunPullRequestBase
 {
     [JsonPropertyName("ref")]
-    public string Ref { get; init; } = null!;
+    public required string Ref { get; init; }
 
     [JsonPropertyName("sha")]
-    public string Sha { get; init; } = null!;
+    public required string Sha { get; init; }
 
     [JsonPropertyName("repo")]
-    public RepoRef Repo { get; init; } = null!;
+    public required RepoRef Repo { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/CheckRunEvent/CheckRunPullRequestHead.cs
+++ b/src/Octokit.Webhooks/Models/CheckRunEvent/CheckRunPullRequestHead.cs
@@ -4,11 +4,11 @@ namespace Octokit.Webhooks.Models.CheckRunEvent;
 public sealed record CheckRunPullRequestHead
 {
     [JsonPropertyName("ref")]
-    public string Ref { get; init; } = null!;
+    public required string Ref { get; init; }
 
     [JsonPropertyName("sha")]
-    public string Sha { get; init; } = null!;
+    public required string Sha { get; init; }
 
     [JsonPropertyName("repo")]
-    public RepoRef Repo { get; init; } = null!;
+    public required RepoRef Repo { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/CheckRunEvent/CheckSuite.cs
+++ b/src/Octokit.Webhooks/Models/CheckRunEvent/CheckSuite.cs
@@ -13,18 +13,18 @@ public sealed record CheckSuite
     public string? HeadBranch { get; init; }
 
     [JsonPropertyName("head_sha")]
-    public string HeadSha { get; init; } = null!;
+    public required string HeadSha { get; init; }
 
     [JsonPropertyName("status")]
     [JsonConverter(typeof(StringEnumConverter<CheckSuiteStatus>))]
-    public StringEnum<CheckSuiteStatus> Status { get; init; } = null!;
+    public required StringEnum<CheckSuiteStatus> Status { get; init; }
 
     [JsonPropertyName("conclusion")]
     [JsonConverter(typeof(StringEnumConverter<CheckSuiteConclusion>))]
     public StringEnum<CheckSuiteConclusion>? Conclusion { get; init; }
 
     [JsonPropertyName("url")]
-    public string Url { get; init; } = null!;
+    public required string Url { get; init; }
 
     [JsonPropertyName("before")]
     public string? Before { get; init; }
@@ -33,13 +33,13 @@ public sealed record CheckSuite
     public string? After { get; init; }
 
     [JsonPropertyName("pull_requests")]
-    public IEnumerable<CheckRunPullRequest> PullRequests { get; init; } = null!;
+    public required IReadOnlyList<CheckRunPullRequest> PullRequests { get; init; }
 
     [JsonPropertyName("deployment")]
     public Deployment? Deployment { get; init; }
 
     [JsonPropertyName("app")]
-    public App App { get; init; } = null!;
+    public required App App { get; init; }
 
     [JsonPropertyName("created_at")]
     [JsonConverter(typeof(DateTimeOffsetConverter))]

--- a/src/Octokit.Webhooks/Models/CheckRunEvent/Deployment.cs
+++ b/src/Octokit.Webhooks/Models/CheckRunEvent/Deployment.cs
@@ -4,22 +4,22 @@ namespace Octokit.Webhooks.Models.CheckRunEvent;
 public sealed record Deployment
 {
     [JsonPropertyName("url")]
-    public string Url { get; init; } = null!;
+    public required string Url { get; init; }
 
     [JsonPropertyName("id")]
     public long Id { get; init; }
 
     [JsonPropertyName("node_id")]
-    public string NodeId { get; init; } = null!;
+    public required string NodeId { get; init; }
 
     [JsonPropertyName("task")]
-    public string Task { get; init; } = null!;
+    public required string Task { get; init; }
 
     [JsonPropertyName("original_environment")]
-    public string OriginalEnvironment { get; init; } = null!;
+    public required string OriginalEnvironment { get; init; }
 
     [JsonPropertyName("environment")]
-    public string Environment { get; init; } = null!;
+    public required string Environment { get; init; }
 
     [JsonPropertyName("description")]
     public string? Description { get; init; }
@@ -33,8 +33,8 @@ public sealed record Deployment
     public DateTimeOffset UpdatedAt { get; init; }
 
     [JsonPropertyName("statuses_url")]
-    public string StatusesUrl { get; init; } = null!;
+    public required string StatusesUrl { get; init; }
 
     [JsonPropertyName("repository_url")]
-    public string RepositoryUrl { get; init; } = null!;
+    public required string RepositoryUrl { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/CheckSuiteEvent/CheckSuite.cs
+++ b/src/Octokit.Webhooks/Models/CheckSuiteEvent/CheckSuite.cs
@@ -15,7 +15,7 @@ public sealed record CheckSuite
     public string? HeadBranch { get; init; }
 
     [JsonPropertyName("head_sha")]
-    public string HeadSha { get; init; } = null!;
+    public required string HeadSha { get; init; }
 
     [JsonPropertyName("status")]
     [JsonConverter(typeof(StringEnumConverter<CheckSuiteStatus>))]
@@ -26,19 +26,19 @@ public sealed record CheckSuite
     public StringEnum<CheckSuiteConclusion>? Conclusion { get; init; }
 
     [JsonPropertyName("url")]
-    public string Url { get; init; } = null!;
+    public required string Url { get; init; }
 
     [JsonPropertyName("before")]
     public string? Before { get; init; }
 
     [JsonPropertyName("after")]
-    public string After { get; init; } = null!;
+    public required string After { get; init; }
 
     [JsonPropertyName("pull_requests")]
-    public IEnumerable<CheckRunPullRequest> PullRequests { get; init; } = null!;
+    public required IReadOnlyList<CheckRunPullRequest> PullRequests { get; init; }
 
     [JsonPropertyName("app")]
-    public App App { get; init; } = null!;
+    public required App App { get; init; }
 
     [JsonPropertyName("created_at")]
     [JsonConverter(typeof(DateTimeOffsetConverter))]
@@ -58,8 +58,8 @@ public sealed record CheckSuite
     public long LatestCheckRunsCount { get; init; }
 
     [JsonPropertyName("check_runs_url")]
-    public string CheckRunsUrl { get; init; } = null!;
+    public required string CheckRunsUrl { get; init; }
 
     [JsonPropertyName("head_commit")]
-    public SimpleCommit HeadCommit { get; init; } = null!;
+    public required SimpleCommit HeadCommit { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/CodeScanningAlertEvent/Alert.cs
+++ b/src/Octokit.Webhooks/Models/CodeScanningAlertEvent/Alert.cs
@@ -11,20 +11,20 @@ public sealed record Alert
     public DateTimeOffset CreatedAt { get; init; }
 
     [JsonPropertyName("url")]
-    public string Url { get; init; } = null!;
+    public required string Url { get; init; }
 
     [JsonPropertyName("html_url")]
-    public string HtmlUrl { get; init; } = null!;
+    public required string HtmlUrl { get; init; }
 
     [JsonPropertyName("instances")]
-    public IEnumerable<AlertInstance> Instances { get; init; } = null!;
+    public required IReadOnlyList<AlertInstance> Instances { get; init; }
 
     [JsonPropertyName("most_recent_instance")]
-    public AlertInstance AlertInstance { get; init; } = null!;
+    public AlertInstance? AlertInstance { get; init; }
 
     [JsonPropertyName("state")]
     [JsonConverter(typeof(StringEnumConverter<AlertState>))]
-    public StringEnum<AlertState> State { get; init; } = null!;
+    public required StringEnum<AlertState> State { get; init; }
 
     [JsonPropertyName("dismissed_by")]
     public User? DismissedBy { get; init; }
@@ -41,5 +41,5 @@ public sealed record Alert
     public AlertRule? Rule { get; init; }
 
     [JsonPropertyName("tool")]
-    public AlertTool Tool { get; init; } = null!;
+    public required AlertTool Tool { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/CodeScanningAlertEvent/AlertInstance.cs
+++ b/src/Octokit.Webhooks/Models/CodeScanningAlertEvent/AlertInstance.cs
@@ -4,17 +4,17 @@ namespace Octokit.Webhooks.Models.CodeScanningAlertEvent;
 public sealed record AlertInstance
 {
     [JsonPropertyName("ref")]
-    public string Ref { get; init; } = null!;
+    public required string Ref { get; init; }
 
     [JsonPropertyName("analysis_key")]
-    public string AnalysisKey { get; init; } = null!;
+    public required string AnalysisKey { get; init; }
 
     [JsonPropertyName("environment")]
-    public string Environment { get; init; } = null!;
+    public required string Environment { get; init; }
 
     [JsonPropertyName("state")]
     [JsonConverter(typeof(StringEnumConverter<AlertState>))]
-    public StringEnum<AlertState> State { get; init; } = null!;
+    public required StringEnum<AlertState> State { get; init; }
 
     [JsonPropertyName("commit_sha")]
     public string? CommitSha { get; init; }
@@ -26,5 +26,5 @@ public sealed record AlertInstance
     public AlertInstanceLocation? Location { get; init; }
 
     [JsonPropertyName("classifications")]
-    public IEnumerable<string>? Classifications { get; init; }
+    public IReadOnlyList<string>? Classifications { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/CodeScanningAlertEvent/AlertRule.cs
+++ b/src/Octokit.Webhooks/Models/CodeScanningAlertEvent/AlertRule.cs
@@ -4,21 +4,21 @@ namespace Octokit.Webhooks.Models.CodeScanningAlertEvent;
 public sealed record AlertRule
 {
     [JsonPropertyName("id")]
-    public string Id { get; init; } = null!;
+    public required string Id { get; init; }
 
     [JsonPropertyName("severity")]
     [JsonConverter(typeof(StringEnumConverter<AlertRuleSeverity>))]
     public StringEnum<AlertRuleSeverity>? Severity { get; init; }
 
     [JsonPropertyName("description")]
-    public string Description { get; init; } = null!;
+    public required string Description { get; init; }
 
     [JsonPropertyName("full_description")]
-    public string FullDescription { get; init; } = null!;
+    public string? FullDescription { get; init; }
 
     [JsonPropertyName("tags")]
-    public IEnumerable<string> Tags { get; init; } = null!;
+    public IReadOnlyList<string>? Tags { get; init; }
 
     [JsonPropertyName("help")]
-    public string Help { get; init; } = null!;
+    public string? Help { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/CodeScanningAlertEvent/AlertTool.cs
+++ b/src/Octokit.Webhooks/Models/CodeScanningAlertEvent/AlertTool.cs
@@ -4,7 +4,7 @@ namespace Octokit.Webhooks.Models.CodeScanningAlertEvent;
 public sealed record AlertTool
 {
     [JsonPropertyName("name")]
-    public string Name { get; init; } = null!;
+    public required string Name { get; init; }
 
     [JsonPropertyName("version")]
     public string? Version { get; init; }

--- a/src/Octokit.Webhooks/Models/CommitCommentEvent/Comment.cs
+++ b/src/Octokit.Webhooks/Models/CommitCommentEvent/Comment.cs
@@ -4,19 +4,19 @@ namespace Octokit.Webhooks.Models.CommitCommentEvent;
 public sealed record Comment
 {
     [JsonPropertyName("url")]
-    public string Url { get; init; } = null!;
+    public required string Url { get; init; }
 
     [JsonPropertyName("html_url")]
-    public string HtmlUrl { get; init; } = null!;
+    public required string HtmlUrl { get; init; }
 
     [JsonPropertyName("id")]
     public long Id { get; init; }
 
     [JsonPropertyName("node_id")]
-    public string NodeId { get; init; } = null!;
+    public required string NodeId { get; init; }
 
     [JsonPropertyName("user")]
-    public User User { get; init; } = null!;
+    public required User User { get; init; }
 
     [JsonPropertyName("position")]
     public int? Position { get; init; }
@@ -28,7 +28,7 @@ public sealed record Comment
     public string? Path { get; init; }
 
     [JsonPropertyName("commit_id")]
-    public string CommitId { get; init; } = null!;
+    public required string CommitId { get; init; }
 
     [JsonPropertyName("created_at")]
     [JsonConverter(typeof(DateTimeOffsetConverter))]
@@ -40,8 +40,8 @@ public sealed record Comment
 
     [JsonPropertyName("author_association")]
     [JsonConverter(typeof(StringEnumConverter<AuthorAssociation>))]
-    public StringEnum<AuthorAssociation> AuthorAssociation { get; init; } = null!;
+    public required StringEnum<AuthorAssociation> AuthorAssociation { get; init; }
 
     [JsonPropertyName("body")]
-    public string Body { get; init; } = null!;
+    public required string Body { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/Committer.cs
+++ b/src/Octokit.Webhooks/Models/Committer.cs
@@ -4,7 +4,7 @@ namespace Octokit.Webhooks.Models;
 public sealed record Committer
 {
     [JsonPropertyName("name")]
-    public string Name { get; init; } = null!;
+    public required string Name { get; init; }
 
     [JsonPropertyName("email")]
     public string? Email { get; init; }

--- a/src/Octokit.Webhooks/Models/ContainerMetadata.cs
+++ b/src/Octokit.Webhooks/Models/ContainerMetadata.cs
@@ -4,10 +4,10 @@ namespace Octokit.Webhooks.Models;
 public sealed record ContainerMetadata
 {
     [JsonPropertyName("labels")]
-    public IDictionary<string, dynamic>? Labels { get; init; }
+    public IDictionary<string, JsonElement>? Labels { get; init; }
 
     [JsonPropertyName("manifest")]
-    public IDictionary<string, dynamic>? Manifest { get; init; }
+    public IDictionary<string, JsonElement>? Manifest { get; init; }
 
     [JsonPropertyName("tag")]
     public ContainerMetadataTag? Tag { get; init; }

--- a/src/Octokit.Webhooks/Models/ContentReferenceEvent/ContentReference.cs
+++ b/src/Octokit.Webhooks/Models/ContentReferenceEvent/ContentReference.cs
@@ -7,8 +7,8 @@ public sealed record ContentReference
     public long Id { get; init; }
 
     [JsonPropertyName("node_id")]
-    public string NodeId { get; init; } = null!;
+    public required string NodeId { get; init; }
 
     [JsonPropertyName("reference")]
-    public string Reference { get; init; } = null!;
+    public required string Reference { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/CustomPropertyEvent/CustomProperty.cs
+++ b/src/Octokit.Webhooks/Models/CustomPropertyEvent/CustomProperty.cs
@@ -6,11 +6,11 @@ using System.Linq;
 public sealed record CustomProperty
 {
     [JsonPropertyName("property_name")]
-    public string PropertyName { get; init; } = null!;
+    public required string PropertyName { get; init; }
 
     [JsonPropertyName("value_type")]
     [JsonConverter(typeof(StringEnumConverter<CustomPropertyValueType>))]
-    public StringEnum<CustomPropertyValueType> ValueType { get; init; } = null!;
+    public required StringEnum<CustomPropertyValueType> ValueType { get; init; }
 
     [JsonPropertyName("required")]
     public bool Required { get; init; }
@@ -40,7 +40,7 @@ public sealed record CustomProperty
     public string? Description { get; init; }
 
     [JsonPropertyName("allowed_values")]
-    public IEnumerable<string>? AllowedValues { get; init; }
+    public IReadOnlyList<string>? AllowedValues { get; init; }
 
     [JsonPropertyName("values_editable_by")]
     [JsonConverter(typeof(StringEnumConverter<CustomPropertyValuesEditableBy>))]

--- a/src/Octokit.Webhooks/Models/CustomPropertyEvent/CustomPropertyLite.cs
+++ b/src/Octokit.Webhooks/Models/CustomPropertyEvent/CustomPropertyLite.cs
@@ -4,5 +4,5 @@ namespace Octokit.Webhooks.Models.CustomPropertyEvent;
 public sealed record CustomPropertyLite
 {
     [JsonPropertyName("property_name")]
-    public string PropertyName { get; init; } = null!;
+    public required string PropertyName { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/CustomPropertyValuesEvent/CustomPropertyValue.cs
+++ b/src/Octokit.Webhooks/Models/CustomPropertyValuesEvent/CustomPropertyValue.cs
@@ -6,7 +6,7 @@ using System.Linq;
 public sealed record CustomPropertyValue
 {
     [JsonPropertyName("property_name")]
-    public string PropertyName { get; init; } = null!;
+    public required string PropertyName { get; init; }
 
     [JsonPropertyName("value")]
     public object? Object { get; init; }

--- a/src/Octokit.Webhooks/Models/DependabotEvent/DependabotAlert.cs
+++ b/src/Octokit.Webhooks/Models/DependabotEvent/DependabotAlert.cs
@@ -8,22 +8,22 @@ public sealed record DependabotAlert
 
     [JsonPropertyName("state")]
     [JsonConverter(typeof(StringEnumConverter<DependabotAlertState>))]
-    public StringEnum<DependabotAlertState> State { get; init; } = null!;
+    public required StringEnum<DependabotAlertState> State { get; init; }
 
     [JsonPropertyName("dependency")]
-    public DependabotAlertDependency Dependency { get; init; } = null!;
+    public required DependabotAlertDependency Dependency { get; init; }
 
     [JsonPropertyName("security_advisory")]
-    public DependabotAlertSecurityAdvisory SecurityAdvisory { get; init; } = null!;
+    public required DependabotAlertSecurityAdvisory SecurityAdvisory { get; init; }
 
     [JsonPropertyName("security_vulnerability")]
-    public DependabotAlertVulnerability SecurityVulnerability { get; init; } = null!;
+    public required DependabotAlertVulnerability SecurityVulnerability { get; init; }
 
     [JsonPropertyName("url")]
-    public string Url { get; init; } = null!;
+    public required string Url { get; init; }
 
     [JsonPropertyName("html_url")]
-    public string HtmlUrl { get; init; } = null!;
+    public required string HtmlUrl { get; init; }
 
     [JsonPropertyName("created_at")]
     [JsonConverter(typeof(DateTimeOffsetConverter))]

--- a/src/Octokit.Webhooks/Models/DependabotEvent/DependabotAlertCwe.cs
+++ b/src/Octokit.Webhooks/Models/DependabotEvent/DependabotAlertCwe.cs
@@ -4,8 +4,8 @@ namespace Octokit.Webhooks.Models.DependabotEvent;
 public sealed record DependabotAlertCwe
 {
     [JsonPropertyName("cwe_id")]
-    public string CweId { get; init; } = null!;
+    public required string CweId { get; init; }
 
     [JsonPropertyName("name")]
-    public string Name { get; init; } = null!;
+    public required string Name { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/DependabotEvent/DependabotAlertDependency.cs
+++ b/src/Octokit.Webhooks/Models/DependabotEvent/DependabotAlertDependency.cs
@@ -4,10 +4,10 @@ namespace Octokit.Webhooks.Models.DependabotEvent;
 public sealed record DependabotAlertDependency
 {
     [JsonPropertyName("package")]
-    public DependabotAlertPackage Package { get; init; } = null!;
+    public required DependabotAlertPackage Package { get; init; }
 
     [JsonPropertyName("manifest_path")]
-    public string ManifestPath { get; init; } = null!;
+    public required string ManifestPath { get; init; }
 
     [JsonPropertyName("scope")]
     [JsonConverter(typeof(StringEnumConverter<DependabotAlertDependencyScope>))]

--- a/src/Octokit.Webhooks/Models/DependabotEvent/DependabotAlertFirstPatchedVersion.cs
+++ b/src/Octokit.Webhooks/Models/DependabotEvent/DependabotAlertFirstPatchedVersion.cs
@@ -4,5 +4,5 @@ namespace Octokit.Webhooks.Models.DependabotEvent;
 public class DependabotAlertFirstPatchedVersion
 {
     [JsonPropertyName("identifier")]
-    public string Identifier { get; init; } = null!;
+    public required string Identifier { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/DependabotEvent/DependabotAlertIdentifier.cs
+++ b/src/Octokit.Webhooks/Models/DependabotEvent/DependabotAlertIdentifier.cs
@@ -4,8 +4,8 @@ namespace Octokit.Webhooks.Models.DependabotEvent;
 public sealed record DependabotAlertIdentifier
 {
     [JsonPropertyName("value")]
-    public string Value { get; init; } = null!;
+    public required string Value { get; init; }
 
     [JsonPropertyName("type")]
-    public string Type { get; init; } = null!;
+    public required string Type { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/DependabotEvent/DependabotAlertPackage.cs
+++ b/src/Octokit.Webhooks/Models/DependabotEvent/DependabotAlertPackage.cs
@@ -4,8 +4,8 @@ namespace Octokit.Webhooks.Models.DependabotEvent;
 public sealed record DependabotAlertPackage
 {
     [JsonPropertyName("name")]
-    public string Name { get; init; } = null!;
+    public required string Name { get; init; }
 
     [JsonPropertyName("ecosystem")]
-    public string Ecosystem { get; init; } = null!;
+    public required string Ecosystem { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/DependabotEvent/DependabotAlertReference.cs
+++ b/src/Octokit.Webhooks/Models/DependabotEvent/DependabotAlertReference.cs
@@ -4,5 +4,5 @@ namespace Octokit.Webhooks.Models.DependabotEvent;
 public sealed record DependabotAlertReference
 {
     [JsonPropertyName("url")]
-    public string Url { get; init; } = null!;
+    public required string Url { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/DependabotEvent/DependabotAlertSecurityAdvisory.cs
+++ b/src/Octokit.Webhooks/Models/DependabotEvent/DependabotAlertSecurityAdvisory.cs
@@ -4,35 +4,35 @@ namespace Octokit.Webhooks.Models.DependabotEvent;
 public sealed record DependabotAlertSecurityAdvisory
 {
     [JsonPropertyName("ghsa_id")]
-    public string GhsaId { get; init; } = null!;
+    public required string GhsaId { get; init; }
 
     [JsonPropertyName("cve_id")]
     public string? CveId { get; init; }
 
     [JsonPropertyName("summary")]
-    public string Summary { get; init; } = null!;
+    public required string Summary { get; init; }
 
     [JsonPropertyName("description")]
-    public string Description { get; init; } = null!;
+    public required string Description { get; init; }
 
     [JsonPropertyName("vulnerabilities")]
-    public IEnumerable<DependabotAlertVulnerability> Vulnerabilities { get; init; } = null!;
+    public required IReadOnlyList<DependabotAlertVulnerability> Vulnerabilities { get; init; }
 
     [JsonPropertyName("severity")]
     [JsonConverter(typeof(StringEnumConverter<DependabotAlertSeverity>))]
-    public StringEnum<DependabotAlertSeverity> Severity { get; init; } = null!;
+    public required StringEnum<DependabotAlertSeverity> Severity { get; init; }
 
     [JsonPropertyName("cvss")]
-    public DependabotAlertCvss Cvss { get; init; } = null!;
+    public required DependabotAlertCvss Cvss { get; init; }
 
     [JsonPropertyName("cwes")]
-    public IEnumerable<DependabotAlertCwe> Cwes { get; init; } = null!;
+    public required IReadOnlyList<DependabotAlertCwe> Cwes { get; init; }
 
     [JsonPropertyName("identifiers")]
-    public IEnumerable<DependabotAlertIdentifier> Identifiers { get; init; } = null!;
+    public required IReadOnlyList<DependabotAlertIdentifier> Identifiers { get; init; }
 
     [JsonPropertyName("references")]
-    public IEnumerable<DependabotAlertReference> References { get; init; } = null!;
+    public required IReadOnlyList<DependabotAlertReference> References { get; init; }
 
     [JsonPropertyName("published_at")]
     [JsonConverter(typeof(DateTimeOffsetConverter))]

--- a/src/Octokit.Webhooks/Models/DependabotEvent/DependabotAlertVulnerability.cs
+++ b/src/Octokit.Webhooks/Models/DependabotEvent/DependabotAlertVulnerability.cs
@@ -4,15 +4,15 @@ namespace Octokit.Webhooks.Models.DependabotEvent;
 public sealed record DependabotAlertVulnerability
 {
     [JsonPropertyName("package")]
-    public DependabotAlertPackage Package { get; init; } = null!;
+    public required DependabotAlertPackage Package { get; init; }
 
     [JsonPropertyName("severity")]
     [JsonConverter(typeof(StringEnumConverter<DependabotAlertSeverity>))]
-    public StringEnum<DependabotAlertSeverity> Severity { get; init; } = null!;
+    public required StringEnum<DependabotAlertSeverity> Severity { get; init; }
 
     [JsonPropertyName("vulnerable_version_range")]
-    public string VulnerableVersionRange { get; init; } = null!;
+    public required string VulnerableVersionRange { get; init; }
 
     [JsonPropertyName("first_patched_version")]
-    public DependabotAlertFirstPatchedVersion FirstPatchedVersion { get; init; } = null!;
+    public required DependabotAlertFirstPatchedVersion FirstPatchedVersion { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/DeployKeyEvent/DeployKey.cs
+++ b/src/Octokit.Webhooks/Models/DeployKeyEvent/DeployKey.cs
@@ -7,13 +7,13 @@ public sealed record DeployKey
     public long Id { get; init; }
 
     [JsonPropertyName("key")]
-    public string Key { get; init; } = null!;
+    public required string Key { get; init; }
 
     [JsonPropertyName("url")]
-    public string Url { get; init; } = null!;
+    public required string Url { get; init; }
 
     [JsonPropertyName("title")]
-    public string Title { get; init; } = null!;
+    public required string Title { get; init; }
 
     [JsonPropertyName("verified")]
     public bool Verified { get; init; }

--- a/src/Octokit.Webhooks/Models/DeploymentEvent/Deployment.cs
+++ b/src/Octokit.Webhooks/Models/DeploymentEvent/Deployment.cs
@@ -4,31 +4,31 @@ namespace Octokit.Webhooks.Models.DeploymentEvent;
 public sealed record Deployment
 {
     [JsonPropertyName("url")]
-    public string Url { get; init; } = null!;
+    public required string Url { get; init; }
 
     [JsonPropertyName("id")]
     public long Id { get; init; }
 
     [JsonPropertyName("node_id")]
-    public string NodeId { get; init; } = null!;
+    public required string NodeId { get; init; }
 
     [JsonPropertyName("sha")]
-    public string Sha { get; init; } = null!;
+    public required string Sha { get; init; }
 
     [JsonPropertyName("ref")]
-    public string Ref { get; init; } = null!;
+    public required string Ref { get; init; }
 
     [JsonPropertyName("task")]
-    public string Task { get; init; } = null!;
+    public required string Task { get; init; }
 
     [JsonPropertyName("payload")]
     public dynamic? Payload { get; init; }
 
     [JsonPropertyName("original_environment")]
-    public string OriginalEnvironment { get; init; } = null!;
+    public required string OriginalEnvironment { get; init; }
 
     [JsonPropertyName("environment")]
-    public string Environment { get; init; } = null!;
+    public required string Environment { get; init; }
 
     [JsonPropertyName("transient_environment")]
     public bool? TransientEnvironment { get; init; }
@@ -40,7 +40,7 @@ public sealed record Deployment
     public string? Description { get; init; }
 
     [JsonPropertyName("creator")]
-    public User Creator { get; init; } = null!;
+    public required User Creator { get; init; }
 
     [JsonPropertyName("created_at")]
     [JsonConverter(typeof(DateTimeOffsetConverter))]
@@ -51,10 +51,10 @@ public sealed record Deployment
     public DateTimeOffset UpdatedAt { get; init; }
 
     [JsonPropertyName("statuses_url")]
-    public string StatusesUrl { get; init; } = null!;
+    public required string StatusesUrl { get; init; }
 
     [JsonPropertyName("repository_url")]
-    public string RepositoryUrl { get; init; } = null!;
+    public required string RepositoryUrl { get; init; }
 
     [JsonPropertyName("performed_via_github_app")]
     public App? PerformedViaGithubApp { get; init; }

--- a/src/Octokit.Webhooks/Models/DeploymentEvent/Deployment.cs
+++ b/src/Octokit.Webhooks/Models/DeploymentEvent/Deployment.cs
@@ -22,7 +22,7 @@ public sealed record Deployment
     public required string Task { get; init; }
 
     [JsonPropertyName("payload")]
-    public dynamic? Payload { get; init; }
+    public JsonElement? Payload { get; init; }
 
     [JsonPropertyName("original_environment")]
     public required string OriginalEnvironment { get; init; }

--- a/src/Octokit.Webhooks/Models/DeploymentEvent/DeploymentCheckRun.cs
+++ b/src/Octokit.Webhooks/Models/DeploymentEvent/DeploymentCheckRun.cs
@@ -7,29 +7,29 @@ public sealed record DeploymentCheckRun
     public long Id { get; init; }
 
     [JsonPropertyName("name")]
-    public string Name { get; init; } = null!;
+    public required string Name { get; init; }
 
     [JsonPropertyName("node_id")]
-    public string NodeId { get; init; } = null!;
+    public required string NodeId { get; init; }
 
     [JsonPropertyName("head_sha")]
-    public string HeadSha { get; init; } = null!;
+    public required string HeadSha { get; init; }
 
     [JsonPropertyName("external_id")]
-    public string ExternalId { get; init; } = null!;
+    public required string ExternalId { get; init; }
 
     [JsonPropertyName("url")]
-    public string Url { get; init; } = null!;
+    public required string Url { get; init; }
 
     [JsonPropertyName("html_url")]
-    public string HtmlUrl { get; init; } = null!;
+    public required string HtmlUrl { get; init; }
 
     [JsonPropertyName("details_url")]
-    public string DetailsUrl { get; init; } = null!;
+    public required string DetailsUrl { get; init; }
 
     [JsonPropertyName("status")]
     [JsonConverter(typeof(StringEnumConverter<DeploymentCheckRunStatus>))]
-    public StringEnum<DeploymentCheckRunStatus> Status { get; init; } = null!;
+    public required StringEnum<DeploymentCheckRunStatus> Status { get; init; }
 
     [JsonPropertyName("conclusion")]
     [JsonConverter(typeof(StringEnumConverter<DeploymentCheckRunConclusion>))]

--- a/src/Octokit.Webhooks/Models/DeploymentEvent/DeploymentWorkflowRun.cs
+++ b/src/Octokit.Webhooks/Models/DeploymentEvent/DeploymentWorkflowRun.cs
@@ -9,25 +9,25 @@ public sealed record DeploymentWorkflowRun
     public long Id { get; init; }
 
     [JsonPropertyName("name")]
-    public string Name { get; init; } = null!;
+    public required string Name { get; init; }
 
     [JsonPropertyName("path")]
     public string? Path { get; init; }
 
     [JsonPropertyName("node_id")]
-    public string NodeId { get; init; } = null!;
+    public required string NodeId { get; init; }
 
     [JsonPropertyName("head_branch")]
-    public string HeadBranch { get; init; } = null!;
+    public required string HeadBranch { get; init; }
 
     [JsonPropertyName("head_sha")]
-    public string HeadSha { get; init; } = null!;
+    public required string HeadSha { get; init; }
 
     [JsonPropertyName("run_number")]
     public long RunNumber { get; init; }
 
     [JsonPropertyName("event")]
-    public string Event { get; init; } = null!;
+    public required string Event { get; init; }
 
     [JsonPropertyName("status")]
     [JsonConverter(typeof(StringEnumConverter<DeploymentWorkflowRunStatus>))]
@@ -44,16 +44,16 @@ public sealed record DeploymentWorkflowRun
     public long CheckSuiteId { get; init; }
 
     [JsonPropertyName("check_suite_node_id")]
-    public string CheckSuiteNodeId { get; init; } = null!;
+    public required string CheckSuiteNodeId { get; init; }
 
     [JsonPropertyName("url")]
-    public string Url { get; init; } = null!;
+    public required string Url { get; init; }
 
     [JsonPropertyName("html_url")]
-    public string HtmlUrl { get; init; } = null!;
+    public required string HtmlUrl { get; init; }
 
     [JsonPropertyName("pull_requests")]
-    public IEnumerable<CheckRunPullRequest> PullRequests { get; init; } = null!;
+    public required IReadOnlyList<CheckRunPullRequest> PullRequests { get; init; }
 
     [JsonPropertyName("created_at")]
     [JsonConverter(typeof(DateTimeOffsetConverter))]
@@ -64,10 +64,10 @@ public sealed record DeploymentWorkflowRun
     public DateTimeOffset UpdatedAt { get; init; }
 
     [JsonPropertyName("actor")]
-    public User Actor { get; init; } = null!;
+    public required User Actor { get; init; }
 
     [JsonPropertyName("triggering_actor")]
-    public User TriggeringActor { get; init; } = null!;
+    public required User TriggeringActor { get; init; }
 
     [JsonPropertyName("run_attempt")]
     public long RunAttempt { get; init; }
@@ -77,5 +77,5 @@ public sealed record DeploymentWorkflowRun
     public DateTimeOffset RunStartedAt { get; init; }
 
     [JsonPropertyName("referenced_workflows")]
-    public IEnumerable<ReferencedWorkflow> ReferencedWorkflows { get; init; } = null!;
+    public IReadOnlyList<ReferencedWorkflow>? ReferencedWorkflows { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/DeploymentReviewReviewer.cs
+++ b/src/Octokit.Webhooks/Models/DeploymentReviewReviewer.cs
@@ -5,10 +5,10 @@ public sealed record DeploymentReviewReviewer
 {
     [JsonPropertyName("type")]
     [JsonConverter(typeof(StringEnumConverter<ReviewerType>))]
-    public StringEnum<ReviewerType> Type { get; init; } = null!;
+    public required StringEnum<ReviewerType> Type { get; init; }
 
     // TODO: Correctly deserialize this property.
     // See https://github.com/octokit/webhooks.net/issues/278
     [JsonPropertyName("reviewer")]
-    public dynamic Reviewer { get; init; } = null!;
+    public required dynamic Reviewer { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/DeploymentReviewReviewer.cs
+++ b/src/Octokit.Webhooks/Models/DeploymentReviewReviewer.cs
@@ -10,5 +10,5 @@ public sealed record DeploymentReviewReviewer
     // TODO: Correctly deserialize this property.
     // See https://github.com/octokit/webhooks.net/issues/278
     [JsonPropertyName("reviewer")]
-    public required dynamic Reviewer { get; init; }
+    public required JsonElement Reviewer { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/DeploymentStatusEvent/Deployment.cs
+++ b/src/Octokit.Webhooks/Models/DeploymentStatusEvent/Deployment.cs
@@ -4,37 +4,37 @@ namespace Octokit.Webhooks.Models.DeploymentStatusEvent;
 public sealed record Deployment
 {
     [JsonPropertyName("url")]
-    public string Url { get; init; } = null!;
+    public required string Url { get; init; }
 
     [JsonPropertyName("id")]
     public long Id { get; init; }
 
     [JsonPropertyName("node_id")]
-    public string NodeId { get; init; } = null!;
+    public required string NodeId { get; init; }
 
     [JsonPropertyName("sha")]
-    public string Sha { get; init; } = null!;
+    public required string Sha { get; init; }
 
     [JsonPropertyName("ref")]
-    public string Ref { get; init; } = null!;
+    public required string Ref { get; init; }
 
     [JsonPropertyName("task")]
-    public string Task { get; init; } = null!;
+    public required string Task { get; init; }
 
     [JsonPropertyName("payload")]
     public dynamic? Payload { get; init; }
 
     [JsonPropertyName("original_environment")]
-    public string OriginalEnvironment { get; init; } = null!;
+    public required string OriginalEnvironment { get; init; }
 
     [JsonPropertyName("environment")]
-    public string Environment { get; init; } = null!;
+    public required string Environment { get; init; }
 
     [JsonPropertyName("description")]
     public string? Description { get; init; }
 
     [JsonPropertyName("creator")]
-    public User Creator { get; init; } = null!;
+    public required User Creator { get; init; }
 
     [JsonPropertyName("created_at")]
     [JsonConverter(typeof(DateTimeOffsetConverter))]
@@ -45,10 +45,10 @@ public sealed record Deployment
     public DateTimeOffset UpdatedAt { get; init; }
 
     [JsonPropertyName("statuses_url")]
-    public string StatusesUrl { get; init; } = null!;
+    public required string StatusesUrl { get; init; }
 
     [JsonPropertyName("repository_url")]
-    public string RepositoryUrl { get; init; } = null!;
+    public required string RepositoryUrl { get; init; }
 
     [JsonPropertyName("performed_via_github_app")]
     public App? PerformedViaGithubApp { get; init; }

--- a/src/Octokit.Webhooks/Models/DeploymentStatusEvent/Deployment.cs
+++ b/src/Octokit.Webhooks/Models/DeploymentStatusEvent/Deployment.cs
@@ -22,7 +22,7 @@ public sealed record Deployment
     public required string Task { get; init; }
 
     [JsonPropertyName("payload")]
-    public dynamic? Payload { get; init; }
+    public JsonElement? Payload { get; init; }
 
     [JsonPropertyName("original_environment")]
     public required string OriginalEnvironment { get; init; }

--- a/src/Octokit.Webhooks/Models/DeploymentStatusEvent/DeploymentStatus.cs
+++ b/src/Octokit.Webhooks/Models/DeploymentStatusEvent/DeploymentStatus.cs
@@ -4,26 +4,26 @@ namespace Octokit.Webhooks.Models.DeploymentStatusEvent;
 public sealed record DeploymentStatus
 {
     [JsonPropertyName("url")]
-    public string Url { get; init; } = null!;
+    public required string Url { get; init; }
 
     [JsonPropertyName("id")]
     public long Id { get; init; }
 
     [JsonPropertyName("node_id")]
-    public string NodeId { get; init; } = null!;
+    public required string NodeId { get; init; }
 
     [JsonPropertyName("state")]
     [JsonConverter(typeof(StringEnumConverter<DeploymentStatusState>))]
-    public StringEnum<DeploymentStatusState> State { get; init; } = null!;
+    public required StringEnum<DeploymentStatusState> State { get; init; }
 
     [JsonPropertyName("creator")]
-    public User Creator { get; init; } = null!;
+    public required User Creator { get; init; }
 
     [JsonPropertyName("description")]
-    public string Description { get; init; } = null!;
+    public required string Description { get; init; }
 
     [JsonPropertyName("environment")]
-    public string Environment { get; init; } = null!;
+    public required string Environment { get; init; }
 
     [JsonPropertyName("environment_url")]
     public string? EnvironmentUrl { get; init; }
@@ -32,7 +32,7 @@ public sealed record DeploymentStatus
     public string? LogUrl { get; init; }
 
     [JsonPropertyName("target_url")]
-    public string TargetUrl { get; init; } = null!;
+    public required string TargetUrl { get; init; }
 
     [JsonPropertyName("created_at")]
     [JsonConverter(typeof(DateTimeOffsetConverter))]
@@ -43,10 +43,10 @@ public sealed record DeploymentStatus
     public DateTimeOffset UpdatedAt { get; init; }
 
     [JsonPropertyName("deployment_url")]
-    public string DeploymentUrl { get; init; } = null!;
+    public required string DeploymentUrl { get; init; }
 
     [JsonPropertyName("repository_url")]
-    public string RepositoryUrl { get; init; } = null!;
+    public required string RepositoryUrl { get; init; }
 
     [JsonPropertyName("performed_via_github_app")]
     public App? PerformedViaGithubApp { get; init; }

--- a/src/Octokit.Webhooks/Models/Discussion.cs
+++ b/src/Octokit.Webhooks/Models/Discussion.cs
@@ -4,10 +4,10 @@ namespace Octokit.Webhooks.Models;
 public sealed record Discussion
 {
     [JsonPropertyName("repository_url")]
-    public string RepositoryUrl { get; init; } = null!;
+    public required string RepositoryUrl { get; init; }
 
     [JsonPropertyName("category")]
-    public DiscussionCategory Category { get; init; } = null!;
+    public required DiscussionCategory Category { get; init; }
 
     [JsonPropertyName("answer_html_url")]
     public string? AnswerHtmlUrl { get; init; }
@@ -20,26 +20,26 @@ public sealed record Discussion
     public User? AnswerChosenBy { get; init; }
 
     [JsonPropertyName("html_url")]
-    public string HtmlUrl { get; init; } = null!;
+    public required string HtmlUrl { get; init; }
 
     [JsonPropertyName("id")]
     public long Id { get; init; }
 
     [JsonPropertyName("node_id")]
-    public string NodeId { get; init; } = null!;
+    public required string NodeId { get; init; }
 
     [JsonPropertyName("number")]
     public long Number { get; init; }
 
     [JsonPropertyName("title")]
-    public string Title { get; init; } = null!;
+    public required string Title { get; init; }
 
     [JsonPropertyName("user")]
-    public User User { get; init; } = null!;
+    public required User User { get; init; }
 
     [JsonPropertyName("state")]
     [JsonConverter(typeof(StringEnumConverter<DiscussionState>))]
-    public StringEnum<DiscussionState> State { get; init; } = null!;
+    public required StringEnum<DiscussionState> State { get; init; }
 
     [JsonPropertyName("locked")]
     public bool Locked { get; init; }
@@ -57,13 +57,13 @@ public sealed record Discussion
 
     [JsonPropertyName("author_association")]
     [JsonConverter(typeof(StringEnumConverter<AuthorAssociation>))]
-    public StringEnum<AuthorAssociation> AuthorAssociation { get; init; } = null!;
+    public required StringEnum<AuthorAssociation> AuthorAssociation { get; init; }
 
     [JsonPropertyName("active_lock_reason")]
     public string? ActiveLockReason { get; init; }
 
     [JsonPropertyName("body")]
-    public string Body { get; init; } = null!;
+    public required string Body { get; init; }
 
     [JsonPropertyName("reactions")]
     public Reactions? Reactions { get; init; }

--- a/src/Octokit.Webhooks/Models/DiscussionAnswer.cs
+++ b/src/Octokit.Webhooks/Models/DiscussionAnswer.cs
@@ -7,10 +7,10 @@ public sealed record DiscussionAnswer
     public long Id { get; init; }
 
     [JsonPropertyName("node_id")]
-    public string NodeId { get; init; } = null!;
+    public required string NodeId { get; init; }
 
     [JsonPropertyName("html_url")]
-    public string HtmlUrl { get; init; } = null!;
+    public required string HtmlUrl { get; init; }
 
     [JsonPropertyName("parent_id")]
     public int? ParentId { get; init; }
@@ -19,17 +19,17 @@ public sealed record DiscussionAnswer
     public long ChildCommentCount { get; init; }
 
     [JsonPropertyName("repository_url")]
-    public string RepositoryUrl { get; init; } = null!;
+    public required string RepositoryUrl { get; init; }
 
     [JsonPropertyName("discussion_id")]
     public long DiscussionId { get; init; }
 
     [JsonPropertyName("author_association")]
     [JsonConverter(typeof(StringEnumConverter<AuthorAssociation>))]
-    public StringEnum<AuthorAssociation> AuthorAssociation { get; init; } = null!;
+    public required StringEnum<AuthorAssociation> AuthorAssociation { get; init; }
 
     [JsonPropertyName("user")]
-    public User User { get; init; } = null!;
+    public required User User { get; init; }
 
     [JsonPropertyName("created_at")]
     [JsonConverter(typeof(DateTimeOffsetConverter))]
@@ -40,5 +40,5 @@ public sealed record DiscussionAnswer
     public DateTimeOffset UpdatedAt { get; init; }
 
     [JsonPropertyName("body")]
-    public string Body { get; init; } = null!;
+    public required string Body { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/DiscussionCategory.cs
+++ b/src/Octokit.Webhooks/Models/DiscussionCategory.cs
@@ -10,13 +10,13 @@ public sealed record DiscussionCategory
     public long RepositoryId { get; init; }
 
     [JsonPropertyName("emoji")]
-    public string Emoji { get; init; } = null!;
+    public required string Emoji { get; init; }
 
     [JsonPropertyName("name")]
-    public string Name { get; init; } = null!;
+    public required string Name { get; init; }
 
     [JsonPropertyName("description")]
-    public string Description { get; init; } = null!;
+    public required string Description { get; init; }
 
     [JsonPropertyName("created_at")]
     [JsonConverter(typeof(DateTimeOffsetConverter))]
@@ -27,7 +27,7 @@ public sealed record DiscussionCategory
     public DateTimeOffset UpdatedAt { get; init; }
 
     [JsonPropertyName("slug")]
-    public string Slug { get; init; } = null!;
+    public required string Slug { get; init; }
 
     [JsonPropertyName("is_answerable")]
     public bool IsAnswerable { get; init; }

--- a/src/Octokit.Webhooks/Models/DiscussionCommentEvent/DiscussionComment.cs
+++ b/src/Octokit.Webhooks/Models/DiscussionCommentEvent/DiscussionComment.cs
@@ -7,10 +7,10 @@ public sealed record DiscussionComment
     public long Id { get; init; }
 
     [JsonPropertyName("node_id")]
-    public string NodeId { get; init; } = null!;
+    public required string NodeId { get; init; }
 
     [JsonPropertyName("html_url")]
-    public string HtmlUrl { get; init; } = null!;
+    public required string HtmlUrl { get; init; }
 
     [JsonPropertyName("parent_id")]
     public int? ParentId { get; init; }
@@ -19,17 +19,17 @@ public sealed record DiscussionComment
     public long ChildCommentCount { get; init; }
 
     [JsonPropertyName("repository_url")]
-    public string RepositoryUrl { get; init; } = null!;
+    public required string RepositoryUrl { get; init; }
 
     [JsonPropertyName("discussion_id")]
     public long DiscussionId { get; init; }
 
     [JsonPropertyName("author_association")]
     [JsonConverter(typeof(StringEnumConverter<AuthorAssociation>))]
-    public StringEnum<AuthorAssociation> AuthorAssociation { get; init; } = null!;
+    public required StringEnum<AuthorAssociation> AuthorAssociation { get; init; }
 
     [JsonPropertyName("user")]
-    public User User { get; init; } = null!;
+    public required User User { get; init; }
 
     [JsonPropertyName("created_at")]
     [JsonConverter(typeof(DateTimeOffsetConverter))]
@@ -40,8 +40,8 @@ public sealed record DiscussionComment
     public DateTimeOffset UpdatedAt { get; init; }
 
     [JsonPropertyName("body")]
-    public string Body { get; init; } = null!;
+    public required string Body { get; init; }
 
     [JsonPropertyName("reactions")]
-    public Reactions Reactions { get; init; } = null!;
+    public required Reactions Reactions { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/DiscussionCommentEvent/DiscussionCommentChangesBody.cs
+++ b/src/Octokit.Webhooks/Models/DiscussionCommentEvent/DiscussionCommentChangesBody.cs
@@ -4,5 +4,5 @@ namespace Octokit.Webhooks.Models.DiscussionCommentEvent;
 public sealed record DiscussionCommentChangesBody
 {
     [JsonPropertyName("from")]
-    public string From { get; init; } = null!;
+    public required string From { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/DiscussionEvent/ChangesBody.cs
+++ b/src/Octokit.Webhooks/Models/DiscussionEvent/ChangesBody.cs
@@ -4,5 +4,5 @@ namespace Octokit.Webhooks.Models.DiscussionEvent;
 public sealed record ChangesBody
 {
     [JsonPropertyName("from")]
-    public string From { get; init; } = null!;
+    public required string From { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/DiscussionEvent/ChangesCategory.cs
+++ b/src/Octokit.Webhooks/Models/DiscussionEvent/ChangesCategory.cs
@@ -4,5 +4,5 @@ namespace Octokit.Webhooks.Models.DiscussionEvent;
 public sealed record ChangesCategory
 {
     [JsonPropertyName("from")]
-    public DiscussionCategory From { get; init; } = null!;
+    public required DiscussionCategory From { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/DiscussionEvent/ChangesTitle.cs
+++ b/src/Octokit.Webhooks/Models/DiscussionEvent/ChangesTitle.cs
@@ -4,5 +4,5 @@ namespace Octokit.Webhooks.Models.DiscussionEvent;
 public sealed record ChangesTitle
 {
     [JsonPropertyName("from")]
-    public string From { get; init; } = null!;
+    public required string From { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/GollumEvent/Page.cs
+++ b/src/Octokit.Webhooks/Models/GollumEvent/Page.cs
@@ -4,21 +4,21 @@ namespace Octokit.Webhooks.Models.GollumEvent;
 public sealed record Page
 {
     [JsonPropertyName("page_name")]
-    public string PageName { get; init; } = null!;
+    public required string PageName { get; init; }
 
     [JsonPropertyName("title")]
-    public string Title { get; init; } = null!;
+    public required string Title { get; init; }
 
     [JsonPropertyName("summary")]
     public string? Summary { get; init; }
 
     [JsonPropertyName("action")]
     [JsonConverter(typeof(StringEnumConverter<PageAction>))]
-    public StringEnum<PageAction> Action { get; init; } = null!;
+    public required StringEnum<PageAction> Action { get; init; }
 
     [JsonPropertyName("sha")]
-    public string Sha { get; init; } = null!;
+    public required string Sha { get; init; }
 
     [JsonPropertyName("html_url")]
-    public string HtmlUrl { get; init; } = null!;
+    public required string HtmlUrl { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/Installation.cs
+++ b/src/Octokit.Webhooks/Models/Installation.cs
@@ -7,20 +7,20 @@ public sealed record Installation
     public long Id { get; init; }
 
     [JsonPropertyName("account")]
-    public User Account { get; init; } = null!;
+    public required User Account { get; init; }
 
     [JsonPropertyName("repository_selection")]
     [JsonConverter(typeof(StringEnumConverter<InstallationRepositorySelection>))]
-    public StringEnum<InstallationRepositorySelection> RepositorySelection { get; init; } = null!;
+    public required StringEnum<InstallationRepositorySelection> RepositorySelection { get; init; }
 
     [JsonPropertyName("access_tokens_url")]
-    public string AccessTokensUrl { get; init; } = null!;
+    public required string AccessTokensUrl { get; init; }
 
     [JsonPropertyName("repositories_url")]
-    public string RepositoriesUrl { get; init; } = null!;
+    public required string RepositoriesUrl { get; init; }
 
     [JsonPropertyName("html_url")]
-    public string HtmlUrl { get; init; } = null!;
+    public required string HtmlUrl { get; init; }
 
     [JsonPropertyName("app_id")]
     public long AppId { get; init; }
@@ -33,7 +33,7 @@ public sealed record Installation
 
     [JsonPropertyName("target_type")]
     [JsonConverter(typeof(StringEnumConverter<InstallationTargetType>))]
-    public StringEnum<InstallationTargetType> TargetType { get; init; } = null!;
+    public required StringEnum<InstallationTargetType> TargetType { get; init; }
 
     [JsonPropertyName("permissions")]
     public AppPermissions? Permissions { get; init; }
@@ -57,7 +57,7 @@ public sealed record Installation
     public bool? HasMultipleSingleFiles { get; init; }
 
     [JsonPropertyName("single_file_paths")]
-    public IEnumerable<string>? SingleFilePaths { get; init; }
+    public IReadOnlyList<string>? SingleFilePaths { get; init; }
 
     [JsonPropertyName("suspended_by")]
     public User? SuspendedBy { get; init; }

--- a/src/Octokit.Webhooks/Models/InstallationEvent/Repository.cs
+++ b/src/Octokit.Webhooks/Models/InstallationEvent/Repository.cs
@@ -7,13 +7,13 @@ public sealed record Repository
     public long Id { get; init; }
 
     [JsonPropertyName("node_id")]
-    public string NodeId { get; init; } = null!;
+    public required string NodeId { get; init; }
 
     [JsonPropertyName("name")]
-    public string Name { get; init; } = null!;
+    public required string Name { get; init; }
 
     [JsonPropertyName("full_name")]
-    public string FullName { get; init; } = null!;
+    public required string FullName { get; init; }
 
     [JsonPropertyName("private")]
     public bool Private { get; init; }

--- a/src/Octokit.Webhooks/Models/InstallationLite.cs
+++ b/src/Octokit.Webhooks/Models/InstallationLite.cs
@@ -7,5 +7,5 @@ public sealed record InstallationLite
     public long Id { get; init; }
 
     [JsonPropertyName("node_id")]
-    public string NodeId { get; init; } = null!;
+    public required string NodeId { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/InstallationRepositoriesEvent/Repository.cs
+++ b/src/Octokit.Webhooks/Models/InstallationRepositoriesEvent/Repository.cs
@@ -7,13 +7,13 @@ public sealed record Repository
     public long Id { get; init; }
 
     [JsonPropertyName("node_id")]
-    public string NodeId { get; init; } = null!;
+    public required string NodeId { get; init; }
 
     [JsonPropertyName("name")]
-    public string Name { get; init; } = null!;
+    public required string Name { get; init; }
 
     [JsonPropertyName("full_name")]
-    public string FullName { get; init; } = null!;
+    public required string FullName { get; init; }
 
     [JsonPropertyName("private")]
     public bool Private { get; init; }

--- a/src/Octokit.Webhooks/Models/InstallationTargetEvent/ChangesLogin.cs
+++ b/src/Octokit.Webhooks/Models/InstallationTargetEvent/ChangesLogin.cs
@@ -4,5 +4,5 @@ namespace Octokit.Webhooks.Models.InstallationTargetEvent;
 public record ChangesLogin
 {
     [JsonPropertyName("from")]
-    public string From { get; init; } = null!;
+    public required string From { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/InstallationTargetEvent/ChangesSlug.cs
+++ b/src/Octokit.Webhooks/Models/InstallationTargetEvent/ChangesSlug.cs
@@ -4,5 +4,5 @@ namespace Octokit.Webhooks.Models.InstallationTargetEvent;
 public sealed record ChangesSlug
 {
     [JsonPropertyName("from")]
-    public string From { get; init; } = null!;
+    public required string From { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/Issue.cs
+++ b/src/Octokit.Webhooks/Models/Issue.cs
@@ -4,40 +4,40 @@ namespace Octokit.Webhooks.Models;
 public sealed record Issue
 {
     [JsonPropertyName("url")]
-    public string Url { get; init; } = null!;
+    public required string Url { get; init; }
 
     [JsonPropertyName("repository_url")]
-    public string RepositoryUrl { get; init; } = null!;
+    public required string RepositoryUrl { get; init; }
 
     [JsonPropertyName("labels_url")]
-    public string LabelsUrl { get; init; } = null!;
+    public required string LabelsUrl { get; init; }
 
     [JsonPropertyName("comments_url")]
-    public string CommentsUrl { get; init; } = null!;
+    public required string CommentsUrl { get; init; }
 
     [JsonPropertyName("events_url")]
-    public string EventsUrl { get; init; } = null!;
+    public required string EventsUrl { get; init; }
 
     [JsonPropertyName("html_url")]
-    public string HtmlUrl { get; init; } = null!;
+    public required string HtmlUrl { get; init; }
 
     [JsonPropertyName("id")]
     public long Id { get; init; }
 
     [JsonPropertyName("node_id")]
-    public string NodeId { get; init; } = null!;
+    public required string NodeId { get; init; }
 
     [JsonPropertyName("number")]
     public long Number { get; init; }
 
     [JsonPropertyName("title")]
-    public string Title { get; init; } = null!;
+    public required string Title { get; init; }
 
     [JsonPropertyName("user")]
-    public User User { get; init; } = null!;
+    public required User User { get; init; }
 
     [JsonPropertyName("labels")]
-    public IEnumerable<Label> Labels { get; init; } = null!;
+    public IReadOnlyList<Label>? Labels { get; init; }
 
     [JsonPropertyName("state")]
     [JsonConverter(typeof(StringEnumConverter<IssueState>))]
@@ -50,7 +50,7 @@ public sealed record Issue
     public User? Assignee { get; init; }
 
     [JsonPropertyName("assignees")]
-    public IEnumerable<User> Assignees { get; init; } = null!;
+    public required IReadOnlyList<User> Assignees { get; init; }
 
     [JsonPropertyName("milestone")]
     public Milestone? Milestone { get; init; }
@@ -72,7 +72,7 @@ public sealed record Issue
 
     [JsonPropertyName("author_association")]
     [JsonConverter(typeof(StringEnumConverter<AuthorAssociation>))]
-    public StringEnum<AuthorAssociation> AuthorAssociation { get; init; } = null!;
+    public StringEnum<AuthorAssociation>? AuthorAssociation { get; init; }
 
     [JsonPropertyName("active_lock_reason")]
     [JsonConverter(typeof(StringEnumConverter<ActiveLockReason>))]
@@ -82,13 +82,13 @@ public sealed record Issue
     public App? PerformedViaGithubApp { get; init; }
 
     [JsonPropertyName("pull_request")]
-    public IssuePullRequest PullRequest { get; init; } = null!;
+    public IssuePullRequest? PullRequest { get; init; }
 
     [JsonPropertyName("body")]
     public string? Body { get; init; }
 
     [JsonPropertyName("reactions")]
-    public Reactions Reactions { get; init; } = null!;
+    public Reactions? Reactions { get; init; }
 
     [JsonPropertyName("state_reason")]
     public string? StateReason { get; init; }

--- a/src/Octokit.Webhooks/Models/IssueComment.cs
+++ b/src/Octokit.Webhooks/Models/IssueComment.cs
@@ -4,22 +4,22 @@ namespace Octokit.Webhooks.Models;
 public sealed record IssueComment
 {
     [JsonPropertyName("url")]
-    public string Url { get; init; } = null!;
+    public required string Url { get; init; }
 
     [JsonPropertyName("html_url")]
-    public string HtmlUrl { get; init; } = null!;
+    public required string HtmlUrl { get; init; }
 
     [JsonPropertyName("issue_url")]
-    public string IssueUrl { get; init; } = null!;
+    public required string IssueUrl { get; init; }
 
     [JsonPropertyName("id")]
     public long Id { get; init; }
 
     [JsonPropertyName("node_id")]
-    public string NodeId { get; init; } = null!;
+    public required string NodeId { get; init; }
 
     [JsonPropertyName("user")]
-    public User User { get; init; } = null!;
+    public required User User { get; init; }
 
     [JsonPropertyName("created_at")]
     [JsonConverter(typeof(DateTimeOffsetConverter))]
@@ -31,10 +31,10 @@ public sealed record IssueComment
 
     [JsonPropertyName("author_association")]
     [JsonConverter(typeof(StringEnumConverter<AuthorAssociation>))]
-    public StringEnum<AuthorAssociation> AuthorAssociation { get; init; } = null!;
+    public required StringEnum<AuthorAssociation> AuthorAssociation { get; init; }
 
     [JsonPropertyName("body")]
-    public string Body { get; init; } = null!;
+    public required string Body { get; init; }
 
     [JsonPropertyName("reactions")]
     public Reactions? Reactions { get; init; }

--- a/src/Octokit.Webhooks/Models/IssueCommentEvent/ChangesBody.cs
+++ b/src/Octokit.Webhooks/Models/IssueCommentEvent/ChangesBody.cs
@@ -4,5 +4,5 @@ namespace Octokit.Webhooks.Models.IssueCommentEvent;
 public sealed record ChangesBody
 {
     [JsonPropertyName("from")]
-    public string From { get; init; } = null!;
+    public required string From { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/IssueType.cs
+++ b/src/Octokit.Webhooks/Models/IssueType.cs
@@ -7,10 +7,10 @@ public sealed record IssueType
     public long Id { get; init; }
 
     [JsonPropertyName("node_id")]
-    public string NodeId { get; init; } = null!;
+    public required string NodeId { get; init; }
 
     [JsonPropertyName("name")]
-    public string Name { get; init; } = null!;
+    public required string Name { get; init; }
 
     [JsonPropertyName("description")]
     public string? Description { get; init; }

--- a/src/Octokit.Webhooks/Models/IssuesEvent/ChangesBody.cs
+++ b/src/Octokit.Webhooks/Models/IssuesEvent/ChangesBody.cs
@@ -4,5 +4,5 @@ namespace Octokit.Webhooks.Models.IssuesEvent;
 public sealed record ChangesBody
 {
     [JsonPropertyName("from")]
-    public string From { get; init; } = null!;
+    public required string From { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/IssuesEvent/ChangesTitle.cs
+++ b/src/Octokit.Webhooks/Models/IssuesEvent/ChangesTitle.cs
@@ -4,5 +4,5 @@ namespace Octokit.Webhooks.Models.IssuesEvent;
 public sealed record ChangesTitle
 {
     [JsonPropertyName("from")]
-    public string From { get; init; } = null!;
+    public required string From { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/Label.cs
+++ b/src/Octokit.Webhooks/Models/Label.cs
@@ -7,19 +7,19 @@ public sealed record Label
     public long Id { get; init; }
 
     [JsonPropertyName("node_id")]
-    public string NodeId { get; init; } = null!;
+    public required string NodeId { get; init; }
 
     [JsonPropertyName("url")]
-    public string Url { get; init; } = null!;
+    public required string Url { get; init; }
 
     [JsonPropertyName("name")]
-    public string Name { get; init; } = null!;
+    public required string Name { get; init; }
 
     [JsonPropertyName("description")]
     public string? Description { get; init; }
 
     [JsonPropertyName("color")]
-    public string Color { get; init; } = null!;
+    public required string Color { get; init; }
 
     [JsonPropertyName("default")]
     public bool Default { get; init; }

--- a/src/Octokit.Webhooks/Models/LabelEvent/Changes.cs
+++ b/src/Octokit.Webhooks/Models/LabelEvent/Changes.cs
@@ -4,11 +4,11 @@ namespace Octokit.Webhooks.Models.LabelEvent;
 public sealed record Changes
 {
     [JsonPropertyName("color")]
-    public ChangesColor Color { get; init; } = null!;
+    public required ChangesColor Color { get; init; }
 
     [JsonPropertyName("name")]
-    public ChangesName Name { get; init; } = null!;
+    public ChangesName? Name { get; init; }
 
     [JsonPropertyName("description")]
-    public ChangesDescription Description { get; init; } = null!;
+    public ChangesDescription? Description { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/LabelEvent/ChangesColor.cs
+++ b/src/Octokit.Webhooks/Models/LabelEvent/ChangesColor.cs
@@ -4,5 +4,5 @@ namespace Octokit.Webhooks.Models.LabelEvent;
 public sealed record ChangesColor
 {
     [JsonPropertyName("from")]
-    public string From { get; init; } = null!;
+    public required string From { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/LabelEvent/ChangesDescription.cs
+++ b/src/Octokit.Webhooks/Models/LabelEvent/ChangesDescription.cs
@@ -4,5 +4,5 @@ namespace Octokit.Webhooks.Models.LabelEvent;
 public sealed record ChangesDescription
 {
     [JsonPropertyName("from")]
-    public string From { get; init; } = null!;
+    public required string From { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/LabelEvent/ChangesName.cs
+++ b/src/Octokit.Webhooks/Models/LabelEvent/ChangesName.cs
@@ -4,5 +4,5 @@ namespace Octokit.Webhooks.Models.LabelEvent;
 public sealed record ChangesName
 {
     [JsonPropertyName("from")]
-    public string From { get; init; } = null!;
+    public required string From { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/License.cs
+++ b/src/Octokit.Webhooks/Models/License.cs
@@ -4,17 +4,17 @@ namespace Octokit.Webhooks.Models;
 public sealed record License
 {
     [JsonPropertyName("key")]
-    public string Key { get; init; } = null!;
+    public required string Key { get; init; }
 
     [JsonPropertyName("name")]
-    public string Name { get; init; } = null!;
+    public required string Name { get; init; }
 
     [JsonPropertyName("spdx_id")]
-    public string SpdxId { get; init; } = null!;
+    public required string SpdxId { get; init; }
 
     [JsonPropertyName("url")]
     public string? Url { get; init; }
 
     [JsonPropertyName("node_id")]
-    public string NodeId { get; init; } = null!;
+    public required string NodeId { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/Link.cs
+++ b/src/Octokit.Webhooks/Models/Link.cs
@@ -4,5 +4,5 @@ namespace Octokit.Webhooks.Models;
 public sealed record Link
 {
     [JsonPropertyName("href")]
-    public string Href { get; init; } = null!;
+    public required string Href { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/MarketplacePurchase.cs
+++ b/src/Octokit.Webhooks/Models/MarketplacePurchase.cs
@@ -4,10 +4,10 @@ namespace Octokit.Webhooks.Models;
 public sealed record MarketplacePurchase
 {
     [JsonPropertyName("account")]
-    public MarketplacePurchaseAccount Account { get; init; } = null!;
+    public required MarketplacePurchaseAccount Account { get; init; }
 
     [JsonPropertyName("billing_cycle")]
-    public string BillingCycle { get; init; } = null!;
+    public required string BillingCycle { get; init; }
 
     [JsonPropertyName("unit_count")]
     public long UnitCount { get; init; }
@@ -22,5 +22,5 @@ public sealed record MarketplacePurchase
     public string? NextBillingDate { get; init; }
 
     [JsonPropertyName("plan")]
-    public MarketplacePurchasePlan Plan { get; init; } = null!;
+    public required MarketplacePurchasePlan Plan { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/MarketplacePurchaseAccount.cs
+++ b/src/Octokit.Webhooks/Models/MarketplacePurchaseAccount.cs
@@ -4,17 +4,17 @@ namespace Octokit.Webhooks.Models;
 public sealed record MarketplacePurchaseAccount
 {
     [JsonPropertyName("type")]
-    public string Type { get; init; } = null!;
+    public required string Type { get; init; }
 
     [JsonPropertyName("id")]
     public long Id { get; init; }
 
     [JsonPropertyName("node_id")]
-    public string NodeId { get; init; } = null!;
+    public required string NodeId { get; init; }
 
     [JsonPropertyName("login")]
-    public string Login { get; init; } = null!;
+    public required string Login { get; init; }
 
     [JsonPropertyName("organization_billing_email")]
-    public string OrganizationBillingEmail { get; init; } = null!;
+    public required string OrganizationBillingEmail { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/MarketplacePurchasePlan.cs
+++ b/src/Octokit.Webhooks/Models/MarketplacePurchasePlan.cs
@@ -7,10 +7,10 @@ public sealed record MarketplacePurchasePlan
     public long Id { get; init; }
 
     [JsonPropertyName("name")]
-    public string Name { get; init; } = null!;
+    public required string Name { get; init; }
 
     [JsonPropertyName("description")]
-    public string Description { get; init; } = null!;
+    public required string Description { get; init; }
 
     [JsonPropertyName("monthly_price_in_cents")]
     public long MonthlyPriceInCents { get; init; }
@@ -19,7 +19,7 @@ public sealed record MarketplacePurchasePlan
     public long YearlyPriceInCents { get; init; }
 
     [JsonPropertyName("price_model")]
-    public string PriceModel { get; init; } = null!;
+    public required string PriceModel { get; init; }
 
     [JsonPropertyName("has_free_trial")]
     public bool HasFreeTrial { get; init; }
@@ -28,5 +28,5 @@ public sealed record MarketplacePurchasePlan
     public string? UnitName { get; init; }
 
     [JsonPropertyName("bullets")]
-    public IEnumerable<string> Bullets { get; init; } = null!;
+    public required IReadOnlyList<string> Bullets { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/MemberEvent/ChangesOldPermission.cs
+++ b/src/Octokit.Webhooks/Models/MemberEvent/ChangesOldPermission.cs
@@ -4,5 +4,5 @@ namespace Octokit.Webhooks.Models.MemberEvent;
 public sealed record ChangesOldPermission
 {
     [JsonPropertyName("from")]
-    public string From { get; init; } = null!;
+    public required string From { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/MemberEvent/ChangesPermission.cs
+++ b/src/Octokit.Webhooks/Models/MemberEvent/ChangesPermission.cs
@@ -4,5 +4,5 @@ namespace Octokit.Webhooks.Models.MemberEvent;
 public sealed record ChangesPermission
 {
     [JsonPropertyName("from")]
-    public string From { get; init; } = null!;
+    public required string From { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/Membership.cs
+++ b/src/Octokit.Webhooks/Models/Membership.cs
@@ -4,17 +4,17 @@ namespace Octokit.Webhooks.Models;
 public sealed record Membership
 {
     [JsonPropertyName("url")]
-    public string Url { get; init; } = null!;
+    public required string Url { get; init; }
 
     [JsonPropertyName("state")]
-    public string State { get; init; } = null!;
+    public required string State { get; init; }
 
     [JsonPropertyName("role")]
-    public string Role { get; init; } = null!;
+    public required string Role { get; init; }
 
     [JsonPropertyName("organization_url")]
-    public string OrganizationUrl { get; init; } = null!;
+    public required string OrganizationUrl { get; init; }
 
     [JsonPropertyName("user")]
-    public User User { get; init; } = null!;
+    public required User User { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/MergeGroupEvent/MergeGroup.cs
+++ b/src/Octokit.Webhooks/Models/MergeGroupEvent/MergeGroup.cs
@@ -4,17 +4,17 @@ namespace Octokit.Webhooks.Models.MergeGroupEvent;
 public sealed record MergeGroup
 {
     [JsonPropertyName("head_sha")]
-    public string HeadSha { get; init; } = null!;
+    public required string HeadSha { get; init; }
 
     [JsonPropertyName("head_ref")]
-    public string HeadRef { get; init; } = null!;
+    public required string HeadRef { get; init; }
 
     [JsonPropertyName("base_ref")]
-    public string BaseRef { get; init; } = null!;
+    public required string BaseRef { get; init; }
 
     [JsonPropertyName("base_sha")]
-    public string BaseSha { get; init; } = null!;
+    public required string BaseSha { get; init; }
 
     [JsonPropertyName("head_commit")]
-    public SimpleCommit HeadCommit { get; init; } = null!;
+    public required SimpleCommit HeadCommit { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/MetaEvent/Hook.cs
+++ b/src/Octokit.Webhooks/Models/MetaEvent/Hook.cs
@@ -4,23 +4,23 @@ namespace Octokit.Webhooks.Models.MetaEvent;
 public sealed record Hook
 {
     [JsonPropertyName("type")]
-    public string Type { get; init; } = null!;
+    public required string Type { get; init; }
 
     [JsonPropertyName("id")]
     public long Id { get; init; }
 
     [JsonPropertyName("name")]
-    public string Name { get; init; } = null!;
+    public required string Name { get; init; }
 
     [JsonPropertyName("active")]
     public bool Active { get; init; }
 
     [JsonPropertyName("events")]
     [JsonConverter(typeof(StringEnumEnumerableConverter<AppEvent>))]
-    public IEnumerable<StringEnum<AppEvent>> Events { get; init; } = null!;
+    public required IEnumerable<StringEnum<AppEvent>> Events { get; init; }
 
     [JsonPropertyName("config")]
-    public HookConfig Config { get; init; } = null!;
+    public required HookConfig Config { get; init; }
 
     [JsonPropertyName("updated_at")]
     [JsonConverter(typeof(DateTimeOffsetConverter))]

--- a/src/Octokit.Webhooks/Models/MetaEvent/HookConfig.cs
+++ b/src/Octokit.Webhooks/Models/MetaEvent/HookConfig.cs
@@ -5,13 +5,13 @@ public sealed record HookConfig
 {
     [JsonPropertyName("content_type")]
     [JsonConverter(typeof(StringEnumConverter<HookConfigContentType>))]
-    public StringEnum<HookConfigContentType> ContentType { get; init; } = null!;
+    public required StringEnum<HookConfigContentType> ContentType { get; init; }
 
     [JsonPropertyName("url")]
-    public string Url { get; init; } = null!;
+    public required string Url { get; init; }
 
     [JsonPropertyName("insecure_ssl")]
-    public string InsecureSsl { get; init; } = null!;
+    public required string InsecureSsl { get; init; }
 
     [JsonPropertyName("secret")]
     public string? Secret { get; init; }

--- a/src/Octokit.Webhooks/Models/Milestone.cs
+++ b/src/Octokit.Webhooks/Models/Milestone.cs
@@ -4,31 +4,31 @@ namespace Octokit.Webhooks.Models;
 public sealed record Milestone
 {
     [JsonPropertyName("url")]
-    public string Url { get; init; } = null!;
+    public required string Url { get; init; }
 
     [JsonPropertyName("html_url")]
-    public string HtmlUrl { get; init; } = null!;
+    public required string HtmlUrl { get; init; }
 
     [JsonPropertyName("labels_url")]
-    public string LabelsUrl { get; init; } = null!;
+    public required string LabelsUrl { get; init; }
 
     [JsonPropertyName("id")]
     public long Id { get; init; }
 
     [JsonPropertyName("node_id")]
-    public string NodeId { get; init; } = null!;
+    public required string NodeId { get; init; }
 
     [JsonPropertyName("number")]
     public long Number { get; init; }
 
     [JsonPropertyName("title")]
-    public string Title { get; init; } = null!;
+    public required string Title { get; init; }
 
     [JsonPropertyName("description")]
     public string? Description { get; init; }
 
     [JsonPropertyName("creator")]
-    public User Creator { get; init; } = null!;
+    public required User Creator { get; init; }
 
     [JsonPropertyName("open_issues")]
     public long OpenIssues { get; init; }
@@ -38,7 +38,7 @@ public sealed record Milestone
 
     [JsonPropertyName("state")]
     [JsonConverter(typeof(StringEnumConverter<MilestoneState>))]
-    public StringEnum<MilestoneState> State { get; init; } = null!;
+    public required StringEnum<MilestoneState> State { get; init; }
 
     [JsonPropertyName("created_at")]
     [JsonConverter(typeof(DateTimeOffsetConverter))]

--- a/src/Octokit.Webhooks/Models/MilestoneEvent/ChangesDescription.cs
+++ b/src/Octokit.Webhooks/Models/MilestoneEvent/ChangesDescription.cs
@@ -4,5 +4,5 @@ namespace Octokit.Webhooks.Models.MilestoneEvent;
 public sealed record ChangesDescription
 {
     [JsonPropertyName("from")]
-    public string From { get; init; } = null!;
+    public required string From { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/MilestoneEvent/ChangesDueOn.cs
+++ b/src/Octokit.Webhooks/Models/MilestoneEvent/ChangesDueOn.cs
@@ -4,5 +4,5 @@ namespace Octokit.Webhooks.Models.MilestoneEvent;
 public sealed record ChangesDueOn
 {
     [JsonPropertyName("from")]
-    public string From { get; init; } = null!;
+    public required string From { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/MilestoneEvent/ChangesTitle.cs
+++ b/src/Octokit.Webhooks/Models/MilestoneEvent/ChangesTitle.cs
@@ -4,5 +4,5 @@ namespace Octokit.Webhooks.Models.MilestoneEvent;
 public sealed record ChangesTitle
 {
     [JsonPropertyName("from")]
-    public string From { get; init; } = null!;
+    public required string From { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/Organization.cs
+++ b/src/Octokit.Webhooks/Models/Organization.cs
@@ -4,40 +4,40 @@ namespace Octokit.Webhooks.Models;
 public sealed record Organization
 {
     [JsonPropertyName("login")]
-    public string Login { get; init; } = null!;
+    public required string Login { get; init; }
 
     [JsonPropertyName("id")]
     public long Id { get; init; }
 
     [JsonPropertyName("node_id")]
-    public string NodeId { get; init; } = null!;
+    public required string NodeId { get; init; }
 
     [JsonPropertyName("url")]
-    public string Url { get; init; } = null!;
+    public required string Url { get; init; }
 
     [JsonPropertyName("html_url")]
     public string? HtmlUrl { get; init; }
 
     [JsonPropertyName("repos_url")]
-    public string ReposUrl { get; init; } = null!;
+    public string? ReposUrl { get; init; }
 
     [JsonPropertyName("events_url")]
-    public string EventsUrl { get; init; } = null!;
+    public string? EventsUrl { get; init; }
 
     [JsonPropertyName("hooks_url")]
-    public string HooksUrl { get; init; } = null!;
+    public string? HooksUrl { get; init; }
 
     [JsonPropertyName("issues_url")]
-    public string IssuesUrl { get; init; } = null!;
+    public string? IssuesUrl { get; init; }
 
     [JsonPropertyName("members_url")]
-    public string MembersUrl { get; init; } = null!;
+    public string? MembersUrl { get; init; }
 
     [JsonPropertyName("public_members_url")]
-    public string PublicMembersUrl { get; init; } = null!;
+    public string? PublicMembersUrl { get; init; }
 
     [JsonPropertyName("avatar_url")]
-    public string AvatarUrl { get; init; } = null!;
+    public required string AvatarUrl { get; init; }
 
     [JsonPropertyName("description")]
     public string? Description { get; init; }

--- a/src/Octokit.Webhooks/Models/OrganizationEvent/Changes.cs
+++ b/src/Octokit.Webhooks/Models/OrganizationEvent/Changes.cs
@@ -4,5 +4,5 @@ namespace Octokit.Webhooks.Models.OrganizationEvent;
 public sealed record Changes
 {
     [JsonPropertyName("login")]
-    public ChangesLogin Login { get; init; } = null!;
+    public required ChangesLogin Login { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/OrganizationEvent/ChangesLogin.cs
+++ b/src/Octokit.Webhooks/Models/OrganizationEvent/ChangesLogin.cs
@@ -4,5 +4,5 @@ namespace Octokit.Webhooks.Models.OrganizationEvent;
 public record ChangesLogin
 {
     [JsonPropertyName("from")]
-    public string From { get; init; } = null!;
+    public required string From { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/OrganizationEvent/Invitation.cs
+++ b/src/Octokit.Webhooks/Models/OrganizationEvent/Invitation.cs
@@ -7,16 +7,16 @@ public sealed record Invitation
     public long Id { get; init; }
 
     [JsonPropertyName("node_id")]
-    public string NodeId { get; init; } = null!;
+    public required string NodeId { get; init; }
 
     [JsonPropertyName("login")]
-    public string Login { get; init; } = null!;
+    public required string Login { get; init; }
 
     [JsonPropertyName("email")]
     public string? Email { get; init; }
 
     [JsonPropertyName("role")]
-    public string Role { get; init; } = null!;
+    public required string Role { get; init; }
 
     [JsonPropertyName("created_at")]
     [JsonConverter(typeof(DateTimeOffsetConverter))]
@@ -30,11 +30,11 @@ public sealed record Invitation
     public string? FailedReason { get; init; }
 
     [JsonPropertyName("inviter")]
-    public User Inviter { get; init; } = null!;
+    public required User Inviter { get; init; }
 
     [JsonPropertyName("team_count")]
     public long TeamCount { get; init; }
 
     [JsonPropertyName("invitation_teams_url")]
-    public string InvitationTeamsUrl { get; init; } = null!;
+    public required string InvitationTeamsUrl { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/Package.cs
+++ b/src/Octokit.Webhooks/Models/Package.cs
@@ -7,23 +7,23 @@ public sealed record Package
     public long Id { get; init; }
 
     [JsonPropertyName("name")]
-    public string Name { get; init; } = null!;
+    public required string Name { get; init; }
 
     [JsonPropertyName("namespace")]
-    public string Namespace { get; init; } = null!;
+    public required string Namespace { get; init; }
 
     [JsonPropertyName("description")]
     public string? Description { get; init; }
 
     [JsonPropertyName("ecosystem")]
-    public string Ecosystem { get; init; } = null!;
+    public required string Ecosystem { get; init; }
 
     [JsonPropertyName("package_type")]
     [JsonConverter(typeof(StringEnumConverter<PackageType>))]
-    public StringEnum<PackageType> PackageType { get; init; } = null!;
+    public required StringEnum<PackageType> PackageType { get; init; }
 
     [JsonPropertyName("html_url")]
-    public string HtmlUrl { get; init; } = null!;
+    public required string HtmlUrl { get; init; }
 
     [JsonPropertyName("created_at")]
     [JsonConverter(typeof(DateTimeOffsetConverter))]
@@ -34,11 +34,11 @@ public sealed record Package
     public DateTimeOffset UpdatedAt { get; init; }
 
     [JsonPropertyName("owner")]
-    public User Owner { get; init; } = null!;
+    public required User Owner { get; init; }
 
     [JsonPropertyName("package_version")]
     public PackageVersion? PackageVersion { get; init; }
 
     [JsonPropertyName("registry")]
-    public PackageRegistry Registry { get; init; } = null!;
+    public required PackageRegistry Registry { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/PackageRegistry.cs
+++ b/src/Octokit.Webhooks/Models/PackageRegistry.cs
@@ -4,17 +4,17 @@ namespace Octokit.Webhooks.Models;
 public sealed record PackageRegistry
 {
     [JsonPropertyName("about_url")]
-    public string AboutUrl { get; init; } = null!;
+    public required string AboutUrl { get; init; }
 
     [JsonPropertyName("name")]
-    public string Name { get; init; } = null!;
+    public required string Name { get; init; }
 
     [JsonPropertyName("type")]
-    public string Type { get; init; } = null!;
+    public required string Type { get; init; }
 
     [JsonPropertyName("url")]
-    public string Url { get; init; } = null!;
+    public required string Url { get; init; }
 
     [JsonPropertyName("vendor")]
-    public string Vendor { get; init; } = null!;
+    public required string Vendor { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/PackageVersion.cs
+++ b/src/Octokit.Webhooks/Models/PackageVersion.cs
@@ -7,16 +7,16 @@ public sealed record PackageVersion
     public long Id { get; init; }
 
     [JsonPropertyName("version")]
-    public string Version { get; init; } = null!;
+    public required string Version { get; init; }
 
     [JsonPropertyName("summary")]
-    public string Summary { get; init; } = null!;
+    public required string Summary { get; init; }
 
     [JsonPropertyName("name")]
-    public string Name { get; init; } = null!;
+    public required string Name { get; init; }
 
     [JsonPropertyName("description")]
-    public string Description { get; init; } = null!;
+    public required string Description { get; init; }
 
     [JsonPropertyName("body")]
     public dynamic? Body { get; init; }
@@ -31,7 +31,7 @@ public sealed record PackageVersion
     public string? Manifest { get; init; }
 
     [JsonPropertyName("html_url")]
-    public string HtmlUrl { get; init; } = null!;
+    public required string HtmlUrl { get; init; }
 
     [JsonPropertyName("tag_name")]
     public string? TagName { get; init; }
@@ -57,25 +57,25 @@ public sealed record PackageVersion
     public DateTimeOffset? UpdatedAt { get; init; }
 
     [JsonPropertyName("metadata")]
-    public IEnumerable<dynamic> Metadata { get; init; } = null!;
+    public required IReadOnlyList<dynamic> Metadata { get; init; }
 
     [JsonPropertyName("container_metadata")]
     public ContainerMetadata? ContainerMetadata { get; init; }
 
     [JsonPropertyName("docker_metadata")]
-    public IEnumerable<dynamic>? DockerMetadata { get; init; }
+    public IReadOnlyList<dynamic>? DockerMetadata { get; init; }
 
     [JsonPropertyName("npm_metadata")]
     public IDictionary<string, dynamic>? NpmMetadata { get; init; }
 
     [JsonPropertyName("nuget_metadata")]
-    public IEnumerable<PackageVersionNugetMetadata>? NugetMetadata { get; init; }
+    public IReadOnlyList<PackageVersionNugetMetadata>? NugetMetadata { get; init; }
 
     [JsonPropertyName("rubygems_metadata")]
     public IDictionary<string, dynamic>? RubygemsMetadata { get; init; }
 
     [JsonPropertyName("package_files")]
-    public IEnumerable<PackageVersionPackageFile> PackageFiles { get; init; } = null!;
+    public required IReadOnlyList<PackageVersionPackageFile> PackageFiles { get; init; }
 
     [JsonPropertyName("package_url")]
     public string? PackageUrl { get; init; }
@@ -87,5 +87,5 @@ public sealed record PackageVersion
     public string? SourceUrl { get; init; }
 
     [JsonPropertyName("installation_command")]
-    public string InstallationCommand { get; init; } = null!;
+    public required string InstallationCommand { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/PackageVersion.cs
+++ b/src/Octokit.Webhooks/Models/PackageVersion.cs
@@ -19,7 +19,7 @@ public sealed record PackageVersion
     public required string Description { get; init; }
 
     [JsonPropertyName("body")]
-    public dynamic? Body { get; init; }
+    public JsonElement? Body { get; init; }
 
     [JsonPropertyName("body_html")]
     public string? BodyHtml { get; init; }
@@ -57,22 +57,22 @@ public sealed record PackageVersion
     public DateTimeOffset? UpdatedAt { get; init; }
 
     [JsonPropertyName("metadata")]
-    public required IReadOnlyList<dynamic> Metadata { get; init; }
+    public required IReadOnlyList<JsonElement> Metadata { get; init; }
 
     [JsonPropertyName("container_metadata")]
     public ContainerMetadata? ContainerMetadata { get; init; }
 
     [JsonPropertyName("docker_metadata")]
-    public IReadOnlyList<dynamic>? DockerMetadata { get; init; }
+    public IReadOnlyList<JsonElement>? DockerMetadata { get; init; }
 
     [JsonPropertyName("npm_metadata")]
-    public IDictionary<string, dynamic>? NpmMetadata { get; init; }
+    public IDictionary<string, JsonElement>? NpmMetadata { get; init; }
 
     [JsonPropertyName("nuget_metadata")]
     public IReadOnlyList<PackageVersionNugetMetadata>? NugetMetadata { get; init; }
 
     [JsonPropertyName("rubygems_metadata")]
-    public IDictionary<string, dynamic>? RubygemsMetadata { get; init; }
+    public IDictionary<string, JsonElement>? RubygemsMetadata { get; init; }
 
     [JsonPropertyName("package_files")]
     public required IReadOnlyList<PackageVersionPackageFile> PackageFiles { get; init; }

--- a/src/Octokit.Webhooks/Models/PackageVersionNugetMetadata.cs
+++ b/src/Octokit.Webhooks/Models/PackageVersionNugetMetadata.cs
@@ -10,5 +10,5 @@ public sealed record PackageVersionNugetMetadata
     public string? Id { get; init; }
 
     [JsonPropertyName("value")]
-    public dynamic? Value { get; init; }
+    public JsonElement? Value { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/PackageVersionPackageFile.cs
+++ b/src/Octokit.Webhooks/Models/PackageVersionPackageFile.cs
@@ -4,28 +4,28 @@ namespace Octokit.Webhooks.Models;
 public sealed record PackageVersionPackageFile
 {
     [JsonPropertyName("download_url")]
-    public string DownloadUrl { get; init; } = null!;
+    public required string DownloadUrl { get; init; }
 
     [JsonPropertyName("id")]
     public long Id { get; init; }
 
     [JsonPropertyName("name")]
-    public string Name { get; init; } = null!;
+    public required string Name { get; init; }
 
     [JsonPropertyName("sha256")]
-    public string Sha256 { get; init; } = null!;
+    public required string Sha256 { get; init; }
 
     [JsonPropertyName("sha1")]
-    public string Sha1 { get; init; } = null!;
+    public required string Sha1 { get; init; }
 
     [JsonPropertyName("md5")]
-    public string Md5 { get; init; } = null!;
+    public required string Md5 { get; init; }
 
     [JsonPropertyName("content_type")]
-    public string ContentType { get; init; } = null!;
+    public required string ContentType { get; init; }
 
     [JsonPropertyName("state")]
-    public string State { get; init; } = null!;
+    public required string State { get; init; }
 
     [JsonPropertyName("size")]
     public long Size { get; init; }

--- a/src/Octokit.Webhooks/Models/PackageVersionRelease.cs
+++ b/src/Octokit.Webhooks/Models/PackageVersionRelease.cs
@@ -4,28 +4,28 @@ namespace Octokit.Webhooks.Models;
 public sealed record PackageVersionRelease
 {
     [JsonPropertyName("url")]
-    public string Url { get; init; } = null!;
+    public required string Url { get; init; }
 
     [JsonPropertyName("html_url")]
-    public string HtmlUrl { get; init; } = null!;
+    public required string HtmlUrl { get; init; }
 
     [JsonPropertyName("id")]
     public long Id { get; init; }
 
     [JsonPropertyName("tag_name")]
-    public string TagName { get; init; } = null!;
+    public required string TagName { get; init; }
 
     [JsonPropertyName("target_commitish")]
-    public string TargetCommitish { get; init; } = null!;
+    public required string TargetCommitish { get; init; }
 
     [JsonPropertyName("name")]
-    public string Name { get; init; } = null!;
+    public required string Name { get; init; }
 
     [JsonPropertyName("draft")]
     public bool Draft { get; init; }
 
     [JsonPropertyName("author")]
-    public User Author { get; init; } = null!;
+    public required User Author { get; init; }
 
     [JsonPropertyName("prerelease")]
     public bool Prerelease { get; init; }

--- a/src/Octokit.Webhooks/Models/PageBuildEvent/Build.cs
+++ b/src/Octokit.Webhooks/Models/PageBuildEvent/Build.cs
@@ -4,19 +4,19 @@ namespace Octokit.Webhooks.Models.PageBuildEvent;
 public sealed record Build
 {
     [JsonPropertyName("url")]
-    public string Url { get; init; } = null!;
+    public required string Url { get; init; }
 
     [JsonPropertyName("status")]
-    public string Status { get; init; } = null!;
+    public required string Status { get; init; }
 
     [JsonPropertyName("error")]
-    public BuildError Error { get; init; } = null!;
+    public required BuildError Error { get; init; }
 
     [JsonPropertyName("pusher")]
-    public User Pusher { get; init; } = null!;
+    public required User Pusher { get; init; }
 
     [JsonPropertyName("commit")]
-    public string Commit { get; init; } = null!;
+    public required string Commit { get; init; }
 
     [JsonPropertyName("duration")]
     public long Duration { get; init; }

--- a/src/Octokit.Webhooks/Models/PersonalAccessTokenRequestEvent/PersonalAccessTokenRequest.cs
+++ b/src/Octokit.Webhooks/Models/PersonalAccessTokenRequestEvent/PersonalAccessTokenRequest.cs
@@ -7,26 +7,26 @@ public sealed record PersonalAccessTokenRequest
     public long Id { get; init; }
 
     [JsonPropertyName("owner")]
-    public User Owner { get; init; } = null!;
+    public required User Owner { get; init; }
 
     [JsonPropertyName("permissions_added")]
-    public AppPermissions PermissionsAdded { get; init; } = null!;
+    public required AppPermissions PermissionsAdded { get; init; }
 
     [JsonPropertyName("permissions_upgraded")]
-    public AppPermissions PermissionsUpgraded { get; init; } = null!;
+    public required AppPermissions PermissionsUpgraded { get; init; }
 
     [JsonPropertyName("permissions_result")]
-    public AppPermissions PermissionsResult { get; init; } = null!;
+    public required AppPermissions PermissionsResult { get; init; }
 
     [JsonPropertyName("repository_selection")]
     [JsonConverter(typeof(StringEnumConverter<PersonalAccessTokenRequestRepositorySelection>))]
-    public StringEnum<PersonalAccessTokenRequestRepositorySelection> RepositorySelection { get; init; } = null!;
+    public required StringEnum<PersonalAccessTokenRequestRepositorySelection> RepositorySelection { get; init; }
 
     [JsonPropertyName("repository_count")]
     public long? RepositoryCount { get; init; }
 
     [JsonPropertyName("repositories")]
-    public IEnumerable<RepositoryLite>? Repositories { get; init; }
+    public IReadOnlyList<RepositoryLite>? Repositories { get; init; }
 
     [JsonPropertyName("created_at")]
     public DateTimeOffset CreatedAt { get; init; }

--- a/src/Octokit.Webhooks/Models/PingEvent/Hook.cs
+++ b/src/Octokit.Webhooks/Models/PingEvent/Hook.cs
@@ -5,13 +5,13 @@ public sealed record Hook
 {
     [JsonPropertyName("type")]
     [JsonConverter(typeof(StringEnumConverter<HookType>))]
-    public StringEnum<HookType> Type { get; init; } = null!;
+    public required StringEnum<HookType> Type { get; init; }
 
     [JsonPropertyName("id")]
     public long Id { get; init; }
 
     [JsonPropertyName("name")]
-    public string Name { get; init; } = null!;
+    public required string Name { get; init; }
 
     [JsonPropertyName("active")]
     public bool Active { get; init; }
@@ -21,10 +21,10 @@ public sealed record Hook
 
     [JsonPropertyName("events")]
     [JsonConverter(typeof(StringEnumEnumerableConverter<AppEvent>))]
-    public IEnumerable<StringEnum<AppEvent>> Events { get; init; } = null!;
+    public required IEnumerable<StringEnum<AppEvent>> Events { get; init; }
 
     [JsonPropertyName("config")]
-    public HookConfig Config { get; init; } = null!;
+    public required HookConfig Config { get; init; }
 
     [JsonPropertyName("updated_at")]
     [JsonConverter(typeof(DateTimeOffsetConverter))]
@@ -35,17 +35,17 @@ public sealed record Hook
     public DateTimeOffset CreatedAt { get; init; }
 
     [JsonPropertyName("url")]
-    public string Url { get; init; } = null!;
+    public required string Url { get; init; }
 
     [JsonPropertyName("test_url")]
     public string? TestUrl { get; init; }
 
     [JsonPropertyName("ping_url")]
-    public string PingUrl { get; init; } = null!;
+    public required string PingUrl { get; init; }
 
     [JsonPropertyName("deliveries_url")]
-    public string DeliveriesUrl { get; init; } = null!;
+    public required string DeliveriesUrl { get; init; }
 
     [JsonPropertyName("last_response")]
-    public HookLastResponse LastResponse { get; init; } = null!;
+    public HookLastResponse? LastResponse { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/PingEvent/HookConfig.cs
+++ b/src/Octokit.Webhooks/Models/PingEvent/HookConfig.cs
@@ -5,14 +5,14 @@ public sealed record HookConfig
 {
     [JsonPropertyName("content_type")]
     [JsonConverter(typeof(StringEnumConverter<HookConfigContentType>))]
-    public StringEnum<HookConfigContentType> ContentType { get; init; } = null!;
+    public required StringEnum<HookConfigContentType> ContentType { get; init; }
 
     [JsonPropertyName("secret")]
     public string? Secret { get; init; }
 
     [JsonPropertyName("url")]
-    public string Url { get; init; } = null!;
+    public required string Url { get; init; }
 
     [JsonPropertyName("insecure_ssl")]
-    public string InsecureSsl { get; init; } = null!;
+    public required string InsecureSsl { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/PingEvent/HookLastResponse.cs
+++ b/src/Octokit.Webhooks/Models/PingEvent/HookLastResponse.cs
@@ -7,7 +7,7 @@ public sealed record HookLastResponse
     public string? Code { get; init; }
 
     [JsonPropertyName("status")]
-    public string Status { get; init; } = null!;
+    public required string Status { get; init; }
 
     [JsonPropertyName("message")]
     public string? Message { get; init; }

--- a/src/Octokit.Webhooks/Models/Project.cs
+++ b/src/Octokit.Webhooks/Models/Project.cs
@@ -4,25 +4,25 @@ namespace Octokit.Webhooks.Models;
 public sealed record Project
 {
     [JsonPropertyName("owner_url")]
-    public string OwnerUrl { get; init; } = null!;
+    public required string OwnerUrl { get; init; }
 
     [JsonPropertyName("url")]
-    public string Url { get; init; } = null!;
+    public required string Url { get; init; }
 
     [JsonPropertyName("html_url")]
-    public string HtmlUrl { get; init; } = null!;
+    public required string HtmlUrl { get; init; }
 
     [JsonPropertyName("columns_url")]
-    public string ColumnsUrl { get; init; } = null!;
+    public required string ColumnsUrl { get; init; }
 
     [JsonPropertyName("id")]
     public long Id { get; init; }
 
     [JsonPropertyName("node_id")]
-    public string NodeId { get; init; } = null!;
+    public required string NodeId { get; init; }
 
     [JsonPropertyName("name")]
-    public string Name { get; init; } = null!;
+    public required string Name { get; init; }
 
     [JsonPropertyName("body")]
     public string? Body { get; init; }
@@ -32,10 +32,10 @@ public sealed record Project
 
     [JsonPropertyName("state")]
     [JsonConverter(typeof(StringEnumConverter<ProjectState>))]
-    public StringEnum<ProjectState> State { get; init; } = null!;
+    public required StringEnum<ProjectState> State { get; init; }
 
     [JsonPropertyName("creator")]
-    public User Creator { get; init; } = null!;
+    public required User Creator { get; init; }
 
     [JsonPropertyName("created_at")]
     [JsonConverter(typeof(DateTimeOffsetConverter))]

--- a/src/Octokit.Webhooks/Models/ProjectCard.cs
+++ b/src/Octokit.Webhooks/Models/ProjectCard.cs
@@ -4,13 +4,13 @@ namespace Octokit.Webhooks.Models;
 public sealed record ProjectCard
 {
     [JsonPropertyName("url")]
-    public string Url { get; init; } = null!;
+    public required string Url { get; init; }
 
     [JsonPropertyName("project_url")]
-    public string ProjectUrl { get; init; } = null!;
+    public required string ProjectUrl { get; init; }
 
     [JsonPropertyName("column_url")]
-    public string ColumnUrl { get; init; } = null!;
+    public required string ColumnUrl { get; init; }
 
     [JsonPropertyName("column_id")]
     public long ColumnId { get; init; }
@@ -19,7 +19,7 @@ public sealed record ProjectCard
     public long Id { get; init; }
 
     [JsonPropertyName("node_id")]
-    public string NodeId { get; init; } = null!;
+    public required string NodeId { get; init; }
 
     [JsonPropertyName("note")]
     public string? Note { get; init; }
@@ -28,7 +28,7 @@ public sealed record ProjectCard
     public bool Archived { get; init; }
 
     [JsonPropertyName("creator")]
-    public User Creator { get; init; } = null!;
+    public required User Creator { get; init; }
 
     [JsonPropertyName("created_at")]
     [JsonConverter(typeof(DateTimeOffsetConverter))]

--- a/src/Octokit.Webhooks/Models/ProjectCardEvent/ChangesNote.cs
+++ b/src/Octokit.Webhooks/Models/ProjectCardEvent/ChangesNote.cs
@@ -4,5 +4,5 @@ namespace Octokit.Webhooks.Models.ProjectCardEvent;
 public sealed record ChangesNote
 {
     [JsonPropertyName("from")]
-    public string From { get; init; } = null!;
+    public required string From { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/ProjectColumn.cs
+++ b/src/Octokit.Webhooks/Models/ProjectColumn.cs
@@ -4,22 +4,22 @@ namespace Octokit.Webhooks.Models;
 public sealed record ProjectColumn
 {
     [JsonPropertyName("url")]
-    public string Url { get; init; } = null!;
+    public required string Url { get; init; }
 
     [JsonPropertyName("project_url")]
-    public string ProjectUrl { get; init; } = null!;
+    public required string ProjectUrl { get; init; }
 
     [JsonPropertyName("cards_url")]
-    public string CardsUrl { get; init; } = null!;
+    public required string CardsUrl { get; init; }
 
     [JsonPropertyName("id")]
     public long Id { get; init; }
 
     [JsonPropertyName("node_id")]
-    public string NodeId { get; init; } = null!;
+    public required string NodeId { get; init; }
 
     [JsonPropertyName("name")]
-    public string Name { get; init; } = null!;
+    public required string Name { get; init; }
 
     [JsonPropertyName("created_at")]
     [JsonConverter(typeof(DateTimeOffsetConverter))]

--- a/src/Octokit.Webhooks/Models/ProjectColumnEvent/ChangesName.cs
+++ b/src/Octokit.Webhooks/Models/ProjectColumnEvent/ChangesName.cs
@@ -4,5 +4,5 @@ namespace Octokit.Webhooks.Models.ProjectColumnEvent;
 public sealed record ChangesName
 {
     [JsonPropertyName("from")]
-    public string From { get; init; } = null!;
+    public required string From { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/ProjectEvent/ChangesBody.cs
+++ b/src/Octokit.Webhooks/Models/ProjectEvent/ChangesBody.cs
@@ -4,5 +4,5 @@ namespace Octokit.Webhooks.Models.ProjectEvent;
 public sealed record ChangesBody
 {
     [JsonPropertyName("from")]
-    public string From { get; init; } = null!;
+    public required string From { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/ProjectEvent/ChangesName.cs
+++ b/src/Octokit.Webhooks/Models/ProjectEvent/ChangesName.cs
@@ -4,5 +4,5 @@ namespace Octokit.Webhooks.Models.ProjectEvent;
 public sealed record ChangesName
 {
     [JsonPropertyName("from")]
-    public string From { get; init; } = null!;
+    public required string From { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/ProjectsV2Item.cs
+++ b/src/Octokit.Webhooks/Models/ProjectsV2Item.cs
@@ -7,20 +7,20 @@ public sealed record ProjectsV2Item
     public long Id { get; init; }
 
     [JsonPropertyName("node_id")]
-    public string NodeId { get; init; } = null!;
+    public required string NodeId { get; init; }
 
     [JsonPropertyName("project_node_id")]
-    public string ProjectNodeId { get; init; } = null!;
+    public required string ProjectNodeId { get; init; }
 
     [JsonPropertyName("content_node_id")]
-    public string ContentNodeId { get; init; } = null!;
+    public required string ContentNodeId { get; init; }
 
     [JsonPropertyName("content_type")]
     [JsonConverter(typeof(StringEnumConverter<ProjectsV2ItemContentType>))]
-    public StringEnum<ProjectsV2ItemContentType> ContentType { get; init; } = null!;
+    public required StringEnum<ProjectsV2ItemContentType> ContentType { get; init; }
 
     [JsonPropertyName("creator")]
-    public User Creator { get; init; } = null!;
+    public required User Creator { get; init; }
 
     [JsonPropertyName("created_at")]
     [JsonConverter(typeof(DateTimeOffsetConverter))]

--- a/src/Octokit.Webhooks/Models/ProjectsV2ItemEvent/ChangesContentType.cs
+++ b/src/Octokit.Webhooks/Models/ProjectsV2ItemEvent/ChangesContentType.cs
@@ -5,9 +5,9 @@ public sealed record ChangesContentType
 {
     [JsonPropertyName("from")]
     [JsonConverter(typeof(StringEnumConverter<ProjectsV2ItemContentType>))]
-    public StringEnum<ProjectsV2ItemContentType> From { get; init; } = null!;
+    public required StringEnum<ProjectsV2ItemContentType> From { get; init; }
 
     [JsonPropertyName("to")]
     [JsonConverter(typeof(StringEnumConverter<ProjectsV2ItemContentType>))]
-    public StringEnum<ProjectsV2ItemContentType> To { get; init; } = null!;
+    public required StringEnum<ProjectsV2ItemContentType> To { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/ProjectsV2ItemEvent/ChangesFieldValue.cs
+++ b/src/Octokit.Webhooks/Models/ProjectsV2ItemEvent/ChangesFieldValue.cs
@@ -5,20 +5,20 @@ public sealed record ChangesFieldValue
 {
     [JsonPropertyName("field_type")]
     [JsonConverter(typeof(StringEnumConverter<FieldType>))]
-    public StringEnum<FieldType> FieldType { get; init; } = null!;
+    public required StringEnum<FieldType> FieldType { get; init; }
 
     [JsonPropertyName("field_node_id")]
-    public string FieldNodeId { get; init; } = null!;
+    public required string FieldNodeId { get; init; }
 
     [JsonPropertyName("field_name")]
-    public string FieldName { get; init; } = null!;
+    public required string FieldName { get; init; }
 
     [JsonPropertyName("project_number")]
     public long ProjectNumber { get; init; }
 
     [JsonPropertyName("from")]
-    public ChangesFieldValueChangeBase From { get; init; } = null!;
+    public required ChangesFieldValueChangeBase From { get; init; }
 
     [JsonPropertyName("to")]
-    public ChangesFieldValueChangeBase To { get; init; } = null!;
+    public required ChangesFieldValueChangeBase To { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/ProjectsV2ItemEvent/ChangesFieldValueChange.cs
+++ b/src/Octokit.Webhooks/Models/ProjectsV2ItemEvent/ChangesFieldValueChange.cs
@@ -4,14 +4,14 @@ namespace Octokit.Webhooks.Models.ProjectsV2ItemEvent;
 public sealed record ChangesFieldValueChange : ChangesFieldValueChangeBase
 {
     [JsonPropertyName("id")]
-    public string Id { get; init; } = null!;
+    public required string Id { get; init; }
 
     [JsonPropertyName("name")]
-    public string Name { get; init; } = null!;
+    public required string Name { get; init; }
 
     [JsonPropertyName("color")]
-    public string Color { get; init; } = null!;
+    public required string Color { get; init; }
 
     [JsonPropertyName("description")]
-    public string Description { get; init; } = null!;
+    public required string Description { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/ProjectsV2ItemEvent/ChangesPreviousProjectsV2ItemNodeId.cs
+++ b/src/Octokit.Webhooks/Models/ProjectsV2ItemEvent/ChangesPreviousProjectsV2ItemNodeId.cs
@@ -4,7 +4,7 @@ namespace Octokit.Webhooks.Models.ProjectsV2ItemEvent;
 public sealed record ChangesPreviousProjectsV2ItemNodeId
 {
     [JsonPropertyName("from")]
-    public string From { get; init; } = null!;
+    public required string From { get; init; }
 
     [JsonPropertyName("to")]
     public string? To { get; init; }

--- a/src/Octokit.Webhooks/Models/ProjectsV2ProjectEvent/ProjectsV2.cs
+++ b/src/Octokit.Webhooks/Models/ProjectsV2ProjectEvent/ProjectsV2.cs
@@ -7,16 +7,16 @@ public sealed record ProjectsV2
     public long Id { get; init; }
 
     [JsonPropertyName("node_id")]
-    public string NodeId { get; init; } = null!;
+    public required string NodeId { get; init; }
 
     [JsonPropertyName("owner")]
-    public User Owner { get; init; } = null!;
+    public required User Owner { get; init; }
 
     [JsonPropertyName("creator")]
-    public User Creator { get; init; } = null!;
+    public required User Creator { get; init; }
 
     [JsonPropertyName("title")]
-    public string Title { get; init; } = null!;
+    public required string Title { get; init; }
 
     [JsonPropertyName("description")]
     public string? Description { get; init; }

--- a/src/Octokit.Webhooks/Models/ProjectsV2StatusUpdateEvent/ProjectsV2StatusUpdate.cs
+++ b/src/Octokit.Webhooks/Models/ProjectsV2StatusUpdateEvent/ProjectsV2StatusUpdate.cs
@@ -7,13 +7,13 @@ public sealed record ProjectsV2StatusUpdate
     public long Id { get; init; }
 
     [JsonPropertyName("node_id")]
-    public string NodeId { get; init; } = null!;
+    public required string NodeId { get; init; }
 
     [JsonPropertyName("project_node_id")]
-    public string ProjectNodeId { get; init; } = null!;
+    public required string ProjectNodeId { get; init; }
 
     [JsonPropertyName("creator")]
-    public User Creator { get; init; } = null!;
+    public required User Creator { get; init; }
 
     [JsonPropertyName("created_at")]
     public DateTimeOffset CreatedAt { get; init; }

--- a/src/Octokit.Webhooks/Models/PullRequestAutoMerge.cs
+++ b/src/Octokit.Webhooks/Models/PullRequestAutoMerge.cs
@@ -4,14 +4,14 @@ namespace Octokit.Webhooks.Models;
 public sealed record PullRequestAutoMerge
 {
     [JsonPropertyName("enabled_by")]
-    public User EnabledBy { get; init; } = null!;
+    public required User EnabledBy { get; init; }
 
     [JsonPropertyName("merge_method")]
-    public string MergeMethod { get; init; } = null!;
+    public required string MergeMethod { get; init; }
 
     [JsonPropertyName("commit_title")]
-    public string CommitTitle { get; init; } = null!;
+    public required string CommitTitle { get; init; }
 
     [JsonPropertyName("commit_message")]
-    public string CommitMessage { get; init; } = null!;
+    public required string CommitMessage { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/PullRequestEvent/PullRequest.cs
+++ b/src/Octokit.Webhooks/Models/PullRequestEvent/PullRequest.cs
@@ -7,41 +7,41 @@ public sealed record PullRequest
     public string? Body { get; init; }
 
     [JsonPropertyName("url")]
-    public string Url { get; init; } = null!;
+    public required string Url { get; init; }
 
     [JsonPropertyName("id")]
     public long Id { get; init; }
 
     [JsonPropertyName("node_id")]
-    public string NodeId { get; init; } = null!;
+    public required string NodeId { get; init; }
 
     [JsonPropertyName("html_url")]
-    public string HtmlUrl { get; init; } = null!;
+    public required string HtmlUrl { get; init; }
 
     [JsonPropertyName("diff_url")]
-    public string DiffUrl { get; init; } = null!;
+    public required string DiffUrl { get; init; }
 
     [JsonPropertyName("patch_url")]
-    public string PatchUrl { get; init; } = null!;
+    public required string PatchUrl { get; init; }
 
     [JsonPropertyName("issue_url")]
-    public string IssueUrl { get; init; } = null!;
+    public required string IssueUrl { get; init; }
 
     [JsonPropertyName("number")]
     public long Number { get; init; }
 
     [JsonPropertyName("state")]
     [JsonConverter(typeof(StringEnumConverter<PullRequestState>))]
-    public StringEnum<PullRequestState> State { get; init; } = null!;
+    public required StringEnum<PullRequestState> State { get; init; }
 
     [JsonPropertyName("locked")]
     public bool Locked { get; init; }
 
     [JsonPropertyName("title")]
-    public string Title { get; init; } = null!;
+    public required string Title { get; init; }
 
     [JsonPropertyName("user")]
-    public User User { get; init; } = null!;
+    public required User User { get; init; }
 
     [JsonPropertyName("created_at")]
     [JsonConverter(typeof(DateTimeOffsetConverter))]
@@ -66,47 +66,47 @@ public sealed record PullRequest
     public User? Assignee { get; init; }
 
     [JsonPropertyName("assignees")]
-    public IEnumerable<User> Assignees { get; init; } = null!;
+    public required IReadOnlyList<User> Assignees { get; init; }
 
     [JsonPropertyName("requested_reviewers")]
-    public IEnumerable<User> RequestedReviewers { get; init; } = null!;
+    public required IReadOnlyList<User> RequestedReviewers { get; init; }
 
     [JsonPropertyName("requested_teams")]
-    public IEnumerable<Team> RequestedTeams { get; init; } = null!;
+    public required IReadOnlyList<Team> RequestedTeams { get; init; }
 
     [JsonPropertyName("labels")]
-    public IEnumerable<Label> Labels { get; init; } = null!;
+    public required IReadOnlyList<Label> Labels { get; init; }
 
     [JsonPropertyName("milestone")]
     public Milestone? Milestone { get; init; }
 
     [JsonPropertyName("commits_url")]
-    public string CommitsUrl { get; init; } = null!;
+    public required string CommitsUrl { get; init; }
 
     [JsonPropertyName("review_comments_url")]
-    public string ReviewCommentsUrl { get; init; } = null!;
+    public required string ReviewCommentsUrl { get; init; }
 
     [JsonPropertyName("review_comment_url")]
-    public string ReviewCommentUrl { get; init; } = null!;
+    public required string ReviewCommentUrl { get; init; }
 
     [JsonPropertyName("comments_url")]
-    public string CommentsUrl { get; init; } = null!;
+    public required string CommentsUrl { get; init; }
 
     [JsonPropertyName("statuses_url")]
-    public string StatusesUrl { get; init; } = null!;
+    public required string StatusesUrl { get; init; }
 
     [JsonPropertyName("head")]
-    public PullRequestHead Head { get; init; } = null!;
+    public required PullRequestHead Head { get; init; }
 
     [JsonPropertyName("base")]
-    public PullRequestBase Base { get; init; } = null!;
+    public required PullRequestBase Base { get; init; }
 
     [JsonPropertyName("_links")]
-    public PullRequestLinks Links { get; init; } = null!;
+    public required PullRequestLinks Links { get; init; }
 
     [JsonPropertyName("author_association")]
     [JsonConverter(typeof(StringEnumConverter<AuthorAssociation>))]
-    public StringEnum<AuthorAssociation> AuthorAssociation { get; init; } = null!;
+    public required StringEnum<AuthorAssociation> AuthorAssociation { get; init; }
 
     [JsonPropertyName("auto_merge")]
     public PullRequestAutoMerge? AutoMerge { get; init; }
@@ -128,7 +128,7 @@ public sealed record PullRequest
     public bool? Rebaseable { get; init; }
 
     [JsonPropertyName("mergeable_state")]
-    public string MergeableState { get; init; } = null!;
+    public required string MergeableState { get; init; }
 
     [JsonPropertyName("merged_by")]
     public User? MergedBy { get; init; }

--- a/src/Octokit.Webhooks/Models/PullRequestEvent/PullRequestBase.cs
+++ b/src/Octokit.Webhooks/Models/PullRequestEvent/PullRequestBase.cs
@@ -4,17 +4,17 @@ namespace Octokit.Webhooks.Models.PullRequestEvent;
 public sealed record PullRequestBase
 {
     [JsonPropertyName("label")]
-    public string Label { get; init; } = null!;
+    public required string Label { get; init; }
 
     [JsonPropertyName("ref")]
-    public string Ref { get; init; } = null!;
+    public required string Ref { get; init; }
 
     [JsonPropertyName("sha")]
-    public string Sha { get; init; } = null!;
+    public required string Sha { get; init; }
 
     [JsonPropertyName("user")]
-    public User User { get; init; } = null!;
+    public required User User { get; init; }
 
     [JsonPropertyName("repo")]
-    public Repository Repo { get; init; } = null!;
+    public required Repository Repo { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/PullRequestEvent/PullRequestEditedEventChangesBody.cs
+++ b/src/Octokit.Webhooks/Models/PullRequestEvent/PullRequestEditedEventChangesBody.cs
@@ -4,5 +4,5 @@ namespace Octokit.Webhooks.Models.PullRequestEvent;
 public sealed record PullRequestEditedEventChangesBody
 {
     [JsonPropertyName("from")]
-    public string From { get; init; } = null!;
+    public required string From { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/PullRequestEvent/PullRequestEditedEventChangesTitle.cs
+++ b/src/Octokit.Webhooks/Models/PullRequestEvent/PullRequestEditedEventChangesTitle.cs
@@ -4,5 +4,5 @@ namespace Octokit.Webhooks.Models.PullRequestEvent;
 public sealed record PullRequestEditedEventChangesTitle
 {
     [JsonPropertyName("from")]
-    public string From { get; init; } = null!;
+    public required string From { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/PullRequestEvent/PullRequestHead.cs
+++ b/src/Octokit.Webhooks/Models/PullRequestEvent/PullRequestHead.cs
@@ -4,16 +4,16 @@ namespace Octokit.Webhooks.Models.PullRequestEvent;
 public sealed record PullRequestHead
 {
     [JsonPropertyName("label")]
-    public string Label { get; init; } = null!;
+    public required string Label { get; init; }
 
     [JsonPropertyName("ref")]
-    public string Ref { get; init; } = null!;
+    public required string Ref { get; init; }
 
     [JsonPropertyName("sha")]
-    public string Sha { get; init; } = null!;
+    public required string Sha { get; init; }
 
     [JsonPropertyName("user")]
-    public User User { get; init; } = null!;
+    public required User User { get; init; }
 
     [JsonPropertyName("repo")]
     public Repository? Repo { get; init; }

--- a/src/Octokit.Webhooks/Models/PullRequestEvent/PullRequestLinks.cs
+++ b/src/Octokit.Webhooks/Models/PullRequestEvent/PullRequestLinks.cs
@@ -4,26 +4,26 @@ namespace Octokit.Webhooks.Models.PullRequestEvent;
 public sealed record PullRequestLinks
 {
     [JsonPropertyName("self")]
-    public Link Self { get; init; } = null!;
+    public required Link Self { get; init; }
 
     [JsonPropertyName("html")]
-    public Link Html { get; init; } = null!;
+    public required Link Html { get; init; }
 
     [JsonPropertyName("issue")]
-    public Link Issue { get; init; } = null!;
+    public required Link Issue { get; init; }
 
     [JsonPropertyName("comments")]
-    public Link Comments { get; init; } = null!;
+    public required Link Comments { get; init; }
 
     [JsonPropertyName("review_comments")]
-    public Link ReviewComments { get; init; } = null!;
+    public required Link ReviewComments { get; init; }
 
     [JsonPropertyName("review_comment")]
-    public Link ReviewComment { get; init; } = null!;
+    public required Link ReviewComment { get; init; }
 
     [JsonPropertyName("commits")]
-    public Link Commits { get; init; } = null!;
+    public required Link Commits { get; init; }
 
     [JsonPropertyName("statuses")]
-    public Link Statuses { get; init; } = null!;
+    public required Link Statuses { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/PullRequestReviewComment.cs
+++ b/src/Octokit.Webhooks/Models/PullRequestReviewComment.cs
@@ -4,7 +4,7 @@ namespace Octokit.Webhooks.Models;
 public sealed record PullRequestReviewComment
 {
     [JsonPropertyName("url")]
-    public string Url { get; init; } = null!;
+    public required string Url { get; init; }
 
     [JsonPropertyName("pull_request_review_id")]
     public long PullRequestReviewId { get; init; }
@@ -13,13 +13,13 @@ public sealed record PullRequestReviewComment
     public long Id { get; init; }
 
     [JsonPropertyName("node_id")]
-    public string NodeId { get; init; } = null!;
+    public required string NodeId { get; init; }
 
     [JsonPropertyName("diff_hunk")]
-    public string DiffHunk { get; init; } = null!;
+    public required string DiffHunk { get; init; }
 
     [JsonPropertyName("path")]
-    public string Path { get; init; } = null!;
+    public required string Path { get; init; }
 
     [JsonPropertyName("position")]
     public int? Position { get; init; }
@@ -28,16 +28,16 @@ public sealed record PullRequestReviewComment
     public long OriginalPosition { get; init; }
 
     [JsonPropertyName("commit_id")]
-    public string CommitId { get; init; } = null!;
+    public required string CommitId { get; init; }
 
     [JsonPropertyName("original_commit_id")]
-    public string OriginalCommitId { get; init; } = null!;
+    public required string OriginalCommitId { get; init; }
 
     [JsonPropertyName("user")]
-    public User User { get; init; } = null!;
+    public required User User { get; init; }
 
     [JsonPropertyName("body")]
-    public string Body { get; init; } = null!;
+    public required string Body { get; init; }
 
     [JsonPropertyName("created_at")]
     [JsonConverter(typeof(DateTimeOffsetConverter))]
@@ -48,20 +48,20 @@ public sealed record PullRequestReviewComment
     public DateTimeOffset UpdatedAt { get; init; }
 
     [JsonPropertyName("html_url")]
-    public string HtmlUrl { get; init; } = null!;
+    public required string HtmlUrl { get; init; }
 
     [JsonPropertyName("pull_request_url")]
-    public string PullRequestUrl { get; init; } = null!;
+    public required string PullRequestUrl { get; init; }
 
     [JsonPropertyName("author_association")]
     [JsonConverter(typeof(StringEnumConverter<AuthorAssociation>))]
-    public StringEnum<AuthorAssociation> AuthorAssociation { get; init; } = null!;
+    public required StringEnum<AuthorAssociation> AuthorAssociation { get; init; }
 
     [JsonPropertyName("_links")]
-    public PullRequestReviewCommentLinks Links { get; init; } = null!;
+    public required PullRequestReviewCommentLinks Links { get; init; }
 
     [JsonPropertyName("reactions")]
-    public Reactions Reactions { get; init; } = null!;
+    public required Reactions Reactions { get; init; }
 
     [JsonPropertyName("start_line")]
     public int? StartLine { get; init; }
@@ -81,7 +81,7 @@ public sealed record PullRequestReviewComment
 
     [JsonPropertyName("side")]
     [JsonConverter(typeof(StringEnumConverter<Side>))]
-    public StringEnum<Side> Side { get; init; } = null!;
+    public required StringEnum<Side> Side { get; init; }
 
     [JsonPropertyName("in_reply_to_id")]
     public long? InReplyToId { get; init; }

--- a/src/Octokit.Webhooks/Models/PullRequestReviewCommentEvent/ChangesBody.cs
+++ b/src/Octokit.Webhooks/Models/PullRequestReviewCommentEvent/ChangesBody.cs
@@ -4,5 +4,5 @@ namespace Octokit.Webhooks.Models.PullRequestReviewCommentEvent;
 public sealed record ChangesBody
 {
     [JsonPropertyName("from")]
-    public string From { get; init; } = null!;
+    public required string From { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/PullRequestReviewCommentLinks.cs
+++ b/src/Octokit.Webhooks/Models/PullRequestReviewCommentLinks.cs
@@ -4,11 +4,11 @@ namespace Octokit.Webhooks.Models;
 public sealed record PullRequestReviewCommentLinks
 {
     [JsonPropertyName("self")]
-    public Link Self { get; init; } = null!;
+    public required Link Self { get; init; }
 
     [JsonPropertyName("html")]
-    public Link Html { get; init; } = null!;
+    public required Link Html { get; init; }
 
     [JsonPropertyName("pull_request")]
-    public Link PullRequest { get; init; } = null!;
+    public required Link PullRequest { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/PullRequestReviewEvent/ChangesBody.cs
+++ b/src/Octokit.Webhooks/Models/PullRequestReviewEvent/ChangesBody.cs
@@ -4,5 +4,5 @@ namespace Octokit.Webhooks.Models.PullRequestReviewEvent;
 public sealed record ChangesBody
 {
     [JsonPropertyName("from")]
-    public string From { get; init; } = null!;
+    public required string From { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/PullRequestReviewEvent/Review.cs
+++ b/src/Octokit.Webhooks/Models/PullRequestReviewEvent/Review.cs
@@ -7,16 +7,16 @@ public sealed record Review
     public long Id { get; init; }
 
     [JsonPropertyName("node_id")]
-    public string NodeId { get; init; } = null!;
+    public required string NodeId { get; init; }
 
     [JsonPropertyName("user")]
-    public User User { get; init; } = null!;
+    public required User User { get; init; }
 
     [JsonPropertyName("body")]
     public string? Body { get; init; }
 
     [JsonPropertyName("commit_id")]
-    public string CommitId { get; init; } = null!;
+    public required string CommitId { get; init; }
 
     [JsonPropertyName("submitted_at")]
     [JsonConverter(typeof(NullableDateTimeOffsetConverter))]
@@ -27,15 +27,15 @@ public sealed record Review
     public StringEnum<ReviewState>? State { get; init; }
 
     [JsonPropertyName("html_url")]
-    public string HtmlUrl { get; init; } = null!;
+    public required string HtmlUrl { get; init; }
 
     [JsonPropertyName("pull_request_url")]
-    public string PullRequestUrl { get; init; } = null!;
+    public required string PullRequestUrl { get; init; }
 
     [JsonPropertyName("author_association")]
     [JsonConverter(typeof(StringEnumConverter<AuthorAssociation>))]
-    public StringEnum<AuthorAssociation> AuthorAssociation { get; init; } = null!;
+    public required StringEnum<AuthorAssociation> AuthorAssociation { get; init; }
 
     [JsonPropertyName("_links")]
-    public ReviewLinks Links { get; init; } = null!;
+    public required ReviewLinks Links { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/PullRequestReviewEvent/ReviewLinks.cs
+++ b/src/Octokit.Webhooks/Models/PullRequestReviewEvent/ReviewLinks.cs
@@ -4,8 +4,8 @@ namespace Octokit.Webhooks.Models.PullRequestReviewEvent;
 public sealed record ReviewLinks
 {
     [JsonPropertyName("html")]
-    public Link Html { get; init; } = null!;
+    public required Link Html { get; init; }
 
     [JsonPropertyName("pull_request")]
-    public Link PullRequest { get; init; } = null!;
+    public required Link PullRequest { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/PullRequestReviewThreadEvent/Thread.cs
+++ b/src/Octokit.Webhooks/Models/PullRequestReviewThreadEvent/Thread.cs
@@ -4,8 +4,8 @@ namespace Octokit.Webhooks.Models.PullRequestReviewThreadEvent;
 public sealed record Thread
 {
     [JsonPropertyName("node_id")]
-    public string NodeId { get; init; } = null!;
+    public required string NodeId { get; init; }
 
     [JsonPropertyName("comments")]
-    public IEnumerable<PullRequestReviewComment> Comments { get; init; } = null!;
+    public required IReadOnlyList<PullRequestReviewComment> Comments { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/PushEvent/Commit.cs
+++ b/src/Octokit.Webhooks/Models/PushEvent/Commit.cs
@@ -4,35 +4,35 @@ namespace Octokit.Webhooks.Models.PushEvent;
 public sealed record Commit
 {
     [JsonPropertyName("id")]
-    public string Id { get; init; } = null!;
+    public required string Id { get; init; }
 
     [JsonPropertyName("tree_id")]
-    public string TreeId { get; init; } = null!;
+    public required string TreeId { get; init; }
 
     [JsonPropertyName("distinct")]
     public bool Distinct { get; init; }
 
     [JsonPropertyName("message")]
-    public string Message { get; init; } = null!;
+    public required string Message { get; init; }
 
     [JsonPropertyName("timestamp")]
-    public string Timestamp { get; init; } = null!;
+    public required string Timestamp { get; init; }
 
     [JsonPropertyName("url")]
-    public string Url { get; init; } = null!;
+    public required string Url { get; init; }
 
     [JsonPropertyName("author")]
-    public Committer Author { get; init; } = null!;
+    public required Committer Author { get; init; }
 
     [JsonPropertyName("committer")]
-    public Committer Committer { get; init; } = null!;
+    public required Committer Committer { get; init; }
 
     [JsonPropertyName("added")]
-    public IEnumerable<string> Added { get; init; } = null!;
+    public required IReadOnlyList<string> Added { get; init; }
 
     [JsonPropertyName("modified")]
-    public IEnumerable<string> Modified { get; init; } = null!;
+    public required IReadOnlyList<string> Modified { get; init; }
 
     [JsonPropertyName("removed")]
-    public IEnumerable<string> Removed { get; init; } = null!;
+    public required IReadOnlyList<string> Removed { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/Reactions.cs
+++ b/src/Octokit.Webhooks/Models/Reactions.cs
@@ -4,7 +4,7 @@ namespace Octokit.Webhooks.Models;
 public sealed record Reactions
 {
     [JsonPropertyName("url")]
-    public string Url { get; init; } = null!;
+    public required string Url { get; init; }
 
     [JsonPropertyName("total_count")]
     public long TotalCount { get; init; }

--- a/src/Octokit.Webhooks/Models/ReferencedWorkflow.cs
+++ b/src/Octokit.Webhooks/Models/ReferencedWorkflow.cs
@@ -4,10 +4,10 @@ namespace Octokit.Webhooks.Models;
 public sealed record ReferencedWorkflow
 {
     [JsonPropertyName("path")]
-    public string Path { get; init; } = null!;
+    public required string Path { get; init; }
 
     [JsonPropertyName("sha")]
-    public string Sha { get; init; } = null!;
+    public required string Sha { get; init; }
 
     [JsonPropertyName("ref")]
     public string? Ref { get; init; }

--- a/src/Octokit.Webhooks/Models/Release.cs
+++ b/src/Octokit.Webhooks/Models/Release.cs
@@ -4,37 +4,37 @@ namespace Octokit.Webhooks.Models;
 public sealed record Release
 {
     [JsonPropertyName("url")]
-    public string Url { get; init; } = null!;
+    public required string Url { get; init; }
 
     [JsonPropertyName("assets_url")]
-    public string AssetsUrl { get; init; } = null!;
+    public required string AssetsUrl { get; init; }
 
     [JsonPropertyName("upload_url")]
-    public string UploadUrl { get; init; } = null!;
+    public required string UploadUrl { get; init; }
 
     [JsonPropertyName("html_url")]
-    public string HtmlUrl { get; init; } = null!;
+    public required string HtmlUrl { get; init; }
 
     [JsonPropertyName("id")]
     public long Id { get; init; }
 
     [JsonPropertyName("node_id")]
-    public string NodeId { get; init; } = null!;
+    public required string NodeId { get; init; }
 
     [JsonPropertyName("tag_name")]
-    public string TagName { get; init; } = null!;
+    public required string TagName { get; init; }
 
     [JsonPropertyName("target_commitish")]
-    public string TargetCommitish { get; init; } = null!;
+    public required string TargetCommitish { get; init; }
 
     [JsonPropertyName("name")]
-    public string Name { get; init; } = null!;
+    public required string Name { get; init; }
 
     [JsonPropertyName("draft")]
     public bool Draft { get; init; }
 
     [JsonPropertyName("author")]
-    public User Author { get; init; } = null!;
+    public required User Author { get; init; }
 
     [JsonPropertyName("prerelease")]
     public bool Prerelease { get; init; }
@@ -48,7 +48,7 @@ public sealed record Release
     public DateTimeOffset? PublishedAt { get; init; }
 
     [JsonPropertyName("assets")]
-    public IEnumerable<ReleaseAsset> Assets { get; init; } = null!;
+    public required IReadOnlyList<ReleaseAsset> Assets { get; init; }
 
     [JsonPropertyName("tarball_url")]
     public string? TarballUrl { get; init; }
@@ -57,7 +57,7 @@ public sealed record Release
     public string? ZipballUrl { get; init; }
 
     [JsonPropertyName("body")]
-    public string Body { get; init; } = null!;
+    public required string Body { get; init; }
 
     [JsonPropertyName("mentions_count")]
     public long? MentionsCount { get; init; }

--- a/src/Octokit.Webhooks/Models/ReleaseAsset.cs
+++ b/src/Octokit.Webhooks/Models/ReleaseAsset.cs
@@ -4,29 +4,29 @@ namespace Octokit.Webhooks.Models;
 public sealed record ReleaseAsset
 {
     [JsonPropertyName("url")]
-    public string Url { get; init; } = null!;
+    public required string Url { get; init; }
 
     [JsonPropertyName("browser_download_url")]
-    public string BrowserDownloadUrl { get; init; } = null!;
+    public required string BrowserDownloadUrl { get; init; }
 
     [JsonPropertyName("id")]
     public long Id { get; init; }
 
     [JsonPropertyName("node_id")]
-    public string NodeId { get; init; } = null!;
+    public required string NodeId { get; init; }
 
     [JsonPropertyName("name")]
-    public string Name { get; init; } = null!;
+    public required string Name { get; init; }
 
     [JsonPropertyName("label")]
     public string? Label { get; init; }
 
     [JsonPropertyName("state")]
     [JsonConverter(typeof(StringEnumConverter<ReleaseAssetState>))]
-    public StringEnum<ReleaseAssetState> State { get; init; } = null!;
+    public required StringEnum<ReleaseAssetState> State { get; init; }
 
     [JsonPropertyName("content_type")]
-    public string ContentType { get; init; } = null!;
+    public required string ContentType { get; init; }
 
     [JsonPropertyName("size")]
     public long Size { get; init; }

--- a/src/Octokit.Webhooks/Models/ReleaseEvent/ChangesBody.cs
+++ b/src/Octokit.Webhooks/Models/ReleaseEvent/ChangesBody.cs
@@ -4,5 +4,5 @@ namespace Octokit.Webhooks.Models.ReleaseEvent;
 public sealed record ChangesBody
 {
     [JsonPropertyName("from")]
-    public string From { get; init; } = null!;
+    public required string From { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/ReleaseEvent/ChangesName.cs
+++ b/src/Octokit.Webhooks/Models/ReleaseEvent/ChangesName.cs
@@ -4,5 +4,5 @@ namespace Octokit.Webhooks.Models.ReleaseEvent;
 public sealed record ChangesName
 {
     [JsonPropertyName("from")]
-    public string From { get; init; } = null!;
+    public required string From { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/RepoRef.cs
+++ b/src/Octokit.Webhooks/Models/RepoRef.cs
@@ -7,8 +7,8 @@ public sealed record RepoRef
     public long Id { get; init; }
 
     [JsonPropertyName("url")]
-    public string Url { get; init; } = null!;
+    public required string Url { get; init; }
 
     [JsonPropertyName("name")]
-    public string Name { get; init; } = null!;
+    public required string Name { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/Repository.cs
+++ b/src/Octokit.Webhooks/Models/Repository.cs
@@ -7,22 +7,22 @@ public sealed record Repository
     public long Id { get; init; }
 
     [JsonPropertyName("node_id")]
-    public string NodeId { get; init; } = null!;
+    public required string NodeId { get; init; }
 
     [JsonPropertyName("name")]
-    public string Name { get; init; } = null!;
+    public required string Name { get; init; }
 
     [JsonPropertyName("full_name")]
-    public string FullName { get; init; } = null!;
+    public required string FullName { get; init; }
 
     [JsonPropertyName("private")]
     public bool Private { get; init; }
 
     [JsonPropertyName("owner")]
-    public User Owner { get; init; } = null!;
+    public required User Owner { get; init; }
 
     [JsonPropertyName("html_url")]
-    public string HtmlUrl { get; init; } = null!;
+    public required string HtmlUrl { get; init; }
 
     [JsonPropertyName("description")]
     public string? Description { get; init; }
@@ -31,115 +31,115 @@ public sealed record Repository
     public bool Fork { get; init; }
 
     [JsonPropertyName("url")]
-    public string Url { get; init; } = null!;
+    public required string Url { get; init; }
 
     [JsonPropertyName("forks_url")]
-    public string ForksUrl { get; init; } = null!;
+    public string? ForksUrl { get; init; }
 
     [JsonPropertyName("keys_url")]
-    public string KeysUrl { get; init; } = null!;
+    public string? KeysUrl { get; init; }
 
     [JsonPropertyName("collaborators_url")]
-    public string CollaboratorsUrl { get; init; } = null!;
+    public string? CollaboratorsUrl { get; init; }
 
     [JsonPropertyName("teams_url")]
-    public string TeamsUrl { get; init; } = null!;
+    public string? TeamsUrl { get; init; }
 
     [JsonPropertyName("hooks_url")]
-    public string HooksUrl { get; init; } = null!;
+    public string? HooksUrl { get; init; }
 
     [JsonPropertyName("issue_events_url")]
-    public string IssueEventsUrl { get; init; } = null!;
+    public string? IssueEventsUrl { get; init; }
 
     [JsonPropertyName("events_url")]
-    public string EventsUrl { get; init; } = null!;
+    public string? EventsUrl { get; init; }
 
     [JsonPropertyName("assignees_url")]
-    public string AssigneesUrl { get; init; } = null!;
+    public string? AssigneesUrl { get; init; }
 
     [JsonPropertyName("branches_url")]
-    public string BranchesUrl { get; init; } = null!;
+    public string? BranchesUrl { get; init; }
 
     [JsonPropertyName("tags_url")]
-    public string TagsUrl { get; init; } = null!;
+    public string? TagsUrl { get; init; }
 
     [JsonPropertyName("blobs_url")]
-    public string BlobsUrl { get; init; } = null!;
+    public string? BlobsUrl { get; init; }
 
     [JsonPropertyName("git_tags_url")]
-    public string GitTagsUrl { get; init; } = null!;
+    public string? GitTagsUrl { get; init; }
 
     [JsonPropertyName("git_refs_url")]
-    public string GitRefsUrl { get; init; } = null!;
+    public string? GitRefsUrl { get; init; }
 
     [JsonPropertyName("trees_url")]
-    public string TreesUrl { get; init; } = null!;
+    public string? TreesUrl { get; init; }
 
     [JsonPropertyName("statuses_url")]
-    public string StatusesUrl { get; init; } = null!;
+    public string? StatusesUrl { get; init; }
 
     [JsonPropertyName("languages_url")]
-    public string LanguagesUrl { get; init; } = null!;
+    public string? LanguagesUrl { get; init; }
 
     [JsonPropertyName("stargazers_url")]
-    public string StargazersUrl { get; init; } = null!;
+    public string? StargazersUrl { get; init; }
 
     [JsonPropertyName("contributors_url")]
-    public string ContributorsUrl { get; init; } = null!;
+    public string? ContributorsUrl { get; init; }
 
     [JsonPropertyName("subscribers_url")]
-    public string SubscribersUrl { get; init; } = null!;
+    public string? SubscribersUrl { get; init; }
 
     [JsonPropertyName("subscription_url")]
-    public string SubscriptionUrl { get; init; } = null!;
+    public string? SubscriptionUrl { get; init; }
 
     [JsonPropertyName("commits_url")]
-    public string CommitsUrl { get; init; } = null!;
+    public string? CommitsUrl { get; init; }
 
     [JsonPropertyName("git_commits_url")]
-    public string GitCommitsUrl { get; init; } = null!;
+    public string? GitCommitsUrl { get; init; }
 
     [JsonPropertyName("comments_url")]
-    public string CommentsUrl { get; init; } = null!;
+    public string? CommentsUrl { get; init; }
 
     [JsonPropertyName("issue_comment_url")]
-    public string IssueCommentUrl { get; init; } = null!;
+    public string? IssueCommentUrl { get; init; }
 
     [JsonPropertyName("contents_url")]
-    public string ContentsUrl { get; init; } = null!;
+    public string? ContentsUrl { get; init; }
 
     [JsonPropertyName("compare_url")]
-    public string CompareUrl { get; init; } = null!;
+    public string? CompareUrl { get; init; }
 
     [JsonPropertyName("merges_url")]
-    public string MergesUrl { get; init; } = null!;
+    public string? MergesUrl { get; init; }
 
     [JsonPropertyName("archive_url")]
-    public string ArchiveUrl { get; init; } = null!;
+    public string? ArchiveUrl { get; init; }
 
     [JsonPropertyName("downloads_url")]
-    public string DownloadsUrl { get; init; } = null!;
+    public string? DownloadsUrl { get; init; }
 
     [JsonPropertyName("issues_url")]
-    public string IssuesUrl { get; init; } = null!;
+    public string? IssuesUrl { get; init; }
 
     [JsonPropertyName("pulls_url")]
-    public string PullsUrl { get; init; } = null!;
+    public string? PullsUrl { get; init; }
 
     [JsonPropertyName("milestones_url")]
-    public string MilestonesUrl { get; init; } = null!;
+    public string? MilestonesUrl { get; init; }
 
     [JsonPropertyName("notifications_url")]
-    public string NotificationsUrl { get; init; } = null!;
+    public string? NotificationsUrl { get; init; }
 
     [JsonPropertyName("labels_url")]
-    public string LabelsUrl { get; init; } = null!;
+    public string? LabelsUrl { get; init; }
 
     [JsonPropertyName("releases_url")]
-    public string ReleasesUrl { get; init; } = null!;
+    public string? ReleasesUrl { get; init; }
 
     [JsonPropertyName("deployments_url")]
-    public string DeploymentsUrl { get; init; } = null!;
+    public string? DeploymentsUrl { get; init; }
 
     [JsonPropertyName("created_at")]
     [JsonConverter(typeof(NullableDateTimeOffsetConverter))]
@@ -154,16 +154,16 @@ public sealed record Repository
     public DateTimeOffset? PushedAt { get; init; }
 
     [JsonPropertyName("git_url")]
-    public string GitUrl { get; init; } = null!;
+    public string? GitUrl { get; init; }
 
     [JsonPropertyName("ssh_url")]
-    public string SshUrl { get; init; } = null!;
+    public string? SshUrl { get; init; }
 
     [JsonPropertyName("clone_url")]
-    public string CloneUrl { get; init; } = null!;
+    public string? CloneUrl { get; init; }
 
     [JsonPropertyName("svn_url")]
-    public string SvnUrl { get; init; } = null!;
+    public string? SvnUrl { get; init; }
 
     [JsonPropertyName("homepage")]
     public string? Homepage { get; init; }
@@ -229,7 +229,7 @@ public sealed record Repository
     public int? Stargazers { get; init; }
 
     [JsonPropertyName("default_branch")]
-    public string DefaultBranch { get; init; } = null!;
+    public string? DefaultBranch { get; init; }
 
     [JsonPropertyName("allow_squash_merge")]
     public bool? AllowSquashMerge { get; init; }
@@ -271,11 +271,11 @@ public sealed record Repository
     public bool WebCommitSignoffRequired { get; init; }
 
     [JsonPropertyName("topics")]
-    public IEnumerable<string> Topics { get; init; } = null!;
+    public IReadOnlyList<string>? Topics { get; init; }
 
     [JsonPropertyName("visibility")]
     [JsonConverter(typeof(StringEnumConverter<RepositoryVisibility>))]
-    public StringEnum<RepositoryVisibility> Visibility { get; init; } = null!;
+    public StringEnum<RepositoryVisibility>? Visibility { get; init; }
 
     [JsonPropertyName("delete_branch_on_merge")]
     public bool? DeleteBranchOnMerge { get; init; }

--- a/src/Octokit.Webhooks/Models/RepositoryAdvisoryEvent/RepositoryAdvisory.cs
+++ b/src/Octokit.Webhooks/Models/RepositoryAdvisoryEvent/RepositoryAdvisory.cs
@@ -4,22 +4,22 @@ namespace Octokit.Webhooks.Models.RepositoryAdvisoryEvent;
 public sealed record RepositoryAdvisory
 {
     [JsonPropertyName("ghsa_id")]
-    public string GhsaId { get; init; } = null!;
+    public required string GhsaId { get; init; }
 
     [JsonPropertyName("cve_id")]
     public string? CveId { get; init; }
 
     [JsonPropertyName("url")]
-    public string Url { get; init; } = null!;
+    public required string Url { get; init; }
 
     [JsonPropertyName("html_url")]
-    public string HtmlUrl { get; init; } = null!;
+    public required string HtmlUrl { get; init; }
 
     [JsonPropertyName("summary")]
-    public string Summary { get; init; } = null!;
+    public required string Summary { get; init; }
 
     [JsonPropertyName("description")]
-    public string Description { get; init; } = null!;
+    public required string Description { get; init; }
 
     [JsonPropertyName("severity")]
     [JsonConverter(typeof(StringEnumConverter<RepositoryAdvisorySeverity>))]
@@ -32,11 +32,11 @@ public sealed record RepositoryAdvisory
     public User? Publisher { get; init; }
 
     [JsonPropertyName("identifiers")]
-    public IEnumerable<RepositoryAdvisoryIdentifier> Identifiers { get; init; } = null!;
+    public required IReadOnlyList<RepositoryAdvisoryIdentifier> Identifiers { get; init; }
 
     [JsonPropertyName("state")]
     [JsonConverter(typeof(StringEnumConverter<RepositoryAdvisoryState>))]
-    public StringEnum<RepositoryAdvisoryState> State { get; init; } = null!;
+    public required StringEnum<RepositoryAdvisoryState> State { get; init; }
 
     [JsonPropertyName("created_at")]
     [JsonConverter(typeof(DateTimeOffsetConverter))]
@@ -62,7 +62,7 @@ public sealed record RepositoryAdvisory
     public RepositoryAdvisorySubmission? Submission { get; init; }
 
     [JsonPropertyName("vulnerabilities")]
-    public IEnumerable<RepositoryAdvisoryVulnerability>? Vulnerabilities { get; init; }
+    public IReadOnlyList<RepositoryAdvisoryVulnerability>? Vulnerabilities { get; init; }
 
     [JsonPropertyName("cvss")]
     public RepositoryAdvisoryCvss? Cvss { get; init; }
@@ -71,22 +71,22 @@ public sealed record RepositoryAdvisory
     public RepositoryAdvisoryCvssSeverities? CvssSeverities { get; init; }
 
     [JsonPropertyName("cwes")]
-    public IEnumerable<RepositoryAdvisoryCwe>? Cwes { get; init; }
+    public IReadOnlyList<RepositoryAdvisoryCwe>? Cwes { get; init; }
 
     [JsonPropertyName("cwe_ids")]
-    public IEnumerable<string>? CweIds { get; init; }
+    public IReadOnlyList<string>? CweIds { get; init; }
 
     [JsonPropertyName("credits")]
-    public IEnumerable<RepositoryAdvisoryCredit>? Credits { get; init; }
+    public IReadOnlyList<RepositoryAdvisoryCredit>? Credits { get; init; }
 
     [JsonPropertyName("credits_detailed")]
-    public IEnumerable<RepositoryAdvisoryCreditDetailed>? CreditsDetailed { get; init; }
+    public IReadOnlyList<RepositoryAdvisoryCreditDetailed>? CreditsDetailed { get; init; }
 
     [JsonPropertyName("collaborating_users")]
-    public IEnumerable<User>? CollaboratingUsers { get; init; }
+    public IReadOnlyList<User>? CollaboratingUsers { get; init; }
 
     [JsonPropertyName("collaborating_teams")]
-    public IEnumerable<Team>? CollaboratingTeams { get; init; }
+    public IReadOnlyList<Team>? CollaboratingTeams { get; init; }
 
     [JsonPropertyName("private_fork")]
     public Repository? PrivateFork { get; init; }

--- a/src/Octokit.Webhooks/Models/RepositoryAdvisoryEvent/RepositoryAdvisoryCredit.cs
+++ b/src/Octokit.Webhooks/Models/RepositoryAdvisoryEvent/RepositoryAdvisoryCredit.cs
@@ -4,9 +4,9 @@ namespace Octokit.Webhooks.Models.RepositoryAdvisoryEvent;
 public sealed record RepositoryAdvisoryCredit
 {
     [JsonPropertyName("login")]
-    public string Login { get; init; } = null!;
+    public required string Login { get; init; }
 
     [JsonPropertyName("type")]
     [JsonConverter(typeof(StringEnumConverter<RepositoryAdvisoryCreditType>))]
-    public StringEnum<RepositoryAdvisoryCreditType> Type { get; init; } = null!;
+    public required StringEnum<RepositoryAdvisoryCreditType> Type { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/RepositoryAdvisoryEvent/RepositoryAdvisoryCreditDetailed.cs
+++ b/src/Octokit.Webhooks/Models/RepositoryAdvisoryEvent/RepositoryAdvisoryCreditDetailed.cs
@@ -4,11 +4,11 @@ namespace Octokit.Webhooks.Models.RepositoryAdvisoryEvent;
 public sealed record RepositoryAdvisoryCreditDetailed
 {
     [JsonPropertyName("user")]
-    public User User { get; init; } = null!;
+    public required User User { get; init; }
 
     [JsonPropertyName("type")]
     [JsonConverter(typeof(StringEnumConverter<RepositoryAdvisoryCreditType>))]
-    public StringEnum<RepositoryAdvisoryCreditType> Type { get; init; } = null!;
+    public required StringEnum<RepositoryAdvisoryCreditType> Type { get; init; }
 
     [JsonPropertyName("state")]
     [JsonConverter(typeof(StringEnumConverter<RepositoryAdvisoryCreditState>))]

--- a/src/Octokit.Webhooks/Models/RepositoryAdvisoryEvent/RepositoryAdvisoryCwe.cs
+++ b/src/Octokit.Webhooks/Models/RepositoryAdvisoryEvent/RepositoryAdvisoryCwe.cs
@@ -4,8 +4,8 @@ namespace Octokit.Webhooks.Models.RepositoryAdvisoryEvent;
 public sealed record RepositoryAdvisoryCwe
 {
     [JsonPropertyName("cwe_id")]
-    public string CweId { get; init; } = null!;
+    public required string CweId { get; init; }
 
     [JsonPropertyName("name")]
-    public string Name { get; init; } = null!;
+    public required string Name { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/RepositoryAdvisoryEvent/RepositoryAdvisoryIdentifier.cs
+++ b/src/Octokit.Webhooks/Models/RepositoryAdvisoryEvent/RepositoryAdvisoryIdentifier.cs
@@ -4,8 +4,8 @@ namespace Octokit.Webhooks.Models.RepositoryAdvisoryEvent;
 public sealed record RepositoryAdvisoryIdentifier
 {
     [JsonPropertyName("value")]
-    public string Value { get; init; } = null!;
+    public required string Value { get; init; }
 
     [JsonPropertyName("type")]
-    public string Type { get; init; } = null!;
+    public required string Type { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/RepositoryAdvisoryEvent/RepositoryAdvisoryVulnerability.cs
+++ b/src/Octokit.Webhooks/Models/RepositoryAdvisoryEvent/RepositoryAdvisoryVulnerability.cs
@@ -13,5 +13,5 @@ public sealed record RepositoryAdvisoryVulnerability
     public string? PatchedVersions { get; init; }
 
     [JsonPropertyName("vulnerable_functions")]
-    public IEnumerable<string>? VulnerableFunctions { get; init; }
+    public IReadOnlyList<string>? VulnerableFunctions { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/RepositoryAdvisoryEvent/RepositoryAdvisoryVulnerabilityPackage.cs
+++ b/src/Octokit.Webhooks/Models/RepositoryAdvisoryEvent/RepositoryAdvisoryVulnerabilityPackage.cs
@@ -5,7 +5,7 @@ public sealed record RepositoryAdvisoryVulnerabilityPackage
 {
     [JsonPropertyName("ecosystem")]
     [JsonConverter(typeof(StringEnumConverter<RepositoryAdvisoryVulnerabilityPackageEcosystem>))]
-    public StringEnum<RepositoryAdvisoryVulnerabilityPackageEcosystem> Ecosystem { get; init; } = null!;
+    public required StringEnum<RepositoryAdvisoryVulnerabilityPackageEcosystem> Ecosystem { get; init; }
 
     [JsonPropertyName("name")]
     public string? Name { get; init; }

--- a/src/Octokit.Webhooks/Models/RepositoryEvent/ChangesDefaultBranch.cs
+++ b/src/Octokit.Webhooks/Models/RepositoryEvent/ChangesDefaultBranch.cs
@@ -4,5 +4,5 @@ namespace Octokit.Webhooks.Models.RepositoryEvent;
 public sealed record ChangesDefaultBranch
 {
     [JsonPropertyName("from")]
-    public string From { get; init; } = null!;
+    public required string From { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/RepositoryEvent/ChangesRepositoryName.cs
+++ b/src/Octokit.Webhooks/Models/RepositoryEvent/ChangesRepositoryName.cs
@@ -4,5 +4,5 @@ namespace Octokit.Webhooks.Models.RepositoryEvent;
 public sealed record ChangesRepositoryName
 {
     [JsonPropertyName("from")]
-    public string From { get; init; } = null!;
+    public required string From { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/RepositoryLite.cs
+++ b/src/Octokit.Webhooks/Models/RepositoryLite.cs
@@ -4,140 +4,140 @@ namespace Octokit.Webhooks.Models;
 public sealed record RepositoryLite
 {
     [JsonPropertyName("archive_url")]
-    public string ArchiveUrl { get; init; } = null!;
+    public required string ArchiveUrl { get; init; }
 
     [JsonPropertyName("assignees_url")]
-    public string AssigneesUrl { get; init; } = null!;
+    public required string AssigneesUrl { get; init; }
 
     [JsonPropertyName("blobs_url")]
-    public string BlobsUrl { get; init; } = null!;
+    public required string BlobsUrl { get; init; }
 
     [JsonPropertyName("branches_url")]
-    public string BranchesUrl { get; init; } = null!;
+    public required string BranchesUrl { get; init; }
 
     [JsonPropertyName("collaborators_url")]
-    public string CollaboratorsUrl { get; init; } = null!;
+    public required string CollaboratorsUrl { get; init; }
 
     [JsonPropertyName("comments_url")]
-    public string CommentsUrl { get; init; } = null!;
+    public required string CommentsUrl { get; init; }
 
     [JsonPropertyName("commits_url")]
-    public string CommitsUrl { get; init; } = null!;
+    public required string CommitsUrl { get; init; }
 
     [JsonPropertyName("compare_url")]
-    public string CompareUrl { get; init; } = null!;
+    public required string CompareUrl { get; init; }
 
     [JsonPropertyName("contents_url")]
-    public string ContentsUrl { get; init; } = null!;
+    public required string ContentsUrl { get; init; }
 
     [JsonPropertyName("contributors_url")]
-    public string ContributorsUrl { get; init; } = null!;
+    public required string ContributorsUrl { get; init; }
 
     [JsonPropertyName("deployments_url")]
-    public string DeploymentsUrl { get; init; } = null!;
+    public required string DeploymentsUrl { get; init; }
 
     [JsonPropertyName("description")]
     public string? Description { get; init; }
 
     [JsonPropertyName("downloads_url")]
-    public string DownloadsUrl { get; init; } = null!;
+    public required string DownloadsUrl { get; init; }
 
     [JsonPropertyName("events_url")]
-    public string EventsUrl { get; init; } = null!;
+    public required string EventsUrl { get; init; }
 
     [JsonPropertyName("fork")]
     public bool Fork { get; init; }
 
     [JsonPropertyName("forks_url")]
-    public string ForksUrl { get; init; } = null!;
+    public required string ForksUrl { get; init; }
 
     [JsonPropertyName("full_name")]
-    public string FullName { get; init; } = null!;
+    public required string FullName { get; init; }
 
     [JsonPropertyName("git_commits_url")]
-    public string GitCommitsUrl { get; init; } = null!;
+    public required string GitCommitsUrl { get; init; }
 
     [JsonPropertyName("git_refs_url")]
-    public string GitRefsUrl { get; init; } = null!;
+    public required string GitRefsUrl { get; init; }
 
     [JsonPropertyName("git_tags_url")]
-    public string GitTagsUrl { get; init; } = null!;
+    public required string GitTagsUrl { get; init; }
 
     [JsonPropertyName("hooks_url")]
-    public string HooksUrl { get; init; } = null!;
+    public required string HooksUrl { get; init; }
 
     [JsonPropertyName("html_url")]
-    public string HtmlUrl { get; init; } = null!;
+    public required string HtmlUrl { get; init; }
 
     [JsonPropertyName("id")]
     public long Id { get; init; }
 
     [JsonPropertyName("issue_comment_url")]
-    public string IssueCommentUrl { get; init; } = null!;
+    public required string IssueCommentUrl { get; init; }
 
     [JsonPropertyName("issue_events_url")]
-    public string IssueEventsUrl { get; init; } = null!;
+    public required string IssueEventsUrl { get; init; }
 
     [JsonPropertyName("issues_url")]
-    public string IssuesUrl { get; init; } = null!;
+    public required string IssuesUrl { get; init; }
 
     [JsonPropertyName("keys_url")]
-    public string KeysUrl { get; init; } = null!;
+    public required string KeysUrl { get; init; }
 
     [JsonPropertyName("labels_url")]
-    public string LabelsUrl { get; init; } = null!;
+    public required string LabelsUrl { get; init; }
 
     [JsonPropertyName("languages_url")]
-    public string LanguagesUrl { get; init; } = null!;
+    public required string LanguagesUrl { get; init; }
 
     [JsonPropertyName("merges_url")]
-    public string MergesUrl { get; init; } = null!;
+    public required string MergesUrl { get; init; }
 
     [JsonPropertyName("milestones_url")]
-    public string MilestonesUrl { get; init; } = null!;
+    public required string MilestonesUrl { get; init; }
 
     [JsonPropertyName("name")]
-    public string Name { get; init; } = null!;
+    public required string Name { get; init; }
 
     [JsonPropertyName("node_id")]
-    public string NodeId { get; init; } = null!;
+    public required string NodeId { get; init; }
 
     [JsonPropertyName("notifications_url")]
-    public string NotificationsUrl { get; init; } = null!;
+    public required string NotificationsUrl { get; init; }
 
     [JsonPropertyName("owner")]
-    public User Owner { get; init; } = null!;
+    public required User Owner { get; init; }
 
     [JsonPropertyName("private")]
     public bool Private { get; init; }
 
     [JsonPropertyName("pulls_url")]
-    public string PullsUrl { get; init; } = null!;
+    public required string PullsUrl { get; init; }
 
     [JsonPropertyName("releases_url")]
-    public string ReleasesUrl { get; init; } = null!;
+    public required string ReleasesUrl { get; init; }
 
     [JsonPropertyName("stargazers_url")]
-    public string StargazersUrl { get; init; } = null!;
+    public required string StargazersUrl { get; init; }
 
     [JsonPropertyName("statuses_url")]
-    public string StatusesUrl { get; init; } = null!;
+    public required string StatusesUrl { get; init; }
 
     [JsonPropertyName("subscribers_url")]
-    public string SubscribersUrl { get; init; } = null!;
+    public required string SubscribersUrl { get; init; }
 
     [JsonPropertyName("subscription_url")]
-    public string SubscriptionUrl { get; init; } = null!;
+    public required string SubscriptionUrl { get; init; }
 
     [JsonPropertyName("tags_url")]
-    public string TagsUrl { get; init; } = null!;
+    public required string TagsUrl { get; init; }
 
     [JsonPropertyName("teams_url")]
-    public string TeamsUrl { get; init; } = null!;
+    public required string TeamsUrl { get; init; }
 
     [JsonPropertyName("trees_url")]
-    public string TreesUrl { get; init; } = null!;
+    public required string TreesUrl { get; init; }
 
     [JsonPropertyName("url")]
-    public string Url { get; init; } = null!;
+    public required string Url { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/RepositoryVulnerabilityAlertEvent/Alert.cs
+++ b/src/Octokit.Webhooks/Models/RepositoryVulnerabilityAlertEvent/Alert.cs
@@ -7,10 +7,10 @@ public sealed record Alert
     public long Id { get; init; }
 
     [JsonPropertyName("affected_range")]
-    public string AffectedRange { get; init; } = null!;
+    public required string AffectedRange { get; init; }
 
     [JsonPropertyName("affected_package_name")]
-    public string AffectedPackageName { get; init; } = null!;
+    public required string AffectedPackageName { get; init; }
 
     [JsonPropertyName("dismisser")]
     public User? Dismisser { get; init; }
@@ -26,13 +26,13 @@ public sealed record Alert
     public string? GhsaId { get; init; }
 
     [JsonPropertyName("external_reference")]
-    public string ExternalReference { get; init; } = null!;
+    public required string ExternalReference { get; init; }
 
     [JsonPropertyName("external_identifier")]
-    public string ExternalIdentifier { get; init; } = null!;
+    public required string ExternalIdentifier { get; init; }
 
     [JsonPropertyName("fixed_in")]
-    public string FixedIn { get; init; } = null!;
+    public required string FixedIn { get; init; }
 
     [JsonPropertyName("created_at")]
     [JsonConverter(typeof(NullableDateTimeOffsetConverter))]

--- a/src/Octokit.Webhooks/Models/SecretScanningAlertEvent/Alert.cs
+++ b/src/Octokit.Webhooks/Models/SecretScanningAlertEvent/Alert.cs
@@ -7,7 +7,7 @@ public sealed record Alert
     public long Number { get; init; }
 
     [JsonPropertyName("secret_type")]
-    public string SecretType { get; init; } = null!;
+    public required string SecretType { get; init; }
 
     [JsonPropertyName("resolution")]
     [JsonConverter(typeof(StringEnumConverter<AlertResolution>))]

--- a/src/Octokit.Webhooks/Models/SecretScanningAlertLocationEvent/SecretScanningLocation.cs
+++ b/src/Octokit.Webhooks/Models/SecretScanningAlertLocationEvent/SecretScanningLocation.cs
@@ -5,9 +5,9 @@ public sealed record SecretScanningLocation
 {
     [JsonPropertyName("type")]
     [JsonConverter(typeof(StringEnumConverter<SecretScanningLocationType>))]
-    public StringEnum<SecretScanningLocationType> Type { get; init; } = null!;
+    public required StringEnum<SecretScanningLocationType> Type { get; init; }
 
     // TODO: type union with SecretScanningLocationCommit, SecretScanningLocationIssueBody, etc.
     [JsonPropertyName("details")]
-    public dynamic Details { get; init; } = null!;
+    public required dynamic Details { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/SecretScanningAlertLocationEvent/SecretScanningLocation.cs
+++ b/src/Octokit.Webhooks/Models/SecretScanningAlertLocationEvent/SecretScanningLocation.cs
@@ -9,5 +9,5 @@ public sealed record SecretScanningLocation
 
     // TODO: type union with SecretScanningLocationCommit, SecretScanningLocationIssueBody, etc.
     [JsonPropertyName("details")]
-    public required dynamic Details { get; init; }
+    public required JsonElement Details { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/SecretScanningAlertLocationEvent/SecretScanningLocationCommit.cs
+++ b/src/Octokit.Webhooks/Models/SecretScanningAlertLocationEvent/SecretScanningLocationCommit.cs
@@ -4,7 +4,7 @@ namespace Octokit.Webhooks.Models.SecretScanningAlertLocationEvent;
 public sealed record SecretScanningLocationCommit
 {
     [JsonPropertyName("path")]
-    public string Path { get; init; } = null!;
+    public required string Path { get; init; }
 
     [JsonPropertyName("start_line")]
     public long StartLine { get; init; }
@@ -19,14 +19,14 @@ public sealed record SecretScanningLocationCommit
     public long EndColumn { get; init; }
 
     [JsonPropertyName("blob_sha")]
-    public string BlobSha { get; init; } = null!;
+    public required string BlobSha { get; init; }
 
     [JsonPropertyName("blob_url")]
-    public string BlobUrl { get; init; } = null!;
+    public required string BlobUrl { get; init; }
 
     [JsonPropertyName("commit_sha")]
-    public string CommitSha { get; init; } = null!;
+    public required string CommitSha { get; init; }
 
     [JsonPropertyName("commit_url")]
-    public string CommitUrl { get; init; } = null!;
+    public required string CommitUrl { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/SecretScanningAlertLocationEvent/SecretScanningLocationIssueBody.cs
+++ b/src/Octokit.Webhooks/Models/SecretScanningAlertLocationEvent/SecretScanningLocationIssueBody.cs
@@ -4,5 +4,5 @@ namespace Octokit.Webhooks.Models.SecretScanningAlertLocationEvent;
 public sealed record SecretScanningLocationIssueBody
 {
     [JsonPropertyName("issue_body_url")]
-    public string IssueBodyUrl { get; init; } = null!;
+    public required string IssueBodyUrl { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/SecretScanningAlertLocationEvent/SecretScanningLocationIssueComment.cs
+++ b/src/Octokit.Webhooks/Models/SecretScanningAlertLocationEvent/SecretScanningLocationIssueComment.cs
@@ -4,5 +4,5 @@ namespace Octokit.Webhooks.Models.SecretScanningAlertLocationEvent;
 public sealed record SecretScanningLocationIssueComment
 {
     [JsonPropertyName("issue_comment_url")]
-    public string IssueCommentUrl { get; init; } = null!;
+    public required string IssueCommentUrl { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/SecretScanningAlertLocationEvent/SecretScanningLocationIssueTitle.cs
+++ b/src/Octokit.Webhooks/Models/SecretScanningAlertLocationEvent/SecretScanningLocationIssueTitle.cs
@@ -4,5 +4,5 @@ namespace Octokit.Webhooks.Models.SecretScanningAlertLocationEvent;
 public sealed record SecretScanningLocationIssueTitle
 {
     [JsonPropertyName("issue_title_url")]
-    public string IssueTitleUrl { get; init; } = null!;
+    public required string IssueTitleUrl { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/SecurityAdvisoryEvent/SecurityAdvisory.cs
+++ b/src/Octokit.Webhooks/Models/SecurityAdvisoryEvent/SecurityAdvisory.cs
@@ -4,31 +4,31 @@ namespace Octokit.Webhooks.Models.SecurityAdvisoryEvent;
 public sealed record SecurityAdvisory
 {
     [JsonPropertyName("cvss")]
-    public SecurityAdvisoryCvss Cvss { get; init; } = null!;
+    public required SecurityAdvisoryCvss Cvss { get; init; }
 
     [JsonPropertyName("cwes")]
-    public IEnumerable<SecurityAdvisoryCwe> Cwes { get; init; } = null!;
+    public required IReadOnlyList<SecurityAdvisoryCwe> Cwes { get; init; }
 
     [JsonPropertyName("ghsa_id")]
-    public string GhsaId { get; init; } = null!;
+    public required string GhsaId { get; init; }
 
     [JsonPropertyName("cve_id")]
     public string? CveId { get; init; }
 
     [JsonPropertyName("summary")]
-    public string Summary { get; init; } = null!;
+    public required string Summary { get; init; }
 
     [JsonPropertyName("description")]
-    public string Description { get; init; } = null!;
+    public required string Description { get; init; }
 
     [JsonPropertyName("severity")]
-    public string Severity { get; init; } = null!;
+    public required string Severity { get; init; }
 
     [JsonPropertyName("identifiers")]
-    public IEnumerable<SecurityAdvisoryIdentifier> Identifiers { get; init; } = null!;
+    public required IReadOnlyList<SecurityAdvisoryIdentifier> Identifiers { get; init; }
 
     [JsonPropertyName("references")]
-    public IEnumerable<SecurityAdvisoryReference> References { get; init; } = null!;
+    public required IReadOnlyList<SecurityAdvisoryReference> References { get; init; }
 
     [JsonPropertyName("published_at")]
     [JsonConverter(typeof(DateTimeOffsetConverter))]
@@ -43,5 +43,5 @@ public sealed record SecurityAdvisory
     public DateTimeOffset? WithdrawnAt { get; init; }
 
     [JsonPropertyName("vulnerabilities")]
-    public IEnumerable<SecurityAdvisoryVulnerability> Vulnerabilities { get; init; } = null!;
+    public required IReadOnlyList<SecurityAdvisoryVulnerability> Vulnerabilities { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/SecurityAdvisoryEvent/SecurityAdvisoryCwe.cs
+++ b/src/Octokit.Webhooks/Models/SecurityAdvisoryEvent/SecurityAdvisoryCwe.cs
@@ -4,8 +4,8 @@ namespace Octokit.Webhooks.Models.SecurityAdvisoryEvent;
 public sealed record SecurityAdvisoryCwe
 {
     [JsonPropertyName("cwe_id")]
-    public string CweId { get; init; } = null!;
+    public required string CweId { get; init; }
 
     [JsonPropertyName("name")]
-    public string Name { get; init; } = null!;
+    public required string Name { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/SecurityAdvisoryEvent/SecurityAdvisoryIdentifier.cs
+++ b/src/Octokit.Webhooks/Models/SecurityAdvisoryEvent/SecurityAdvisoryIdentifier.cs
@@ -4,8 +4,8 @@ namespace Octokit.Webhooks.Models.SecurityAdvisoryEvent;
 public sealed record SecurityAdvisoryIdentifier
 {
     [JsonPropertyName("value")]
-    public string Value { get; init; } = null!;
+    public required string Value { get; init; }
 
     [JsonPropertyName("type")]
-    public string Type { get; init; } = null!;
+    public required string Type { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/SecurityAdvisoryEvent/SecurityAdvisoryReference.cs
+++ b/src/Octokit.Webhooks/Models/SecurityAdvisoryEvent/SecurityAdvisoryReference.cs
@@ -4,5 +4,5 @@ namespace Octokit.Webhooks.Models.SecurityAdvisoryEvent;
 public sealed record SecurityAdvisoryReference
 {
     [JsonPropertyName("url")]
-    public string Url { get; init; } = null!;
+    public required string Url { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/SecurityAdvisoryEvent/SecurityAdvisoryVulnerability.cs
+++ b/src/Octokit.Webhooks/Models/SecurityAdvisoryEvent/SecurityAdvisoryVulnerability.cs
@@ -4,13 +4,13 @@ namespace Octokit.Webhooks.Models.SecurityAdvisoryEvent;
 public sealed record SecurityAdvisoryVulnerability
 {
     [JsonPropertyName("package")]
-    public SecurityAdvisoryVulnerabilityPackage Package { get; init; } = null!;
+    public required SecurityAdvisoryVulnerabilityPackage Package { get; init; }
 
     [JsonPropertyName("severity")]
-    public string Severity { get; init; } = null!;
+    public required string Severity { get; init; }
 
     [JsonPropertyName("vulnerable_version_range")]
-    public string VulnerableVersionRange { get; init; } = null!;
+    public required string VulnerableVersionRange { get; init; }
 
     [JsonPropertyName("first_patched_version")]
     public SecurityAdvisoryVulnerabilityFirstPatchedVersion? FirstPatchedVersion { get; init; }

--- a/src/Octokit.Webhooks/Models/SecurityAdvisoryEvent/SecurityAdvisoryVulnerabilityFirstPatchedVersion.cs
+++ b/src/Octokit.Webhooks/Models/SecurityAdvisoryEvent/SecurityAdvisoryVulnerabilityFirstPatchedVersion.cs
@@ -4,5 +4,5 @@ namespace Octokit.Webhooks.Models.SecurityAdvisoryEvent;
 public sealed record SecurityAdvisoryVulnerabilityFirstPatchedVersion
 {
     [JsonPropertyName("identifier")]
-    public string Identifier { get; init; } = null!;
+    public required string Identifier { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/SecurityAdvisoryEvent/SecurityAdvisoryVulnerabilityPackage.cs
+++ b/src/Octokit.Webhooks/Models/SecurityAdvisoryEvent/SecurityAdvisoryVulnerabilityPackage.cs
@@ -4,8 +4,8 @@ namespace Octokit.Webhooks.Models.SecurityAdvisoryEvent;
 public sealed record SecurityAdvisoryVulnerabilityPackage
 {
     [JsonPropertyName("ecosystem")]
-    public string Ecosystem { get; init; } = null!;
+    public required string Ecosystem { get; init; }
 
     [JsonPropertyName("name")]
-    public string Name { get; init; } = null!;
+    public required string Name { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/SecurityAndAnalysisEvent/Changes.cs
+++ b/src/Octokit.Webhooks/Models/SecurityAndAnalysisEvent/Changes.cs
@@ -4,5 +4,5 @@ namespace Octokit.Webhooks.Models.SecurityAndAnalysisEvent;
 public sealed record Changes
 {
     [JsonPropertyName("from")]
-    public ChangesFrom From { get; init; } = null!;
+    public required ChangesFrom From { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/SimpleCommit.cs
+++ b/src/Octokit.Webhooks/Models/SimpleCommit.cs
@@ -4,20 +4,20 @@ namespace Octokit.Webhooks.Models;
 public sealed record SimpleCommit
 {
     [JsonPropertyName("id")]
-    public string Id { get; init; } = null!;
+    public required string Id { get; init; }
 
     [JsonPropertyName("tree_id")]
-    public string TreeId { get; init; } = null!;
+    public required string TreeId { get; init; }
 
     [JsonPropertyName("message")]
-    public string Message { get; init; } = null!;
+    public required string Message { get; init; }
 
     [JsonPropertyName("timestamp")]
-    public string Timestamp { get; init; } = null!;
+    public required string Timestamp { get; init; }
 
     [JsonPropertyName("author")]
-    public Committer Author { get; init; } = null!;
+    public required Committer Author { get; init; }
 
     [JsonPropertyName("committer")]
-    public Committer Committer { get; init; } = null!;
+    public required Committer Committer { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/SimplePullRequest.cs
+++ b/src/Octokit.Webhooks/Models/SimplePullRequest.cs
@@ -4,41 +4,41 @@ namespace Octokit.Webhooks.Models;
 public sealed record SimplePullRequest
 {
     [JsonPropertyName("url")]
-    public string Url { get; init; } = null!;
+    public required string Url { get; init; }
 
     [JsonPropertyName("id")]
     public long Id { get; init; }
 
     [JsonPropertyName("node_id")]
-    public string NodeId { get; init; } = null!;
+    public required string NodeId { get; init; }
 
     [JsonPropertyName("html_url")]
-    public string HtmlUrl { get; init; } = null!;
+    public required string HtmlUrl { get; init; }
 
     [JsonPropertyName("diff_url")]
-    public string DiffUrl { get; init; } = null!;
+    public required string DiffUrl { get; init; }
 
     [JsonPropertyName("patch_url")]
-    public string PatchUrl { get; init; } = null!;
+    public required string PatchUrl { get; init; }
 
     [JsonPropertyName("issue_url")]
-    public string IssueUrl { get; init; } = null!;
+    public required string IssueUrl { get; init; }
 
     [JsonPropertyName("number")]
     public long Number { get; init; }
 
     [JsonPropertyName("state")]
     [JsonConverter(typeof(StringEnumConverter<SimplePullRequestState>))]
-    public StringEnum<SimplePullRequestState> State { get; init; } = null!;
+    public required StringEnum<SimplePullRequestState> State { get; init; }
 
     [JsonPropertyName("locked")]
     public bool Locked { get; init; }
 
     [JsonPropertyName("title")]
-    public string Title { get; init; } = null!;
+    public required string Title { get; init; }
 
     [JsonPropertyName("user")]
-    public User User { get; init; } = null!;
+    public required User User { get; init; }
 
     [JsonPropertyName("body")]
     public string? Body { get; init; }
@@ -66,16 +66,16 @@ public sealed record SimplePullRequest
     public User? Assignee { get; init; }
 
     [JsonPropertyName("assignees")]
-    public IEnumerable<User> Assignees { get; init; } = null!;
+    public required IReadOnlyList<User> Assignees { get; init; }
 
     [JsonPropertyName("requested_reviewers")]
-    public IEnumerable<User> RequestedReviewers { get; init; } = null!;
+    public required IReadOnlyList<User> RequestedReviewers { get; init; }
 
     [JsonPropertyName("requested_teams")]
-    public IEnumerable<Team> RequestedTeams { get; init; } = null!;
+    public required IReadOnlyList<Team> RequestedTeams { get; init; }
 
     [JsonPropertyName("labels")]
-    public IEnumerable<Label> Labels { get; init; } = null!;
+    public required IReadOnlyList<Label> Labels { get; init; }
 
     [JsonPropertyName("milestone")]
     public Milestone? Milestone { get; init; }
@@ -84,32 +84,32 @@ public sealed record SimplePullRequest
     public bool Draft { get; init; }
 
     [JsonPropertyName("commits_url")]
-    public string CommitsUrl { get; init; } = null!;
+    public required string CommitsUrl { get; init; }
 
     [JsonPropertyName("review_comments_url")]
-    public string ReviewCommentsUrl { get; init; } = null!;
+    public required string ReviewCommentsUrl { get; init; }
 
     [JsonPropertyName("review_comment_url")]
-    public string ReviewCommentUrl { get; init; } = null!;
+    public required string ReviewCommentUrl { get; init; }
 
     [JsonPropertyName("comments_url")]
-    public string CommentsUrl { get; init; } = null!;
+    public required string CommentsUrl { get; init; }
 
     [JsonPropertyName("statuses_url")]
-    public string StatusesUrl { get; init; } = null!;
+    public required string StatusesUrl { get; init; }
 
     [JsonPropertyName("head")]
-    public SimplePullRequestHead Head { get; init; } = null!;
+    public required SimplePullRequestHead Head { get; init; }
 
     [JsonPropertyName("base")]
-    public SimplePullRequestBase Base { get; init; } = null!;
+    public required SimplePullRequestBase Base { get; init; }
 
     [JsonPropertyName("_links")]
     public SimplePullRequestLinks? Links { get; init; }
 
     [JsonPropertyName("author_association")]
     [JsonConverter(typeof(StringEnumConverter<AuthorAssociation>))]
-    public StringEnum<AuthorAssociation> AuthorAssociation { get; init; } = null!;
+    public required StringEnum<AuthorAssociation> AuthorAssociation { get; init; }
 
     [JsonPropertyName("auto_merge")]
     public PullRequestAutoMerge? AutoMerge { get; init; }

--- a/src/Octokit.Webhooks/Models/SimplePullRequestBase.cs
+++ b/src/Octokit.Webhooks/Models/SimplePullRequestBase.cs
@@ -4,17 +4,17 @@ namespace Octokit.Webhooks.Models;
 public sealed record SimplePullRequestBase
 {
     [JsonPropertyName("label")]
-    public string Label { get; init; } = null!;
+    public required string Label { get; init; }
 
     [JsonPropertyName("ref")]
-    public string Ref { get; init; } = null!;
+    public required string Ref { get; init; }
 
     [JsonPropertyName("sha")]
-    public string Sha { get; init; } = null!;
+    public required string Sha { get; init; }
 
     [JsonPropertyName("user")]
-    public User User { get; init; } = null!;
+    public required User User { get; init; }
 
     [JsonPropertyName("repo")]
-    public Repository Repo { get; init; } = null!;
+    public required Repository Repo { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/SimplePullRequestHead.cs
+++ b/src/Octokit.Webhooks/Models/SimplePullRequestHead.cs
@@ -4,17 +4,17 @@ namespace Octokit.Webhooks.Models;
 public sealed record SimplePullRequestHead
 {
     [JsonPropertyName("label")]
-    public string Label { get; init; } = null!;
+    public required string Label { get; init; }
 
     [JsonPropertyName("ref")]
-    public string Ref { get; init; } = null!;
+    public required string Ref { get; init; }
 
     [JsonPropertyName("sha")]
-    public string Sha { get; init; } = null!;
+    public required string Sha { get; init; }
 
     [JsonPropertyName("user")]
-    public User User { get; init; } = null!;
+    public required User User { get; init; }
 
     [JsonPropertyName("repo")]
-    public Repository Repo { get; init; } = null!;
+    public required Repository Repo { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/SimplePullRequestLinks.cs
+++ b/src/Octokit.Webhooks/Models/SimplePullRequestLinks.cs
@@ -4,26 +4,26 @@ namespace Octokit.Webhooks.Models;
 public sealed record SimplePullRequestLinks
 {
     [JsonPropertyName("self")]
-    public Link Self { get; init; } = null!;
+    public required Link Self { get; init; }
 
     [JsonPropertyName("html")]
-    public Link Html { get; init; } = null!;
+    public required Link Html { get; init; }
 
     [JsonPropertyName("issue")]
-    public Link Issue { get; init; } = null!;
+    public required Link Issue { get; init; }
 
     [JsonPropertyName("comments")]
-    public Link Comments { get; init; } = null!;
+    public required Link Comments { get; init; }
 
     [JsonPropertyName("review_comments")]
-    public Link ReviewComments { get; init; } = null!;
+    public required Link ReviewComments { get; init; }
 
     [JsonPropertyName("review_comment")]
-    public Link ReviewComment { get; init; } = null!;
+    public required Link ReviewComment { get; init; }
 
     [JsonPropertyName("commits")]
-    public Link Commits { get; init; } = null!;
+    public required Link Commits { get; init; }
 
     [JsonPropertyName("statuses")]
-    public Link Statuses { get; init; } = null!;
+    public required Link Statuses { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/SponsorshipEvent/ChangesPrivacyLevel.cs
+++ b/src/Octokit.Webhooks/Models/SponsorshipEvent/ChangesPrivacyLevel.cs
@@ -4,5 +4,5 @@ namespace Octokit.Webhooks.Models.SponsorshipEvent;
 public sealed record ChangesPrivacyLevel
 {
     [JsonPropertyName("from")]
-    public string From { get; init; } = null!;
+    public required string From { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/SponsorshipEvent/ChangesTier.cs
+++ b/src/Octokit.Webhooks/Models/SponsorshipEvent/ChangesTier.cs
@@ -4,5 +4,5 @@ namespace Octokit.Webhooks.Models.SponsorshipEvent;
 public sealed record ChangesTier
 {
     [JsonPropertyName("from")]
-    public SponsorshipTier From { get; init; } = null!;
+    public required SponsorshipTier From { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/SponsorshipEvent/Sponsorship.cs
+++ b/src/Octokit.Webhooks/Models/SponsorshipEvent/Sponsorship.cs
@@ -4,21 +4,21 @@ namespace Octokit.Webhooks.Models.SponsorshipEvent;
 public sealed record Sponsorship
 {
     [JsonPropertyName("node_id")]
-    public string NodeId { get; init; } = null!;
+    public required string NodeId { get; init; }
 
     [JsonPropertyName("created_at")]
     [JsonConverter(typeof(DateTimeOffsetConverter))]
     public DateTimeOffset CreatedAt { get; init; }
 
     [JsonPropertyName("sponsorable")]
-    public User Sponsorable { get; init; } = null!;
+    public required User Sponsorable { get; init; }
 
     [JsonPropertyName("sponsor")]
-    public User Sponsor { get; init; } = null!;
+    public required User Sponsor { get; init; }
 
     [JsonPropertyName("privacy_level")]
-    public string PrivacyLevel { get; init; } = null!;
+    public required string PrivacyLevel { get; init; }
 
     [JsonPropertyName("tier")]
-    public SponsorshipTier Tier { get; init; } = null!;
+    public required SponsorshipTier Tier { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/SponsorshipEvent/SponsorshipTier.cs
+++ b/src/Octokit.Webhooks/Models/SponsorshipEvent/SponsorshipTier.cs
@@ -4,14 +4,14 @@ namespace Octokit.Webhooks.Models.SponsorshipEvent;
 public sealed record SponsorshipTier
 {
     [JsonPropertyName("node_id")]
-    public string NodeId { get; init; } = null!;
+    public required string NodeId { get; init; }
 
     [JsonPropertyName("created_at")]
     [JsonConverter(typeof(DateTimeOffsetConverter))]
     public DateTimeOffset CreatedAt { get; init; }
 
     [JsonPropertyName("description")]
-    public string Description { get; init; } = null!;
+    public required string Description { get; init; }
 
     [JsonPropertyName("monthly_price_in_cents")]
     public long MonthlyPriceInCents { get; init; }
@@ -20,7 +20,7 @@ public sealed record SponsorshipTier
     public long MonthlyPriceInDollars { get; init; }
 
     [JsonPropertyName("name")]
-    public string Name { get; init; } = null!;
+    public required string Name { get; init; }
 
     [JsonPropertyName("is_one_time")]
     public bool IsOneTime { get; init; }

--- a/src/Octokit.Webhooks/Models/StatusEvent/Branch.cs
+++ b/src/Octokit.Webhooks/Models/StatusEvent/Branch.cs
@@ -4,10 +4,10 @@ namespace Octokit.Webhooks.Models.StatusEvent;
 public sealed record Branch
 {
     [JsonPropertyName("name")]
-    public string Name { get; init; } = null!;
+    public required string Name { get; init; }
 
     [JsonPropertyName("commit")]
-    public BranchCommit Commit { get; init; } = null!;
+    public required BranchCommit Commit { get; init; }
 
     [JsonPropertyName("protected")]
     public bool Protected { get; init; }

--- a/src/Octokit.Webhooks/Models/StatusEvent/BranchCommit.cs
+++ b/src/Octokit.Webhooks/Models/StatusEvent/BranchCommit.cs
@@ -4,8 +4,8 @@ namespace Octokit.Webhooks.Models.StatusEvent;
 public sealed record BranchCommit
 {
     [JsonPropertyName("sha")]
-    public string Sha { get; init; } = null!;
+    public required string Sha { get; init; }
 
     [JsonPropertyName("url")]
-    public string Url { get; init; } = null!;
+    public required string Url { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/StatusEvent/Commit.cs
+++ b/src/Octokit.Webhooks/Models/StatusEvent/Commit.cs
@@ -4,22 +4,22 @@ namespace Octokit.Webhooks.Models.StatusEvent;
 public sealed record Commit
 {
     [JsonPropertyName("sha")]
-    public string Sha { get; init; } = null!;
+    public required string Sha { get; init; }
 
     [JsonPropertyName("node_id")]
-    public string NodeId { get; init; } = null!;
+    public required string NodeId { get; init; }
 
     [JsonPropertyName("commit")]
-    public CommitDetails CommitDetails { get; init; } = null!;
+    public required CommitDetails CommitDetails { get; init; }
 
     [JsonPropertyName("url")]
-    public string Url { get; init; } = null!;
+    public required string Url { get; init; }
 
     [JsonPropertyName("html_url")]
-    public string HtmlUrl { get; init; } = null!;
+    public required string HtmlUrl { get; init; }
 
     [JsonPropertyName("comments_url")]
-    public string CommentsUrl { get; init; } = null!;
+    public required string CommentsUrl { get; init; }
 
     [JsonPropertyName("author")]
     public User? Author { get; init; }
@@ -28,5 +28,5 @@ public sealed record Commit
     public User? Committer { get; init; }
 
     [JsonPropertyName("parents")]
-    public IEnumerable<CommitParent> Parents { get; init; } = null!;
+    public required IReadOnlyList<CommitParent> Parents { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/StatusEvent/CommitDetails.cs
+++ b/src/Octokit.Webhooks/Models/StatusEvent/CommitDetails.cs
@@ -13,7 +13,7 @@ public sealed record CommitDetails
     public string? Message { get; init; }
 
     [JsonPropertyName("tree")]
-    public CommitDetails? Tree { get; init; }
+    public CommitDetailsTree? Tree { get; init; }
 
     [JsonPropertyName("url")]
     public required string Url { get; init; }

--- a/src/Octokit.Webhooks/Models/StatusEvent/CommitDetails.cs
+++ b/src/Octokit.Webhooks/Models/StatusEvent/CommitDetails.cs
@@ -4,19 +4,19 @@ namespace Octokit.Webhooks.Models.StatusEvent;
 public sealed record CommitDetails
 {
     [JsonPropertyName("author")]
-    public Committer Author { get; init; } = null!;
+    public Committer? Author { get; init; }
 
     [JsonPropertyName("committer")]
-    public Committer Committer { get; init; } = null!;
+    public Committer? Committer { get; init; }
 
     [JsonPropertyName("message")]
-    public string Message { get; init; } = null!;
+    public string? Message { get; init; }
 
     [JsonPropertyName("tree")]
-    public CommitDetails Tree { get; init; } = null!;
+    public CommitDetails? Tree { get; init; }
 
     [JsonPropertyName("url")]
-    public string Url { get; init; } = null!;
+    public required string Url { get; init; }
 
     [JsonPropertyName("comment_count")]
     public long CommentCount { get; init; }

--- a/src/Octokit.Webhooks/Models/StatusEvent/CommitDetailsTree.cs
+++ b/src/Octokit.Webhooks/Models/StatusEvent/CommitDetailsTree.cs
@@ -4,8 +4,8 @@ namespace Octokit.Webhooks.Models.StatusEvent;
 public sealed record CommitDetailsTree
 {
     [JsonPropertyName("sha")]
-    public string Sha { get; init; } = null!;
+    public required string Sha { get; init; }
 
     [JsonPropertyName("url")]
-    public string Url { get; init; } = null!;
+    public required string Url { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/StatusEvent/CommitParent.cs
+++ b/src/Octokit.Webhooks/Models/StatusEvent/CommitParent.cs
@@ -4,11 +4,11 @@ namespace Octokit.Webhooks.Models.StatusEvent;
 public sealed record CommitParent
 {
     [JsonPropertyName("sha")]
-    public string Sha { get; init; } = null!;
+    public required string Sha { get; init; }
 
     [JsonPropertyName("url")]
-    public string Url { get; init; } = null!;
+    public required string Url { get; init; }
 
     [JsonPropertyName("html_url")]
-    public string HtmlUrl { get; init; } = null!;
+    public required string HtmlUrl { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/StatusEvent/CommitVerification.cs
+++ b/src/Octokit.Webhooks/Models/StatusEvent/CommitVerification.cs
@@ -8,7 +8,7 @@ public sealed record CommitVerification
 
     [JsonPropertyName("reason")]
     [JsonConverter(typeof(StringEnumConverter<CommitVerificationReason>))]
-    public StringEnum<CommitVerificationReason> Reason { get; init; } = null!;
+    public required StringEnum<CommitVerificationReason> Reason { get; init; }
 
     [JsonPropertyName("signature")]
     public string? Signature { get; init; }

--- a/src/Octokit.Webhooks/Models/Team.cs
+++ b/src/Octokit.Webhooks/Models/Team.cs
@@ -4,38 +4,38 @@ namespace Octokit.Webhooks.Models;
 public sealed record Team
 {
     [JsonPropertyName("name")]
-    public string Name { get; init; } = null!;
+    public required string Name { get; init; }
 
     [JsonPropertyName("id")]
     public long Id { get; init; }
 
     [JsonPropertyName("node_id")]
-    public string NodeId { get; init; } = null!;
+    public string? NodeId { get; init; }
 
     [JsonPropertyName("slug")]
-    public string Slug { get; init; } = null!;
+    public string? Slug { get; init; }
 
     [JsonPropertyName("description")]
     public string? Description { get; init; }
 
     [JsonPropertyName("privacy")]
     [JsonConverter(typeof(StringEnumConverter<TeamPrivacy>))]
-    public StringEnum<TeamPrivacy> Privacy { get; init; } = null!;
+    public StringEnum<TeamPrivacy>? Privacy { get; init; }
 
     [JsonPropertyName("url")]
-    public string Url { get; init; } = null!;
+    public string? Url { get; init; }
 
     [JsonPropertyName("html_url")]
-    public string HtmlUrl { get; init; } = null!;
+    public string? HtmlUrl { get; init; }
 
     [JsonPropertyName("members_url")]
-    public string MembersUrl { get; init; } = null!;
+    public string? MembersUrl { get; init; }
 
     [JsonPropertyName("repositories_url")]
-    public string RepositoriesUrl { get; init; } = null!;
+    public string? RepositoriesUrl { get; init; }
 
     [JsonPropertyName("permission")]
-    public string Permission { get; init; } = null!;
+    public string? Permission { get; init; }
 
     [JsonPropertyName("parent")]
     public TeamParent? Parent { get; init; }

--- a/src/Octokit.Webhooks/Models/TeamEvent/ChangesDescription.cs
+++ b/src/Octokit.Webhooks/Models/TeamEvent/ChangesDescription.cs
@@ -4,5 +4,5 @@ namespace Octokit.Webhooks.Models.TeamEvent;
 public sealed record ChangesDescription
 {
     [JsonPropertyName("from")]
-    public string From { get; init; } = null!;
+    public required string From { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/TeamEvent/ChangesName.cs
+++ b/src/Octokit.Webhooks/Models/TeamEvent/ChangesName.cs
@@ -4,5 +4,5 @@ namespace Octokit.Webhooks.Models.TeamEvent;
 public sealed record ChangesName
 {
     [JsonPropertyName("from")]
-    public string From { get; init; } = null!;
+    public required string From { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/TeamEvent/ChangesPrivacy.cs
+++ b/src/Octokit.Webhooks/Models/TeamEvent/ChangesPrivacy.cs
@@ -4,5 +4,5 @@ namespace Octokit.Webhooks.Models.TeamEvent;
 public sealed record ChangesPrivacy
 {
     [JsonPropertyName("from")]
-    public string From { get; init; } = null!;
+    public required string From { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/TeamEvent/ChangesRepository.cs
+++ b/src/Octokit.Webhooks/Models/TeamEvent/ChangesRepository.cs
@@ -4,5 +4,5 @@ namespace Octokit.Webhooks.Models.TeamEvent;
 public sealed record ChangesRepository
 {
     [JsonPropertyName("permissions")]
-    public ChangesRepositoryPermissions Permissions { get; init; } = null!;
+    public required ChangesRepositoryPermissions Permissions { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/TeamEvent/ChangesRepositoryPermissions.cs
+++ b/src/Octokit.Webhooks/Models/TeamEvent/ChangesRepositoryPermissions.cs
@@ -4,5 +4,5 @@ namespace Octokit.Webhooks.Models.TeamEvent;
 public sealed record ChangesRepositoryPermissions
 {
     [JsonPropertyName("from")]
-    public ChangesRepositoryPermissionsFrom From { get; init; } = null!;
+    public required ChangesRepositoryPermissionsFrom From { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/TeamParent.cs
+++ b/src/Octokit.Webhooks/Models/TeamParent.cs
@@ -7,33 +7,33 @@ public sealed record TeamParent
     public string? Description { get; init; }
 
     [JsonPropertyName("name")]
-    public string Name { get; init; } = null!;
+    public required string Name { get; init; }
 
     [JsonPropertyName("id")]
     public long Id { get; init; }
 
     [JsonPropertyName("node_id")]
-    public string NodeId { get; init; } = null!;
+    public required string NodeId { get; init; }
 
     [JsonPropertyName("slug")]
-    public string Slug { get; init; } = null!;
+    public required string Slug { get; init; }
 
     [JsonPropertyName("privacy")]
     [JsonConverter(typeof(StringEnumConverter<TeamParentPrivacy>))]
-    public StringEnum<TeamParentPrivacy> Privacy { get; init; } = null!;
+    public required StringEnum<TeamParentPrivacy> Privacy { get; init; }
 
     [JsonPropertyName("url")]
-    public string Url { get; init; } = null!;
+    public required string Url { get; init; }
 
     [JsonPropertyName("html_url")]
-    public string HtmlUrl { get; init; } = null!;
+    public required string HtmlUrl { get; init; }
 
     [JsonPropertyName("members_url")]
-    public string MembersUrl { get; init; } = null!;
+    public required string MembersUrl { get; init; }
 
     [JsonPropertyName("repositories_url")]
-    public string RepositoriesUrl { get; init; } = null!;
+    public required string RepositoriesUrl { get; init; }
 
     [JsonPropertyName("permission")]
-    public string Permission { get; init; } = null!;
+    public required string Permission { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/User.cs
+++ b/src/Octokit.Webhooks/Models/User.cs
@@ -4,13 +4,13 @@ namespace Octokit.Webhooks.Models;
 public sealed record User
 {
     [JsonPropertyName("login")]
-    public string Login { get; init; } = null!;
+    public required string Login { get; init; }
 
     [JsonPropertyName("id")]
     public long Id { get; init; }
 
     [JsonPropertyName("node_id")]
-    public string NodeId { get; init; } = null!;
+    public string? NodeId { get; init; }
 
     [JsonPropertyName("name")]
     public string? Name { get; init; }
@@ -19,47 +19,47 @@ public sealed record User
     public string? Email { get; init; }
 
     [JsonPropertyName("avatar_url")]
-    public string AvatarUrl { get; init; } = null!;
+    public required string AvatarUrl { get; init; }
 
     [JsonPropertyName("gravatar_id")]
-    public string GravatarId { get; init; } = null!;
+    public string? GravatarId { get; init; }
 
     [JsonPropertyName("url")]
-    public string Url { get; init; } = null!;
+    public required string Url { get; init; }
 
     [JsonPropertyName("html_url")]
-    public string HtmlUrl { get; init; } = null!;
+    public string? HtmlUrl { get; init; }
 
     [JsonPropertyName("followers_url")]
-    public string FollowersUrl { get; init; } = null!;
+    public string? FollowersUrl { get; init; }
 
     [JsonPropertyName("following_url")]
-    public string FollowingUrl { get; init; } = null!;
+    public string? FollowingUrl { get; init; }
 
     [JsonPropertyName("gists_url")]
-    public string GistsUrl { get; init; } = null!;
+    public string? GistsUrl { get; init; }
 
     [JsonPropertyName("starred_url")]
-    public string StarredUrl { get; init; } = null!;
+    public string? StarredUrl { get; init; }
 
     [JsonPropertyName("subscriptions_url")]
-    public string SubscriptionsUrl { get; init; } = null!;
+    public string? SubscriptionsUrl { get; init; }
 
     [JsonPropertyName("organizations_url")]
-    public string OrganizationsUrl { get; init; } = null!;
+    public string? OrganizationsUrl { get; init; }
 
     [JsonPropertyName("repos_url")]
-    public string ReposUrl { get; init; } = null!;
+    public string? ReposUrl { get; init; }
 
     [JsonPropertyName("events_url")]
-    public string EventsUrl { get; init; } = null!;
+    public string? EventsUrl { get; init; }
 
     [JsonPropertyName("received_events_url")]
-    public string ReceivedEventsUrl { get; init; } = null!;
+    public string? ReceivedEventsUrl { get; init; }
 
     [JsonPropertyName("type")]
     [JsonConverter(typeof(StringEnumConverter<UserType>))]
-    public StringEnum<UserType> Type { get; init; } = null!;
+    public required StringEnum<UserType> Type { get; init; }
 
     [JsonPropertyName("site_admin")]
     public bool SiteAdmin { get; init; }

--- a/src/Octokit.Webhooks/Models/Workflow.cs
+++ b/src/Octokit.Webhooks/Models/Workflow.cs
@@ -4,35 +4,35 @@ namespace Octokit.Webhooks.Models;
 public sealed record Workflow
 {
     [JsonPropertyName("badge_url")]
-    public string BadgeUrl { get; init; } = null!;
+    public required string BadgeUrl { get; init; }
 
     [JsonPropertyName("created_at")]
     [JsonConverter(typeof(DateTimeOffsetConverter))]
     public DateTimeOffset CreatedAt { get; init; }
 
     [JsonPropertyName("html_url")]
-    public string HtmlUrl { get; init; } = null!;
+    public required string HtmlUrl { get; init; }
 
     [JsonPropertyName("id")]
     public long Id { get; init; }
 
     [JsonPropertyName("name")]
-    public string Name { get; init; } = null!;
+    public required string Name { get; init; }
 
     [JsonPropertyName("node_id")]
-    public string NodeId { get; init; } = null!;
+    public required string NodeId { get; init; }
 
     [JsonPropertyName("path")]
-    public string Path { get; init; } = null!;
+    public required string Path { get; init; }
 
     [JsonPropertyName("state")]
     [JsonConverter(typeof(StringEnumConverter<WorkflowState>))]
-    public StringEnum<WorkflowState> State { get; init; } = null!;
+    public required StringEnum<WorkflowState> State { get; init; }
 
     [JsonPropertyName("updated_at")]
     [JsonConverter(typeof(DateTimeOffsetConverter))]
     public DateTimeOffset UpdatedAt { get; init; }
 
     [JsonPropertyName("url")]
-    public string Url { get; init; } = null!;
+    public required string Url { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/WorkflowJobEvent/WorkflowJob.cs
+++ b/src/Octokit.Webhooks/Models/WorkflowJobEvent/WorkflowJob.cs
@@ -13,39 +13,39 @@ public sealed record WorkflowJob
     public long RunAttempt { get; init; }
 
     [JsonPropertyName("run_url")]
-    public string RunUrl { get; init; } = null!;
+    public required string RunUrl { get; init; }
 
     [JsonPropertyName("head_sha")]
-    public string HeadSha { get; init; } = null!;
+    public required string HeadSha { get; init; }
 
     [JsonPropertyName("node_id")]
-    public string NodeId { get; init; } = null!;
+    public required string NodeId { get; init; }
 
     [JsonPropertyName("name")]
-    public string Name { get; init; } = null!;
+    public required string Name { get; init; }
 
     [JsonPropertyName("check_run_url")]
-    public string CheckRunUrl { get; init; } = null!;
+    public required string CheckRunUrl { get; init; }
 
     [JsonPropertyName("html_url")]
-    public string HtmlUrl { get; init; } = null!;
+    public required string HtmlUrl { get; init; }
 
     [JsonPropertyName("url")]
-    public string Url { get; init; } = null!;
+    public required string Url { get; init; }
 
     [JsonPropertyName("status")]
     [JsonConverter(typeof(StringEnumConverter<WorkflowJobStatus>))]
-    public StringEnum<WorkflowJobStatus> Status { get; init; } = null!;
+    public required StringEnum<WorkflowJobStatus> Status { get; init; }
 
     [JsonPropertyName("steps")]
-    public IEnumerable<WorkflowJobStep> Steps { get; init; } = null!;
+    public required IReadOnlyList<WorkflowJobStep> Steps { get; init; }
 
     [JsonPropertyName("conclusion")]
     [JsonConverter(typeof(StringEnumConverter<WorkflowJobConclusion>))]
     public StringEnum<WorkflowJobConclusion>? Conclusion { get; init; }
 
     [JsonPropertyName("labels")]
-    public IEnumerable<string> Labels { get; init; } = null!;
+    public required IReadOnlyList<string> Labels { get; init; }
 
     [JsonPropertyName("runner_id")]
     public int? RunnerId { get; init; }

--- a/src/Octokit.Webhooks/Models/WorkflowJobEvent/WorkflowJobStep.cs
+++ b/src/Octokit.Webhooks/Models/WorkflowJobEvent/WorkflowJobStep.cs
@@ -4,11 +4,11 @@ namespace Octokit.Webhooks.Models.WorkflowJobEvent;
 public sealed record WorkflowJobStep
 {
     [JsonPropertyName("name")]
-    public string Name { get; init; } = null!;
+    public required string Name { get; init; }
 
     [JsonPropertyName("status")]
     [JsonConverter(typeof(StringEnumConverter<WorkflowJobStepStatus>))]
-    public StringEnum<WorkflowJobStepStatus> Status { get; init; } = null!;
+    public required StringEnum<WorkflowJobStepStatus> Status { get; init; }
 
     [JsonPropertyName("conclusion")]
     [JsonConverter(typeof(StringEnumConverter<WorkflowJobStepConclusion>))]

--- a/src/Octokit.Webhooks/Models/WorkflowJobRun.cs
+++ b/src/Octokit.Webhooks/Models/WorkflowJobRun.cs
@@ -7,18 +7,18 @@ public sealed record WorkflowJobRun
     public long Id { get; init; }
 
     [JsonPropertyName("name")]
-    public string Name { get; init; } = null!;
+    public required string Name { get; init; }
 
     [JsonPropertyName("status")]
     [JsonConverter(typeof(StringEnumConverter<WorkflowJobRunStatus>))]
-    public StringEnum<WorkflowJobRunStatus> Status { get; init; } = null!;
+    public required StringEnum<WorkflowJobRunStatus> Status { get; init; }
 
     [JsonPropertyName("conclusion")]
     [JsonConverter(typeof(StringEnumConverter<WorkflowJobRunConclusion>))]
     public StringEnum<WorkflowJobRunConclusion>? Conclusion { get; init; }
 
     [JsonPropertyName("html_url")]
-    public string HtmlUrl { get; init; } = null!;
+    public required string HtmlUrl { get; init; }
 
     [JsonPropertyName("created_at")]
     [JsonConverter(typeof(DateTimeOffsetConverter))]
@@ -29,5 +29,5 @@ public sealed record WorkflowJobRun
     public DateTimeOffset UpdatedAt { get; init; }
 
     [JsonPropertyName("environment")]
-    public string Environment { get; init; } = null!;
+    public required string Environment { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/WorkflowPullRequest.cs
+++ b/src/Octokit.Webhooks/Models/WorkflowPullRequest.cs
@@ -4,7 +4,7 @@ namespace Octokit.Webhooks.Models;
 public sealed record WorkflowPullRequest
 {
     [JsonPropertyName("url")]
-    public string Url { get; init; } = null!;
+    public required string Url { get; init; }
 
     [JsonPropertyName("id")]
     public long Id { get; init; }
@@ -13,8 +13,8 @@ public sealed record WorkflowPullRequest
     public long Number { get; init; }
 
     [JsonPropertyName("head")]
-    public WorkflowPullRequestHead Head { get; init; } = null!;
+    public required WorkflowPullRequestHead Head { get; init; }
 
     [JsonPropertyName("base")]
-    public WorkflowPullRequestBase Base { get; init; } = null!;
+    public required WorkflowPullRequestBase Base { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/WorkflowPullRequestBase.cs
+++ b/src/Octokit.Webhooks/Models/WorkflowPullRequestBase.cs
@@ -4,11 +4,11 @@ namespace Octokit.Webhooks.Models;
 public sealed record WorkflowPullRequestBase
 {
     [JsonPropertyName("ref")]
-    public string Ref { get; init; } = null!;
+    public required string Ref { get; init; }
 
     [JsonPropertyName("sha")]
-    public string Sha { get; init; } = null!;
+    public required string Sha { get; init; }
 
     [JsonPropertyName("repo")]
-    public RepoRef Repo { get; init; } = null!;
+    public required RepoRef Repo { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/WorkflowPullRequestHead.cs
+++ b/src/Octokit.Webhooks/Models/WorkflowPullRequestHead.cs
@@ -4,11 +4,11 @@ namespace Octokit.Webhooks.Models;
 public sealed record WorkflowPullRequestHead
 {
     [JsonPropertyName("ref")]
-    public string Ref { get; init; } = null!;
+    public required string Ref { get; init; }
 
     [JsonPropertyName("sha")]
-    public string Sha { get; init; } = null!;
+    public required string Sha { get; init; }
 
     [JsonPropertyName("repo")]
-    public RepoRef Repo { get; init; } = null!;
+    public required RepoRef Repo { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/WorkflowRun.cs
+++ b/src/Octokit.Webhooks/Models/WorkflowRun.cs
@@ -4,19 +4,19 @@ namespace Octokit.Webhooks.Models;
 public sealed record WorkflowRun
 {
     [JsonPropertyName("artifacts_url")]
-    public string ArtifactsUrl { get; init; } = null!;
+    public required string ArtifactsUrl { get; init; }
 
     [JsonPropertyName("cancel_url")]
-    public string CancelUrl { get; init; } = null!;
+    public required string CancelUrl { get; init; }
 
     [JsonPropertyName("check_suite_url")]
-    public string CheckSuiteUrl { get; init; } = null!;
+    public required string CheckSuiteUrl { get; init; }
 
     [JsonPropertyName("check_suite_id")]
     public long CheckSuiteId { get; init; }
 
     [JsonPropertyName("check_suite_node_id")]
-    public string CheckSuiteNodeId { get; init; } = null!;
+    public required string CheckSuiteNodeId { get; init; }
 
     [JsonPropertyName("conclusion")]
     [JsonConverter(typeof(StringEnumConverter<WorkflowRunConclusion>))]
@@ -27,72 +27,72 @@ public sealed record WorkflowRun
     public DateTimeOffset CreatedAt { get; init; }
 
     [JsonPropertyName("display_title")]
-    public string DisplayTitle { get; init; } = null!;
+    public required string DisplayTitle { get; init; }
 
     [JsonPropertyName("event")]
-    public string Event { get; init; } = null!;
+    public required string Event { get; init; }
 
     [JsonPropertyName("head_branch")]
-    public string HeadBranch { get; init; } = null!;
+    public required string HeadBranch { get; init; }
 
     [JsonPropertyName("head_commit")]
-    public SimpleCommit HeadCommit { get; init; } = null!;
+    public required SimpleCommit HeadCommit { get; init; }
 
     [JsonPropertyName("head_repository")]
-    public RepositoryLite HeadRepository { get; init; } = null!;
+    public required RepositoryLite HeadRepository { get; init; }
 
     [JsonPropertyName("head_sha")]
-    public string HeadSha { get; init; } = null!;
+    public required string HeadSha { get; init; }
 
     [JsonPropertyName("html_url")]
-    public string HtmlUrl { get; init; } = null!;
+    public required string HtmlUrl { get; init; }
 
     [JsonPropertyName("id")]
     public long Id { get; init; }
 
     [JsonPropertyName("jobs_url")]
-    public string JobsUrl { get; init; } = null!;
+    public required string JobsUrl { get; init; }
 
     [JsonPropertyName("logs_url")]
-    public string LogsUrl { get; init; } = null!;
+    public required string LogsUrl { get; init; }
 
     [JsonPropertyName("node_id")]
-    public string NodeId { get; init; } = null!;
+    public required string NodeId { get; init; }
 
     [JsonPropertyName("name")]
-    public string Name { get; init; } = null!;
+    public required string Name { get; init; }
 
     [JsonPropertyName("path")]
-    public string Path { get; init; } = null!;
+    public required string Path { get; init; }
 
     [JsonPropertyName("pull_requests")]
-    public IEnumerable<WorkflowPullRequest> PullRequests { get; init; } = null!;
+    public required IReadOnlyList<WorkflowPullRequest> PullRequests { get; init; }
 
     [JsonPropertyName("repository")]
-    public RepositoryLite Repository { get; init; } = null!;
+    public required RepositoryLite Repository { get; init; }
 
     [JsonPropertyName("rerun_url")]
-    public string RerunUrl { get; init; } = null!;
+    public required string RerunUrl { get; init; }
 
     [JsonPropertyName("run_number")]
     public long RunNumber { get; init; }
 
     [JsonPropertyName("status")]
     [JsonConverter(typeof(StringEnumConverter<WorkflowRunStatus>))]
-    public StringEnum<WorkflowRunStatus> Status { get; init; } = null!;
+    public required StringEnum<WorkflowRunStatus> Status { get; init; }
 
     [JsonPropertyName("updated_at")]
     [JsonConverter(typeof(DateTimeOffsetConverter))]
     public DateTimeOffset UpdatedAt { get; init; }
 
     [JsonPropertyName("url")]
-    public string Url { get; init; } = null!;
+    public required string Url { get; init; }
 
     [JsonPropertyName("workflow_id")]
     public long WorkflowId { get; init; }
 
     [JsonPropertyName("workflow_url")]
-    public string WorkflowUrl { get; init; } = null!;
+    public required string WorkflowUrl { get; init; }
 
     [JsonPropertyName("run_attempt")]
     public long RunAttempt { get; init; }
@@ -105,11 +105,11 @@ public sealed record WorkflowRun
     public string? PreviousAttemptUrl { get; init; }
 
     [JsonPropertyName("actor")]
-    public User Actor { get; init; } = null!;
+    public required User Actor { get; init; }
 
     [JsonPropertyName("triggering_actor")]
-    public User TriggeringActor { get; init; } = null!;
+    public required User TriggeringActor { get; init; }
 
     [JsonPropertyName("referenced_workflows")]
-    public IEnumerable<ReferencedWorkflow> ReferencedWorkflows { get; init; } = null!;
+    public IReadOnlyList<ReferencedWorkflow>? ReferencedWorkflows { get; init; }
 }


### PR DESCRIPTION
### Before the change?

* 1010 properties used `= null!` to suppress nullable warnings on non-nullable reference types — no compile-time enforcement that callers set them
* 69 collection properties used `IEnumerable<T>`, which allows multiple enumeration and has no indexer

### After the change?

* 917 properties now use the `required` keyword (C# 11) — callers must set them in object initializers or the compiler errors
* ~90 properties that are sometimes absent in real GitHub payloads were changed to nullable (`?`) instead, since `required` would break deserialization for those
* 69 `IEnumerable<T>` properties changed to `IReadOnlyList<T>` — prevents multiple enumeration, adds O(1) indexing
* 2 remaining `= null!` on `InstallationEvent`/`InstallationRepositoriesEvent` use `new` to hide a base property, where `required` does not apply

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?

- [x] Yes
- [ ] No

* `required` properties must be set in object initializers (affects anyone constructing model objects manually)
* `IEnumerable<T>` changed to `IReadOnlyList<T>` on collection properties
