### PR TITLE
Remove Microsoft.SourceLink.GitHub package

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -17,7 +17,6 @@
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.3.0"/>
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.7"/>
     <PackageVersion Include="Microsoft.Extensions.Primitives" Version="10.0.5"/>
-    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.201"/>
     <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.14.15"/>
     <PackageVersion Include="MinVer" Version="7.0.0"/>
     <PackageVersion Include="Moq" Version="4.20.72"/>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -27,10 +27,6 @@
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
   </PropertyGroup>
 
-  <ItemGroup Label="Package References">
-    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="all"/>
-  </ItemGroup>
-
   <ItemGroup Label="Files">
     <None Include="..\..\images\Icon.png" Pack="true" PackagePath="\"/>
     <None Include="..\..\README.md" Pack="true" PackagePath="\"/>


### PR DESCRIPTION
### Before the change?

* `Microsoft.SourceLink.GitHub` was explicitly referenced as a package dependency

### After the change?

* Removed the package — SourceLink for GitHub has been built into the .NET SDK since .NET 8
* The SourceLink properties (`PublishRepositoryUrl`, `EmbedUntrackedSources`, etc.) are kept since they still control behavior

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?

- [ ] Yes
- [x] No
