### PR TITLE
Use string interpolation in CustomProperty and CustomPropertyValue

### DIFF
--- a/src/Octokit.Webhooks/Models/CustomPropertyEvent/CustomProperty.cs
+++ b/src/Octokit.Webhooks/Models/CustomPropertyEvent/CustomProperty.cs
@@ -21,9 +21,9 @@ public sealed record CustomProperty
     public string? DefaultValue => this.Default switch
     {
         string str => str,
-        IEnumerable<string> strings => "[" + string.Join(",", strings) + "]",
+        IEnumerable<string> strings => $"[{string.Join(",", strings)}]",
         JsonElement { ValueKind: JsonValueKind.String } json => json.GetString(),
-        JsonElement { ValueKind: JsonValueKind.Array } json => "[" + string.Join(",", json.EnumerateArray().Select(e => e.GetString()!)) + "]",
+        JsonElement { ValueKind: JsonValueKind.Array } json => $"[{string.Join(",", json.EnumerateArray().Select(e => e.GetString()!))}]",
         _ => null,
     };
 

--- a/src/Octokit.Webhooks/Models/CustomPropertyValuesEvent/CustomPropertyValue.cs
+++ b/src/Octokit.Webhooks/Models/CustomPropertyValuesEvent/CustomPropertyValue.cs
@@ -14,9 +14,9 @@ public sealed record CustomPropertyValue
     public string? Value => this.Object switch
     {
         string str => str,
-        IEnumerable<string> strings => "[" + string.Join(",", strings) + "]",
+        IEnumerable<string> strings => $"[{string.Join(",", strings)}]",
         JsonElement { ValueKind: JsonValueKind.String } json => json.GetString(),
-        JsonElement { ValueKind: JsonValueKind.Array } json => "[" + string.Join(",", json.EnumerateArray().Select(e => e.GetString()!)) + "]",
+        JsonElement { ValueKind: JsonValueKind.Array } json => $"[{string.Join(",", json.EnumerateArray().Select(e => e.GetString()!))}]",
         _ => null,
     };
 


### PR DESCRIPTION
### Before the change?

* 4 string concatenation expressions using `"[" + string.Join(...) + "]"` in `CustomProperty.DefaultValue` and `CustomPropertyValue.Value`

### After the change?

* Replaced with `$"[{string.Join(...)}]"`

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?

- [ ] Yes
- [x] No
