### PR TITLE
Migrate to Microsoft.Testing.Platform

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -17,13 +17,11 @@
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.3.0"/>
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.7"/>
     <PackageVersion Include="Microsoft.Extensions.Primitives" Version="10.0.5"/>
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.4.0"/>
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.201"/>
     <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.14.15"/>
     <PackageVersion Include="MinVer" Version="7.0.0"/>
     <PackageVersion Include="Moq" Version="4.20.72"/>
     <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.556"/>
-    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5"/>
     <PackageVersion Include="xunit.v3" Version="3.2.2"/>
   </ItemGroup>
 

--- a/global.json
+++ b/global.json
@@ -3,5 +3,8 @@
     "rollForward": "latestFeature",
     "allowPrerelease": false,
     "version": "10.0.201"
+  },
+  "test": {
+    "runner": "Microsoft.Testing.Platform"
   }
 }

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -5,6 +5,7 @@
   <PropertyGroup Label="Build">
     <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
+    <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
   </PropertyGroup>
 
   <ItemGroup Label="Package References" Condition="'$(OutputType)' == 'Exe'">
@@ -13,12 +14,8 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="AwesomeAssertions" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk"/>
     <PackageReference Include="Moq"/>
     <PackageReference Include="xunit.v3"/>
-    <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="all">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
### Before the change?

* Tests ran on VSTest via `Microsoft.NET.Test.Sdk` and `xunit.runner.visualstudio`

### After the change?

* Tests run on Microsoft.Testing.Platform natively (xUnit v3 + .NET 10 SDK support this out of the box)
* Removed `Microsoft.NET.Test.Sdk` and `xunit.runner.visualstudio` — no longer needed
* Added `test.runner` to `global.json` and `UseMicrosoftTestingPlatformRunner` to test props

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?

- [ ] Yes
- [x] No
