### PR TITLE
Use FrozenDictionary in WebhookConverter, seal unsealed types

### DIFF
--- a/src/Octokit.Webhooks/Converter/ChangesFieldValueChangeConverter.cs
+++ b/src/Octokit.Webhooks/Converter/ChangesFieldValueChangeConverter.cs
@@ -2,7 +2,7 @@ namespace Octokit.Webhooks.Converter;
 
 using Octokit.Webhooks.Models.ProjectsV2ItemEvent;
 
-public class ChangesFieldValueChangeConverter : JsonConverter<ChangesFieldValueChangeBase>
+public sealed class ChangesFieldValueChangeConverter : JsonConverter<ChangesFieldValueChangeBase>
 {
     public override ChangesFieldValueChangeBase? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {

--- a/src/Octokit.Webhooks/Converter/DateTimeOffsetConverter.cs
+++ b/src/Octokit.Webhooks/Converter/DateTimeOffsetConverter.cs
@@ -1,6 +1,6 @@
 namespace Octokit.Webhooks.Converter;
 
-public class DateTimeOffsetConverter : JsonConverter<DateTimeOffset>
+public sealed class DateTimeOffsetConverter : JsonConverter<DateTimeOffset>
 {
     public override DateTimeOffset Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) =>
         ReadInternal(ref reader);

--- a/src/Octokit.Webhooks/Converter/NullableDateTimeOffsetConverter.cs
+++ b/src/Octokit.Webhooks/Converter/NullableDateTimeOffsetConverter.cs
@@ -1,6 +1,6 @@
 namespace Octokit.Webhooks.Converter;
 
-public class NullableDateTimeOffsetConverter : JsonConverter<DateTimeOffset?>
+public sealed class NullableDateTimeOffsetConverter : JsonConverter<DateTimeOffset?>
 {
     public override DateTimeOffset? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) => reader.TokenType switch
     {

--- a/src/Octokit.Webhooks/Converter/WebhookConverter.cs
+++ b/src/Octokit.Webhooks/Converter/WebhookConverter.cs
@@ -1,24 +1,14 @@
 namespace Octokit.Webhooks.Converter;
 
+using System.Collections.Frozen;
 using System.Linq;
 using System.Reflection;
 
 [PublicAPI]
-public class WebhookConverter<T> : JsonConverter<T>
+public sealed class WebhookConverter<T> : JsonConverter<T>
     where T : WebhookEvent
 {
-    private readonly Dictionary<string, Type> types;
-
-    public WebhookConverter()
-    {
-        var type = typeof(T);
-        this.types = this.GetType().Assembly.GetTypes()
-            .Where(x => type.IsAssignableFrom(x) && x is { IsClass: true, IsAbstract: false } &&
-                        x.GetCustomAttribute<WebhookActionTypeAttribute>() is not null)
-            .ToDictionary(
-                y => y.GetCustomAttribute<WebhookActionTypeAttribute>()!.ActionType,
-                y => y);
-    }
+    private static readonly FrozenDictionary<string, Type> Types = BuildTypeMap();
 
     public override T Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {
@@ -37,7 +27,7 @@ public class WebhookConverter<T> : JsonConverter<T>
 
         var actionValue = action.GetString();
 
-        if (actionValue is not null && this.types.TryGetValue(actionValue, out var payloadType))
+        if (actionValue is not null && Types.TryGetValue(actionValue, out var payloadType))
         {
             type = payloadType;
         }
@@ -61,4 +51,15 @@ public class WebhookConverter<T> : JsonConverter<T>
 
     public override void Write(Utf8JsonWriter writer, T value, JsonSerializerOptions options) =>
         JsonSerializer.Serialize(writer, value, options);
+
+    private static FrozenDictionary<string, Type> BuildTypeMap()
+    {
+        var type = typeof(T);
+        return type.Assembly.GetTypes()
+            .Where(x => type.IsAssignableFrom(x) && x is { IsClass: true, IsAbstract: false } &&
+                        x.GetCustomAttribute<WebhookActionTypeAttribute>() is not null)
+            .ToFrozenDictionary(
+                y => y.GetCustomAttribute<WebhookActionTypeAttribute>()!.ActionType,
+                y => y);
+    }
 }

--- a/src/Octokit.Webhooks/Events/MergeQueueEntry/MergeQueueEntryCreatedEvent.cs
+++ b/src/Octokit.Webhooks/Events/MergeQueueEntry/MergeQueueEntryCreatedEvent.cs
@@ -2,7 +2,7 @@ namespace Octokit.Webhooks.Events.MergeQueueEntry;
 
 [PublicAPI]
 [WebhookActionType(MergeQueueEntryActionValue.Created)]
-public record MergeQueueEntryCreatedEvent : MergeQueueEntryEvent
+public sealed record MergeQueueEntryCreatedEvent : MergeQueueEntryEvent
 {
     [JsonPropertyName("action")]
     public override string Action => MergeQueueEntryAction.Created;

--- a/src/Octokit.Webhooks/Events/MergeQueueEntry/MergeQueueEntryDeletedEvent.cs
+++ b/src/Octokit.Webhooks/Events/MergeQueueEntry/MergeQueueEntryDeletedEvent.cs
@@ -2,7 +2,7 @@ namespace Octokit.Webhooks.Events.MergeQueueEntry;
 
 [PublicAPI]
 [WebhookActionType(MergeQueueEntryActionValue.Deleted)]
-public record MergeQueueEntryDeletedEvent : MergeQueueEntryEvent
+public sealed record MergeQueueEntryDeletedEvent : MergeQueueEntryEvent
 {
     [JsonPropertyName("action")]
     public override string Action => MergeQueueEntryAction.Deleted;

--- a/src/Octokit.Webhooks/Events/RepositoryRuleset/RepositoryRulesetCreatedEvent.cs
+++ b/src/Octokit.Webhooks/Events/RepositoryRuleset/RepositoryRulesetCreatedEvent.cs
@@ -2,7 +2,7 @@ namespace Octokit.Webhooks.Events.RepositoryRuleset;
 
 [PublicAPI]
 [WebhookActionType(RepositoryRulesetActionValue.Created)]
-public record RepositoryRulesetCreatedEvent : RepositoryRulesetEvent
+public sealed record RepositoryRulesetCreatedEvent : RepositoryRulesetEvent
 {
     [JsonPropertyName("action")]
     public override string Action => RepositoryRulesetAction.Created;

--- a/src/Octokit.Webhooks/Events/RepositoryRuleset/RepositoryRulesetDeletedEvent.cs
+++ b/src/Octokit.Webhooks/Events/RepositoryRuleset/RepositoryRulesetDeletedEvent.cs
@@ -2,7 +2,7 @@ namespace Octokit.Webhooks.Events.RepositoryRuleset;
 
 [PublicAPI]
 [WebhookActionType(RepositoryRulesetActionValue.Deleted)]
-public record RepositoryRulesetDeletedEvent : RepositoryRulesetEvent
+public sealed record RepositoryRulesetDeletedEvent : RepositoryRulesetEvent
 {
     [JsonPropertyName("action")]
     public override string Action => RepositoryRulesetAction.Deleted;

--- a/src/Octokit.Webhooks/Events/RepositoryRuleset/RepositoryRulesetEditedEvent.cs
+++ b/src/Octokit.Webhooks/Events/RepositoryRuleset/RepositoryRulesetEditedEvent.cs
@@ -4,7 +4,7 @@ using Octokit.Webhooks.Models.RepositoryRulesetEvent;
 
 [PublicAPI]
 [WebhookActionType(RepositoryRulesetActionValue.Edited)]
-public record RepositoryRulesetEditedEvent : RepositoryRulesetEvent
+public sealed record RepositoryRulesetEditedEvent : RepositoryRulesetEvent
 {
     [JsonPropertyName("action")]
     public override string Action => RepositoryRulesetAction.Edited;

--- a/src/Octokit.Webhooks/Models/InstallationTargetEvent/ChangesLogin.cs
+++ b/src/Octokit.Webhooks/Models/InstallationTargetEvent/ChangesLogin.cs
@@ -1,7 +1,7 @@
 namespace Octokit.Webhooks.Models.InstallationTargetEvent;
 
 [PublicAPI]
-public record ChangesLogin
+public sealed record ChangesLogin
 {
     [JsonPropertyName("from")]
     public required string From { get; init; }

--- a/src/Octokit.Webhooks/Models/OrganizationEvent/ChangesLogin.cs
+++ b/src/Octokit.Webhooks/Models/OrganizationEvent/ChangesLogin.cs
@@ -1,7 +1,7 @@
 namespace Octokit.Webhooks.Models.OrganizationEvent;
 
 [PublicAPI]
-public record ChangesLogin
+public sealed record ChangesLogin
 {
     [JsonPropertyName("from")]
     public required string From { get; init; }


### PR DESCRIPTION
### Before the change?

* `WebhookConverter<T>` rebuilt its action-to-type dictionary on every new instance via runtime reflection
* 7 records and 3 converter classes were missing `sealed`

### After the change?

* `WebhookConverter<T>` now uses a `static FrozenDictionary` — the type map is built once per generic type parameter and shared across all instances
* Converter class itself is sealed
* Sealed 5 action event records (`RepositoryRuleset*Event`, `MergeQueueEntry*Event`), 2 model records (`ChangesLogin`), and 3 converter classes

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?

- [x] Yes
- [ ] No

* `WebhookConverter<T>` is now `sealed` (anyone subclassing it will break, though this seems unlikely)
* 10 types that were implicitly unsealed are now `sealed`
