### PR TITLE
Seal DependabotAlertFirstPatchedVersion, add missing [PublicAPI], strip last BOM

### DIFF
--- a/src/Octokit.Webhooks.AspNetCore/GitHubWebhookOptions.cs
+++ b/src/Octokit.Webhooks.AspNetCore/GitHubWebhookOptions.cs
@@ -1,4 +1,4 @@
-﻿namespace Octokit.Webhooks.AspNetCore;
+namespace Octokit.Webhooks.AspNetCore;
 
 public record GitHubWebhookOptions
 {

--- a/src/Octokit.Webhooks/Converter/ChangesFieldValueChangeConverter.cs
+++ b/src/Octokit.Webhooks/Converter/ChangesFieldValueChangeConverter.cs
@@ -2,6 +2,7 @@ namespace Octokit.Webhooks.Converter;
 
 using Octokit.Webhooks.Models.ProjectsV2ItemEvent;
 
+[PublicAPI]
 public sealed class ChangesFieldValueChangeConverter : JsonConverter<ChangesFieldValueChangeBase>
 {
     public override ChangesFieldValueChangeBase? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)

--- a/src/Octokit.Webhooks/Converter/DateTimeOffsetConverter.cs
+++ b/src/Octokit.Webhooks/Converter/DateTimeOffsetConverter.cs
@@ -1,5 +1,6 @@
 namespace Octokit.Webhooks.Converter;
 
+[PublicAPI]
 public sealed class DateTimeOffsetConverter : JsonConverter<DateTimeOffset>
 {
     public override DateTimeOffset Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) =>

--- a/src/Octokit.Webhooks/Converter/NullableDateTimeOffsetConverter.cs
+++ b/src/Octokit.Webhooks/Converter/NullableDateTimeOffsetConverter.cs
@@ -1,5 +1,6 @@
 namespace Octokit.Webhooks.Converter;
 
+[PublicAPI]
 public sealed class NullableDateTimeOffsetConverter : JsonConverter<DateTimeOffset?>
 {
     public override DateTimeOffset? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) => reader.TokenType switch

--- a/src/Octokit.Webhooks/Converter/StringEnumConverter.cs
+++ b/src/Octokit.Webhooks/Converter/StringEnumConverter.cs
@@ -5,6 +5,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using Octokit.Webhooks.Extensions;
 
+[PublicAPI]
 public sealed class StringEnumConverter<TEnum> : JsonConverter<StringEnum<TEnum>>
     where TEnum : struct, Enum
 {

--- a/src/Octokit.Webhooks/Converter/StringEnumEnumerableConverter.cs
+++ b/src/Octokit.Webhooks/Converter/StringEnumEnumerableConverter.cs
@@ -6,6 +6,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using Octokit.Webhooks.Extensions;
 
+[PublicAPI]
 public sealed class StringEnumEnumerableConverter<TEnum> : JsonConverter<IEnumerable<StringEnum<TEnum>>>
     where TEnum : struct, Enum
 {

--- a/src/Octokit.Webhooks/Events/BranchProtectionConfiguration/BranchProtectionConfigurationActionValue.cs
+++ b/src/Octokit.Webhooks/Events/BranchProtectionConfiguration/BranchProtectionConfigurationActionValue.cs
@@ -1,5 +1,6 @@
 namespace Octokit.Webhooks.Events.BranchProtectionConfiguration;
 
+[PublicAPI]
 public static class BranchProtectionConfigurationActionValue
 {
     public const string Disabled = "disabled";

--- a/src/Octokit.Webhooks/Events/BranchProtectionRule/BranchProtectionRuleActionValue.cs
+++ b/src/Octokit.Webhooks/Events/BranchProtectionRule/BranchProtectionRuleActionValue.cs
@@ -1,5 +1,6 @@
 namespace Octokit.Webhooks.Events.BranchProtectionRule;
 
+[PublicAPI]
 public static class BranchProtectionRuleActionValue
 {
     public const string Created = "created";

--- a/src/Octokit.Webhooks/Events/CheckRun/CheckRunActionValue.cs
+++ b/src/Octokit.Webhooks/Events/CheckRun/CheckRunActionValue.cs
@@ -1,5 +1,6 @@
 namespace Octokit.Webhooks.Events.CheckRun;
 
+[PublicAPI]
 public static class CheckRunActionValue
 {
     public const string Completed = "completed";

--- a/src/Octokit.Webhooks/Events/CheckSuite/CheckSuiteActionValue.cs
+++ b/src/Octokit.Webhooks/Events/CheckSuite/CheckSuiteActionValue.cs
@@ -1,5 +1,6 @@
 namespace Octokit.Webhooks.Events.CheckSuite;
 
+[PublicAPI]
 public static class CheckSuiteActionValue
 {
     public const string Completed = "completed";

--- a/src/Octokit.Webhooks/Events/CodeScanningAlert/CodeScanningAlertActionValue.cs
+++ b/src/Octokit.Webhooks/Events/CodeScanningAlert/CodeScanningAlertActionValue.cs
@@ -1,5 +1,6 @@
 namespace Octokit.Webhooks.Events.CodeScanningAlert;
 
+[PublicAPI]
 public static class CodeScanningAlertActionValue
 {
     public const string AppearedInBranch = "appeared_in_branch";

--- a/src/Octokit.Webhooks/Events/CommitComment/CommitCommentActionValue.cs
+++ b/src/Octokit.Webhooks/Events/CommitComment/CommitCommentActionValue.cs
@@ -1,5 +1,6 @@
 namespace Octokit.Webhooks.Events.CommitComment;
 
+[PublicAPI]
 public static class CommitCommentActionValue
 {
     public const string Created = "created";

--- a/src/Octokit.Webhooks/Events/ContentReference/ContentReferenceActionValue.cs
+++ b/src/Octokit.Webhooks/Events/ContentReference/ContentReferenceActionValue.cs
@@ -1,5 +1,6 @@
 namespace Octokit.Webhooks.Events.ContentReference;
 
+[PublicAPI]
 public static class ContentReferenceActionValue
 {
     public const string Created = "created";

--- a/src/Octokit.Webhooks/Events/CustomProperty/CustomPropertyActionValue.cs
+++ b/src/Octokit.Webhooks/Events/CustomProperty/CustomPropertyActionValue.cs
@@ -1,5 +1,6 @@
 namespace Octokit.Webhooks.Events.CustomProperty;
 
+[PublicAPI]
 public static class CustomPropertyActionValue
 {
     public const string Created = "created";

--- a/src/Octokit.Webhooks/Events/CustomPropertyPromotedToEnterprise/CustomPropertyPromotedToEnterpriseActionValue.cs
+++ b/src/Octokit.Webhooks/Events/CustomPropertyPromotedToEnterprise/CustomPropertyPromotedToEnterpriseActionValue.cs
@@ -1,5 +1,6 @@
 namespace Octokit.Webhooks.Events.CustomPropertyPromotedToEnterprise;
 
+[PublicAPI]
 public static class CustomPropertyPromotedToEnterpriseActionValue
 {
     public const string PromoteToEnterprise = "promote_to_enterprise";

--- a/src/Octokit.Webhooks/Events/CustomPropertyValues/CustomPropertyValuesActionValue.cs
+++ b/src/Octokit.Webhooks/Events/CustomPropertyValues/CustomPropertyValuesActionValue.cs
@@ -1,5 +1,6 @@
 namespace Octokit.Webhooks.Events.CustomPropertyValues;
 
+[PublicAPI]
 public static class CustomPropertyValuesActionValue
 {
     public const string Updated = "updated";

--- a/src/Octokit.Webhooks/Events/DependabotAlert/DependabotAlertActionValue.cs
+++ b/src/Octokit.Webhooks/Events/DependabotAlert/DependabotAlertActionValue.cs
@@ -1,5 +1,6 @@
 namespace Octokit.Webhooks.Events.DependabotAlert;
 
+[PublicAPI]
 public static class DependabotAlertActionValue
 {
     public const string Created = "created";

--- a/src/Octokit.Webhooks/Events/DeployKey/DeployKeyActionValue.cs
+++ b/src/Octokit.Webhooks/Events/DeployKey/DeployKeyActionValue.cs
@@ -1,5 +1,6 @@
 namespace Octokit.Webhooks.Events.DeployKey;
 
+[PublicAPI]
 public static class DeployKeyActionValue
 {
     public const string Created = "created";

--- a/src/Octokit.Webhooks/Events/Deployment/DeploymentActionValue.cs
+++ b/src/Octokit.Webhooks/Events/Deployment/DeploymentActionValue.cs
@@ -1,5 +1,6 @@
 namespace Octokit.Webhooks.Events.Deployment;
 
+[PublicAPI]
 public static class DeploymentActionValue
 {
     public const string Created = "created";

--- a/src/Octokit.Webhooks/Events/DeploymentProtectionRule/DeploymentProtectionRuleActionValue.cs
+++ b/src/Octokit.Webhooks/Events/DeploymentProtectionRule/DeploymentProtectionRuleActionValue.cs
@@ -1,5 +1,6 @@
 namespace Octokit.Webhooks.Events.DeploymentProtectionRule;
 
+[PublicAPI]
 public static class DeploymentProtectionRuleActionValue
 {
     public const string Requested = "requested";

--- a/src/Octokit.Webhooks/Events/DeploymentReview/DeploymentReviewActionValue.cs
+++ b/src/Octokit.Webhooks/Events/DeploymentReview/DeploymentReviewActionValue.cs
@@ -1,5 +1,6 @@
 namespace Octokit.Webhooks.Events.DeploymentReview;
 
+[PublicAPI]
 public static class DeploymentReviewActionValue
 {
     public const string Approved = "approved";

--- a/src/Octokit.Webhooks/Events/DeploymentStatus/DeploymentStatusActionValue.cs
+++ b/src/Octokit.Webhooks/Events/DeploymentStatus/DeploymentStatusActionValue.cs
@@ -1,5 +1,6 @@
 namespace Octokit.Webhooks.Events.DeploymentStatus;
 
+[PublicAPI]
 public static class DeploymentStatusActionValue
 {
     public const string Created = "created";

--- a/src/Octokit.Webhooks/Events/Discussion/DiscussionActionValue.cs
+++ b/src/Octokit.Webhooks/Events/Discussion/DiscussionActionValue.cs
@@ -1,5 +1,6 @@
 namespace Octokit.Webhooks.Events.Discussion;
 
+[PublicAPI]
 public static class DiscussionActionValue
 {
     public const string Answered = "answered";

--- a/src/Octokit.Webhooks/Events/DiscussionComment/DiscussionCommentActionValue.cs
+++ b/src/Octokit.Webhooks/Events/DiscussionComment/DiscussionCommentActionValue.cs
@@ -1,5 +1,6 @@
 namespace Octokit.Webhooks.Events.DiscussionComment;
 
+[PublicAPI]
 public static class DiscussionCommentActionValue
 {
     public const string Created = "created";

--- a/src/Octokit.Webhooks/Events/GithubAppAuthorization/GithubAppAuthorizationActionValue.cs
+++ b/src/Octokit.Webhooks/Events/GithubAppAuthorization/GithubAppAuthorizationActionValue.cs
@@ -1,5 +1,6 @@
 namespace Octokit.Webhooks.Events.GithubAppAuthorization;
 
+[PublicAPI]
 public static class GithubAppAuthorizationActionValue
 {
     public const string Revoked = "revoked";

--- a/src/Octokit.Webhooks/Events/Installation/InstallationActionValue.cs
+++ b/src/Octokit.Webhooks/Events/Installation/InstallationActionValue.cs
@@ -1,5 +1,6 @@
 namespace Octokit.Webhooks.Events.Installation;
 
+[PublicAPI]
 public static class InstallationActionValue
 {
     public const string Created = "created";

--- a/src/Octokit.Webhooks/Events/InstallationRepositories/InstallationRepositoriesActionValue.cs
+++ b/src/Octokit.Webhooks/Events/InstallationRepositories/InstallationRepositoriesActionValue.cs
@@ -1,5 +1,6 @@
 namespace Octokit.Webhooks.Events.InstallationRepositories;
 
+[PublicAPI]
 public static class InstallationRepositoriesActionValue
 {
     public const string Added = "added";

--- a/src/Octokit.Webhooks/Events/InstallationTarget/InstallationTargetActionValue.cs
+++ b/src/Octokit.Webhooks/Events/InstallationTarget/InstallationTargetActionValue.cs
@@ -1,5 +1,6 @@
 namespace Octokit.Webhooks.Events.InstallationTarget;
 
+[PublicAPI]
 public static class InstallationTargetActionValue
 {
     public const string Renamed = "renamed";

--- a/src/Octokit.Webhooks/Events/IssueComment/IssueCommentActionValue.cs
+++ b/src/Octokit.Webhooks/Events/IssueComment/IssueCommentActionValue.cs
@@ -1,5 +1,6 @@
 namespace Octokit.Webhooks.Events.IssueComment;
 
+[PublicAPI]
 public static class IssueCommentActionValue
 {
     public const string Created = "created";

--- a/src/Octokit.Webhooks/Events/IssueDependencies/IssueDependenciesActionValue.cs
+++ b/src/Octokit.Webhooks/Events/IssueDependencies/IssueDependenciesActionValue.cs
@@ -1,5 +1,6 @@
 namespace Octokit.Webhooks.Events.IssueDependencies;
 
+[PublicAPI]
 public static class IssueDependenciesActionValue
 {
     public const string BlockedByAdded = "blocked_by_added";

--- a/src/Octokit.Webhooks/Events/Issues/IssuesActionValue.cs
+++ b/src/Octokit.Webhooks/Events/Issues/IssuesActionValue.cs
@@ -1,5 +1,6 @@
 namespace Octokit.Webhooks.Events.Issues;
 
+[PublicAPI]
 public static class IssuesActionValue
 {
     public const string Assigned = "assigned";

--- a/src/Octokit.Webhooks/Events/Label/LabelActionValue.cs
+++ b/src/Octokit.Webhooks/Events/Label/LabelActionValue.cs
@@ -1,5 +1,6 @@
 namespace Octokit.Webhooks.Events.Label;
 
+[PublicAPI]
 public static class LabelActionValue
 {
     public const string Created = "created";

--- a/src/Octokit.Webhooks/Events/MarketplacePurchase/MarketplacePurchaseActionValue.cs
+++ b/src/Octokit.Webhooks/Events/MarketplacePurchase/MarketplacePurchaseActionValue.cs
@@ -1,5 +1,6 @@
 namespace Octokit.Webhooks.Events.MarketplacePurchase;
 
+[PublicAPI]
 public static class MarketplacePurchaseActionValue
 {
     public const string Cancelled = "cancelled";

--- a/src/Octokit.Webhooks/Events/Member/MemberActionValue.cs
+++ b/src/Octokit.Webhooks/Events/Member/MemberActionValue.cs
@@ -1,5 +1,6 @@
 namespace Octokit.Webhooks.Events.Member;
 
+[PublicAPI]
 public static class MemberActionValue
 {
     public const string Added = "added";

--- a/src/Octokit.Webhooks/Events/Membership/MembershipActionValue.cs
+++ b/src/Octokit.Webhooks/Events/Membership/MembershipActionValue.cs
@@ -1,5 +1,6 @@
 namespace Octokit.Webhooks.Events.Membership;
 
+[PublicAPI]
 public static class MembershipActionValue
 {
     public const string Added = "added";

--- a/src/Octokit.Webhooks/Events/MergeGroup/MergeGroupActionValue.cs
+++ b/src/Octokit.Webhooks/Events/MergeGroup/MergeGroupActionValue.cs
@@ -1,5 +1,6 @@
 namespace Octokit.Webhooks.Events.MergeGroup;
 
+[PublicAPI]
 public static class MergeGroupActionValue
 {
     public const string ChecksRequested = "checks_requested";

--- a/src/Octokit.Webhooks/Events/MergeQueueEntry/MergeQueueEntryActionValue.cs
+++ b/src/Octokit.Webhooks/Events/MergeQueueEntry/MergeQueueEntryActionValue.cs
@@ -1,5 +1,6 @@
 namespace Octokit.Webhooks.Events.MergeQueueEntry;
 
+[PublicAPI]
 public static class MergeQueueEntryActionValue
 {
     public const string Created = "created";

--- a/src/Octokit.Webhooks/Events/Meta/MetaActionValue.cs
+++ b/src/Octokit.Webhooks/Events/Meta/MetaActionValue.cs
@@ -1,5 +1,6 @@
 namespace Octokit.Webhooks.Events.Meta;
 
+[PublicAPI]
 public static class MetaActionValue
 {
     public const string Deleted = "deleted";

--- a/src/Octokit.Webhooks/Events/Milestone/MilestoneActionValue.cs
+++ b/src/Octokit.Webhooks/Events/Milestone/MilestoneActionValue.cs
@@ -1,5 +1,6 @@
 namespace Octokit.Webhooks.Events.Milestone;
 
+[PublicAPI]
 public static class MilestoneActionValue
 {
     public const string Closed = "closed";

--- a/src/Octokit.Webhooks/Events/OrgBlock/OrgBlockActionValue.cs
+++ b/src/Octokit.Webhooks/Events/OrgBlock/OrgBlockActionValue.cs
@@ -1,5 +1,6 @@
 namespace Octokit.Webhooks.Events.OrgBlock;
 
+[PublicAPI]
 public static class OrgBlockActionValue
 {
     public const string Blocked = "blocked";

--- a/src/Octokit.Webhooks/Events/Organization/OrganizationActionValue.cs
+++ b/src/Octokit.Webhooks/Events/Organization/OrganizationActionValue.cs
@@ -1,5 +1,6 @@
 namespace Octokit.Webhooks.Events.Organization;
 
+[PublicAPI]
 public static class OrganizationActionValue
 {
     public const string Deleted = "deleted";

--- a/src/Octokit.Webhooks/Events/Package/PackageActionValue.cs
+++ b/src/Octokit.Webhooks/Events/Package/PackageActionValue.cs
@@ -1,5 +1,6 @@
 namespace Octokit.Webhooks.Events.Package;
 
+[PublicAPI]
 public static class PackageActionValue
 {
     public const string Published = "published";

--- a/src/Octokit.Webhooks/Events/PersonalAccessTokenRequest/PersonalAccessTokenRequestActionValue.cs
+++ b/src/Octokit.Webhooks/Events/PersonalAccessTokenRequest/PersonalAccessTokenRequestActionValue.cs
@@ -1,5 +1,6 @@
 namespace Octokit.Webhooks.Events.PersonalAccessTokenRequest;
 
+[PublicAPI]
 public static class PersonalAccessTokenRequestActionValue
 {
     public const string Approved = "approved";

--- a/src/Octokit.Webhooks/Events/Project/ProjectActionValue.cs
+++ b/src/Octokit.Webhooks/Events/Project/ProjectActionValue.cs
@@ -1,5 +1,6 @@
 namespace Octokit.Webhooks.Events.Project;
 
+[PublicAPI]
 public static class ProjectActionValue
 {
     public const string Closed = "closed";

--- a/src/Octokit.Webhooks/Events/ProjectCard/ProjectCardActionValue.cs
+++ b/src/Octokit.Webhooks/Events/ProjectCard/ProjectCardActionValue.cs
@@ -1,5 +1,6 @@
 namespace Octokit.Webhooks.Events.ProjectCard;
 
+[PublicAPI]
 public static class ProjectCardActionValue
 {
     public const string Converted = "converted";

--- a/src/Octokit.Webhooks/Events/ProjectColumn/ProjectColumnActionValue.cs
+++ b/src/Octokit.Webhooks/Events/ProjectColumn/ProjectColumnActionValue.cs
@@ -1,5 +1,6 @@
 namespace Octokit.Webhooks.Events.ProjectColumn;
 
+[PublicAPI]
 public static class ProjectColumnActionValue
 {
     public const string Created = "created";

--- a/src/Octokit.Webhooks/Events/ProjectsV2Item/ProjectsV2ItemActionValue.cs
+++ b/src/Octokit.Webhooks/Events/ProjectsV2Item/ProjectsV2ItemActionValue.cs
@@ -1,5 +1,6 @@
 namespace Octokit.Webhooks.Events.ProjectsV2Item;
 
+[PublicAPI]
 public static class ProjectsV2ItemActionValue
 {
     public const string Archived = "archived";

--- a/src/Octokit.Webhooks/Events/ProjectsV2Project/ProjectsV2ProjectActionValue.cs
+++ b/src/Octokit.Webhooks/Events/ProjectsV2Project/ProjectsV2ProjectActionValue.cs
@@ -1,5 +1,6 @@
 namespace Octokit.Webhooks.Events.ProjectsV2Project;
 
+[PublicAPI]
 public static class ProjectsV2ProjectActionValue
 {
     public const string Closed = "closed";

--- a/src/Octokit.Webhooks/Events/ProjectsV2StatusUpdate/ProjectsV2StatusUpdateActionValue.cs
+++ b/src/Octokit.Webhooks/Events/ProjectsV2StatusUpdate/ProjectsV2StatusUpdateActionValue.cs
@@ -1,5 +1,6 @@
 namespace Octokit.Webhooks.Events.ProjectsV2StatusUpdate;
 
+[PublicAPI]
 public static class ProjectsV2StatusUpdateActionValue
 {
     public const string Created = "created";

--- a/src/Octokit.Webhooks/Events/PullRequest/PullRequestActionValue.cs
+++ b/src/Octokit.Webhooks/Events/PullRequest/PullRequestActionValue.cs
@@ -1,5 +1,6 @@
 namespace Octokit.Webhooks.Events.PullRequest;
 
+[PublicAPI]
 public static class PullRequestActionValue
 {
     public const string Assigned = "assigned";

--- a/src/Octokit.Webhooks/Events/PullRequestReview/PullRequestReviewActionValue.cs
+++ b/src/Octokit.Webhooks/Events/PullRequestReview/PullRequestReviewActionValue.cs
@@ -1,5 +1,6 @@
 namespace Octokit.Webhooks.Events.PullRequestReview;
 
+[PublicAPI]
 public static class PullRequestReviewActionValue
 {
     public const string Dismissed = "dismissed";

--- a/src/Octokit.Webhooks/Events/PullRequestReviewComment/PullRequestReviewCommentActionValue.cs
+++ b/src/Octokit.Webhooks/Events/PullRequestReviewComment/PullRequestReviewCommentActionValue.cs
@@ -1,5 +1,6 @@
 namespace Octokit.Webhooks.Events.PullRequestReviewComment;
 
+[PublicAPI]
 public static class PullRequestReviewCommentActionValue
 {
     public const string Created = "created";

--- a/src/Octokit.Webhooks/Events/PullRequestReviewThread/PullRequestReviewThreadActionValue.cs
+++ b/src/Octokit.Webhooks/Events/PullRequestReviewThread/PullRequestReviewThreadActionValue.cs
@@ -1,5 +1,6 @@
 namespace Octokit.Webhooks.Events.PullRequestReviewThread;
 
+[PublicAPI]
 public static class PullRequestReviewThreadActionValue
 {
     public const string Resolved = "resolved";

--- a/src/Octokit.Webhooks/Events/RegistryPackage/RegistryPackageActionValue.cs
+++ b/src/Octokit.Webhooks/Events/RegistryPackage/RegistryPackageActionValue.cs
@@ -1,5 +1,6 @@
 namespace Octokit.Webhooks.Events.RegistryPackage;
 
+[PublicAPI]
 public static class RegistryPackageActionValue
 {
     public const string Published = "published";

--- a/src/Octokit.Webhooks/Events/Release/ReleaseActionValue.cs
+++ b/src/Octokit.Webhooks/Events/Release/ReleaseActionValue.cs
@@ -1,5 +1,6 @@
 namespace Octokit.Webhooks.Events.Release;
 
+[PublicAPI]
 public static class ReleaseActionValue
 {
     public const string Created = "created";

--- a/src/Octokit.Webhooks/Events/Repository/RepositoryActionValue.cs
+++ b/src/Octokit.Webhooks/Events/Repository/RepositoryActionValue.cs
@@ -1,5 +1,6 @@
 namespace Octokit.Webhooks.Events.Repository;
 
+[PublicAPI]
 public static class RepositoryActionValue
 {
     public const string Archived = "archived";

--- a/src/Octokit.Webhooks/Events/RepositoryAdvisory/RepositoryAdvisoryActionValue.cs
+++ b/src/Octokit.Webhooks/Events/RepositoryAdvisory/RepositoryAdvisoryActionValue.cs
@@ -1,5 +1,6 @@
 namespace Octokit.Webhooks.Events.RepositoryAdvisory;
 
+[PublicAPI]
 public static class RepositoryAdvisoryActionValue
 {
     public const string Reported = "reported";

--- a/src/Octokit.Webhooks/Events/RepositoryDispatch/RepositoryDispatchActionValue.cs
+++ b/src/Octokit.Webhooks/Events/RepositoryDispatch/RepositoryDispatchActionValue.cs
@@ -1,5 +1,6 @@
 namespace Octokit.Webhooks.Events.RepositoryDispatch;
 
+[PublicAPI]
 public static class RepositoryDispatchActionValue
 {
     public const string OnDemandTest = "on-demand-test";

--- a/src/Octokit.Webhooks/Events/RepositoryRuleset/RepositoryRulesetActionValue.cs
+++ b/src/Octokit.Webhooks/Events/RepositoryRuleset/RepositoryRulesetActionValue.cs
@@ -1,5 +1,6 @@
 namespace Octokit.Webhooks.Events.RepositoryRuleset;
 
+[PublicAPI]
 public static class RepositoryRulesetActionValue
 {
     public const string Created = "created";

--- a/src/Octokit.Webhooks/Events/RepositoryVulnerabilityAlert/RepositoryVulnerabilityAlertActionValue.cs
+++ b/src/Octokit.Webhooks/Events/RepositoryVulnerabilityAlert/RepositoryVulnerabilityAlertActionValue.cs
@@ -1,5 +1,6 @@
 namespace Octokit.Webhooks.Events.RepositoryVulnerabilityAlert;
 
+[PublicAPI]
 public static class RepositoryVulnerabilityAlertActionValue
 {
     public const string Create = "create";

--- a/src/Octokit.Webhooks/Events/SecretScanningAlert/SecretScanningAlertActionValue.cs
+++ b/src/Octokit.Webhooks/Events/SecretScanningAlert/SecretScanningAlertActionValue.cs
@@ -1,5 +1,6 @@
 namespace Octokit.Webhooks.Events.SecretScanningAlert;
 
+[PublicAPI]
 public static class SecretScanningAlertActionValue
 {
     public const string Created = "created";

--- a/src/Octokit.Webhooks/Events/SecretScanningAlertLocation/SecretScanningAlertLocationActionValue.cs
+++ b/src/Octokit.Webhooks/Events/SecretScanningAlertLocation/SecretScanningAlertLocationActionValue.cs
@@ -1,5 +1,6 @@
 namespace Octokit.Webhooks.Events.SecretScanningAlertLocation;
 
+[PublicAPI]
 public static class SecretScanningAlertLocationActionValue
 {
     public const string Created = "created";

--- a/src/Octokit.Webhooks/Events/SecretScanningScan/SecretScanningScanActionValue.cs
+++ b/src/Octokit.Webhooks/Events/SecretScanningScan/SecretScanningScanActionValue.cs
@@ -1,5 +1,6 @@
 namespace Octokit.Webhooks.Events.SecretScanningScan;
 
+[PublicAPI]
 public static class SecretScanningScanActionValue
 {
     public const string Completed = "completed";

--- a/src/Octokit.Webhooks/Events/SecurityAdvisory/SecurityAdvisoryActionValue.cs
+++ b/src/Octokit.Webhooks/Events/SecurityAdvisory/SecurityAdvisoryActionValue.cs
@@ -1,5 +1,6 @@
 namespace Octokit.Webhooks.Events.SecurityAdvisory;
 
+[PublicAPI]
 public static class SecurityAdvisoryActionValue
 {
     public const string Performed = "performed";

--- a/src/Octokit.Webhooks/Events/Sponsorship/SponsorshipActionValue.cs
+++ b/src/Octokit.Webhooks/Events/Sponsorship/SponsorshipActionValue.cs
@@ -1,5 +1,6 @@
 namespace Octokit.Webhooks.Events.Sponsorship;
 
+[PublicAPI]
 public static class SponsorshipActionValue
 {
     public const string Cancelled = "cancelled";

--- a/src/Octokit.Webhooks/Events/Star/StarActionValue.cs
+++ b/src/Octokit.Webhooks/Events/Star/StarActionValue.cs
@@ -1,5 +1,6 @@
 namespace Octokit.Webhooks.Events.Star;
 
+[PublicAPI]
 public static class StarActionValue
 {
     public const string Created = "created";

--- a/src/Octokit.Webhooks/Events/SubIssues/SubIssuesActionValue.cs
+++ b/src/Octokit.Webhooks/Events/SubIssues/SubIssuesActionValue.cs
@@ -1,5 +1,6 @@
 namespace Octokit.Webhooks.Events.SubIssues;
 
+[PublicAPI]
 public static class SubIssuesActionValue
 {
     public const string ParentIssueAdded = "parent_issue_added";

--- a/src/Octokit.Webhooks/Events/Team/TeamActionValue.cs
+++ b/src/Octokit.Webhooks/Events/Team/TeamActionValue.cs
@@ -1,5 +1,6 @@
 namespace Octokit.Webhooks.Events.Team;
 
+[PublicAPI]
 public static class TeamActionValue
 {
     public const string AddedToRepository = "added_to_repository";

--- a/src/Octokit.Webhooks/Events/Watch/WatchActionValue.cs
+++ b/src/Octokit.Webhooks/Events/Watch/WatchActionValue.cs
@@ -1,5 +1,6 @@
 namespace Octokit.Webhooks.Events.Watch;
 
+[PublicAPI]
 public static class WatchActionValue
 {
     public const string Started = "started";

--- a/src/Octokit.Webhooks/Events/WorkflowJob/WorkflowJobActionValue.cs
+++ b/src/Octokit.Webhooks/Events/WorkflowJob/WorkflowJobActionValue.cs
@@ -1,5 +1,6 @@
 namespace Octokit.Webhooks.Events.WorkflowJob;
 
+[PublicAPI]
 public static class WorkflowJobActionValue
 {
     public const string Queued = "queued";

--- a/src/Octokit.Webhooks/Events/WorkflowRun/WorkflowRunActionValue.cs
+++ b/src/Octokit.Webhooks/Events/WorkflowRun/WorkflowRunActionValue.cs
@@ -1,5 +1,6 @@
 namespace Octokit.Webhooks.Events.WorkflowRun;
 
+[PublicAPI]
 public static class WorkflowRunActionValue
 {
     public const string Completed = "completed";

--- a/src/Octokit.Webhooks/Models/DependabotEvent/DependabotAlertFirstPatchedVersion.cs
+++ b/src/Octokit.Webhooks/Models/DependabotEvent/DependabotAlertFirstPatchedVersion.cs
@@ -1,7 +1,7 @@
 namespace Octokit.Webhooks.Models.DependabotEvent;
 
 [PublicAPI]
-public class DependabotAlertFirstPatchedVersion
+public sealed record DependabotAlertFirstPatchedVersion
 {
     [JsonPropertyName("identifier")]
     public required string Identifier { get; init; }

--- a/src/Octokit.Webhooks/Models/ProjectsV2ItemEvent/ChangesFieldValueChangeBase.cs
+++ b/src/Octokit.Webhooks/Models/ProjectsV2ItemEvent/ChangesFieldValueChangeBase.cs
@@ -1,6 +1,7 @@
 namespace Octokit.Webhooks.Models.ProjectsV2ItemEvent;
 
 [JsonConverter(typeof(ChangesFieldValueChangeConverter))]
+[PublicAPI]
 public abstract record ChangesFieldValueChangeBase
 {
 }

--- a/src/Octokit.Webhooks/Models/RepositoryRulesetEvent/Changes.cs
+++ b/src/Octokit.Webhooks/Models/RepositoryRulesetEvent/Changes.cs
@@ -1,5 +1,6 @@
 namespace Octokit.Webhooks.Models.RepositoryRulesetEvent;
 
+[PublicAPI]
 public sealed record Changes
 {
     [JsonPropertyName("name")]

--- a/src/Octokit.Webhooks/Models/RepositoryRulesetEvent/ChangesConditions.cs
+++ b/src/Octokit.Webhooks/Models/RepositoryRulesetEvent/ChangesConditions.cs
@@ -1,5 +1,6 @@
 namespace Octokit.Webhooks.Models.RepositoryRulesetEvent;
 
+[PublicAPI]
 public sealed record ChangesConditions
 {
     [JsonPropertyName("added")]

--- a/src/Octokit.Webhooks/Models/RepositoryRulesetEvent/ChangesConditionsUpdated.cs
+++ b/src/Octokit.Webhooks/Models/RepositoryRulesetEvent/ChangesConditionsUpdated.cs
@@ -1,5 +1,6 @@
 namespace Octokit.Webhooks.Models.RepositoryRulesetEvent;
 
+[PublicAPI]
 public sealed record ChangesConditionsUpdated
 {
     [JsonPropertyName("condition")]

--- a/src/Octokit.Webhooks/Models/RepositoryRulesetEvent/ChangesConditionsUpdatedChanges.cs
+++ b/src/Octokit.Webhooks/Models/RepositoryRulesetEvent/ChangesConditionsUpdatedChanges.cs
@@ -1,5 +1,6 @@
 namespace Octokit.Webhooks.Models.RepositoryRulesetEvent;
 
+[PublicAPI]
 public sealed record ChangesConditionsUpdatedChanges
 {
     [JsonPropertyName("condition_type")]

--- a/src/Octokit.Webhooks/Models/RepositoryRulesetEvent/ChangesFrom.cs
+++ b/src/Octokit.Webhooks/Models/RepositoryRulesetEvent/ChangesFrom.cs
@@ -1,5 +1,6 @@
 namespace Octokit.Webhooks.Models.RepositoryRulesetEvent;
 
+[PublicAPI]
 public sealed record ChangesFrom
 {
     [JsonPropertyName("from")]

--- a/src/Octokit.Webhooks/Models/RepositoryRulesetEvent/ChangesFromArray.cs
+++ b/src/Octokit.Webhooks/Models/RepositoryRulesetEvent/ChangesFromArray.cs
@@ -1,5 +1,6 @@
 namespace Octokit.Webhooks.Models.RepositoryRulesetEvent;
 
+[PublicAPI]
 public sealed record ChangesFromArray
 {
     [JsonPropertyName("from")]

--- a/src/Octokit.Webhooks/WebHookEventType.cs
+++ b/src/Octokit.Webhooks/WebHookEventType.cs
@@ -1,5 +1,6 @@
 namespace Octokit.Webhooks;
 
+[PublicAPI]
 public static class WebhookEventType
 {
     public const string BranchProtectionConfiguration = "branch_protection_configuration";

--- a/src/Octokit.Webhooks/WebhookEventProcessor.cs
+++ b/src/Octokit.Webhooks/WebhookEventProcessor.cs
@@ -70,6 +70,7 @@ using Octokit.Webhooks.Events.Watch;
 using Octokit.Webhooks.Events.WorkflowJob;
 using Octokit.Webhooks.Events.WorkflowRun;
 
+[PublicAPI]
 public abstract class WebhookEventProcessor
 {
     [PublicAPI]

--- a/src/Octokit.Webhooks/WebhookHeaders.cs
+++ b/src/Octokit.Webhooks/WebhookHeaders.cs
@@ -2,6 +2,7 @@ namespace Octokit.Webhooks;
 
 using Microsoft.Extensions.Primitives;
 
+[PublicAPI]
 public sealed class WebhookHeaders
 {
     public string? UserAgent { get; init; }

--- a/src/Octokit.Webhooks/WebhookSignatureValidationResult.cs
+++ b/src/Octokit.Webhooks/WebhookSignatureValidationResult.cs
@@ -3,6 +3,7 @@ namespace Octokit.Webhooks;
 /// <summary>
 /// The result of validating a GitHub webhook signature.
 /// </summary>
+[PublicAPI]
 public enum WebhookSignatureValidationResult
 {
     /// <summary>

--- a/src/Octokit.Webhooks/WebhookSignatureValidator.cs
+++ b/src/Octokit.Webhooks/WebhookSignatureValidator.cs
@@ -7,6 +7,7 @@ using System.Text;
 /// <summary>
 /// Provides methods to verify GitHub webhook payload signatures.
 /// </summary>
+[PublicAPI]
 public static class WebhookSignatureValidator
 {
     private const string Prefix = "sha256=";


### PR DESCRIPTION
### Before the change?

* `DependabotAlertFirstPatchedVersion` was the only `class` in Models/ — everything else is a `sealed record`
* 82 public types were missing the `[PublicAPI]` attribute (mostly action event files and ActionValue classes)
* `GitHubWebhookOptions.cs` in the AspNetCore project still had a UTF-8 BOM

### After the change?

* `DependabotAlertFirstPatchedVersion` is now a `sealed record`
* Added `[PublicAPI]` to all 82 public types that were missing it
* Stripped the last BOM

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?

- [x] Yes
- [ ] No

* `DependabotAlertFirstPatchedVersion` changed from `class` to `sealed record`
