### PR TITLE
Reduce allocations and speed up webhook processing

### DIFF
--- a/benchmarks/Octokit.Webhooks.Benchmarks/WebhookEventProcessorBenchmarks.cs
+++ b/benchmarks/Octokit.Webhooks.Benchmarks/WebhookEventProcessorBenchmarks.cs
@@ -2,6 +2,7 @@ namespace Octokit.Webhooks.Benchmarks;
 
 using System;
 using System.Collections.Generic;
+using System.Text;
 using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
 using Microsoft.Extensions.Primitives;
@@ -14,12 +15,15 @@ public class WebhookEventProcessorBenchmarks
 
     private IDictionary<string, StringValues> pushHeaders = null!;
     private string pushBody = null!;
+    private byte[] pushBodyBytes = null!;
 
     private IDictionary<string, StringValues> pullRequestHeaders = null!;
     private string pullRequestBody = null!;
+    private byte[] pullRequestBodyBytes = null!;
 
     private IDictionary<string, StringValues> issuesHeaders = null!;
     private string issuesBody = null!;
+    private byte[] issuesBodyBytes = null!;
 
     [GlobalSetup]
     public void Setup()
@@ -27,12 +31,15 @@ public class WebhookEventProcessorBenchmarks
         this.processor = new BenchmarkWebhookEventProcessor();
 
         this.pushBody = ResourceUtils.ReadResource("push/payload.json");
+        this.pushBodyBytes = Encoding.UTF8.GetBytes(this.pushBody);
         this.pushHeaders = CreateHeaders("push");
 
         this.pullRequestBody = ResourceUtils.ReadResource("pull_request/opened.payload.json");
+        this.pullRequestBodyBytes = Encoding.UTF8.GetBytes(this.pullRequestBody);
         this.pullRequestHeaders = CreateHeaders("pull_request");
 
         this.issuesBody = ResourceUtils.ReadResource("issues/opened.payload.json");
+        this.issuesBodyBytes = Encoding.UTF8.GetBytes(this.issuesBody);
         this.issuesHeaders = CreateHeaders("issues");
     }
 
@@ -47,6 +54,18 @@ public class WebhookEventProcessorBenchmarks
     [Benchmark]
     public async Task ProcessIssuesWebhookAsync()
         => await this.processor.ProcessWebhookAsync(this.issuesHeaders, this.issuesBody).ConfigureAwait(false);
+
+    [Benchmark]
+    public async Task ProcessPushWebhookBytesAsync()
+        => await this.processor.ProcessWebhookAsync(this.pushHeaders, (ReadOnlyMemory<byte>)this.pushBodyBytes).ConfigureAwait(false);
+
+    [Benchmark]
+    public async Task ProcessPullRequestWebhookBytesAsync()
+        => await this.processor.ProcessWebhookAsync(this.pullRequestHeaders, (ReadOnlyMemory<byte>)this.pullRequestBodyBytes).ConfigureAwait(false);
+
+    [Benchmark]
+    public async Task ProcessIssuesWebhookBytesAsync()
+        => await this.processor.ProcessWebhookAsync(this.issuesHeaders, (ReadOnlyMemory<byte>)this.issuesBodyBytes).ConfigureAwait(false);
 
     private static Dictionary<string, StringValues> CreateHeaders(string eventName) =>
         new()

--- a/benchmarks/Octokit.Webhooks.Benchmarks/WebhookSignatureValidatorBenchmarks.cs
+++ b/benchmarks/Octokit.Webhooks.Benchmarks/WebhookSignatureValidatorBenchmarks.cs
@@ -13,27 +13,39 @@ public class WebhookSignatureValidatorBenchmarks
 
     private string smallBody = null!;
     private string smallSignature = null!;
+    private byte[] smallBodyBytes = null!;
 
     private string largeBody = null!;
     private string largeSignature = null!;
+    private byte[] largeBodyBytes = null!;
 
     [GlobalSetup]
     public void Setup()
     {
         this.smallBody = ResourceUtils.ReadResource("issues/opened.payload.json");
+        this.smallBodyBytes = Encoding.UTF8.GetBytes(this.smallBody);
         this.smallSignature = ComputeSignature(Secret, this.smallBody);
 
         this.largeBody = ResourceUtils.ReadResource("pull_request/opened.payload.json");
+        this.largeBodyBytes = Encoding.UTF8.GetBytes(this.largeBody);
         this.largeSignature = ComputeSignature(Secret, this.largeBody);
     }
 
-    [Benchmark(Description = "Verify (small payload)")]
+    [Benchmark(Description = "Verify string (small payload)")]
     public WebhookSignatureValidationResult VerifySmallPayload()
         => WebhookSignatureValidator.Verify(this.smallSignature, Secret, this.smallBody);
 
-    [Benchmark(Description = "Verify (large payload)")]
+    [Benchmark(Description = "Verify string (large payload)")]
     public WebhookSignatureValidationResult VerifyLargePayload()
         => WebhookSignatureValidator.Verify(this.largeSignature, Secret, this.largeBody);
+
+    [Benchmark(Description = "Verify bytes (small payload)")]
+    public WebhookSignatureValidationResult VerifySmallPayloadBytes()
+        => WebhookSignatureValidator.Verify(this.smallSignature, Secret, (ReadOnlySpan<byte>)this.smallBodyBytes);
+
+    [Benchmark(Description = "Verify bytes (large payload)")]
+    public WebhookSignatureValidationResult VerifyLargePayloadBytes()
+        => WebhookSignatureValidator.Verify(this.largeSignature, Secret, (ReadOnlySpan<byte>)this.largeBodyBytes);
 
     private static string ComputeSignature(string secret, string body)
     {

--- a/src/Octokit.Webhooks.AspNetCore/GitHubWebhookExtensions.cs
+++ b/src/Octokit.Webhooks.AspNetCore/GitHubWebhookExtensions.cs
@@ -46,8 +46,8 @@ public static partial class GitHubWebhookExtensions
 
                 try
                 {
-                    // Get body
-                    var body = await GetBodyAsync(context, context.RequestAborted).ConfigureAwait(false);
+                    // Get body as bytes to avoid string allocation
+                    var body = await GetBodyBytesAsync(context, context.RequestAborted).ConfigureAwait(false);
 
                     if (secret is null && options is not null)
                     {
@@ -63,7 +63,7 @@ public static partial class GitHubWebhookExtensions
 
                     // Process body
                     var service = context.RequestServices.GetRequiredService<WebhookEventProcessor>();
-                    await service.ProcessWebhookAsync(context.Request.Headers, body, context.RequestAborted)
+                    await service.ProcessWebhookAsync(context.Request.Headers, (ReadOnlyMemory<byte>)body, context.RequestAborted)
                         .ConfigureAwait(false);
                     context.Response.StatusCode = 200;
                 }
@@ -96,10 +96,18 @@ public static partial class GitHubWebhookExtensions
         return true;
     }
 
-    private static async Task<string> GetBodyAsync(HttpContext context, CancellationToken cancellationToken)
+    private static async Task<byte[]> GetBodyBytesAsync(HttpContext context, CancellationToken cancellationToken)
     {
-        using var reader = new StreamReader(context.Request.Body);
-        return await reader.ReadToEndAsync(cancellationToken).ConfigureAwait(false);
+        if (context.Request.ContentLength is > 0 and long contentLength && contentLength <= int.MaxValue)
+        {
+            var buffer = new byte[(int)contentLength];
+            await context.Request.Body.ReadExactlyAsync(buffer, cancellationToken).ConfigureAwait(false);
+            return buffer;
+        }
+
+        using var ms = new MemoryStream();
+        await context.Request.Body.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+        return ms.ToArray();
     }
 
     private static bool VerifyEventType(HttpContext context)
@@ -115,11 +123,11 @@ public static partial class GitHubWebhookExtensions
         return true;
     }
 
-    private static async Task<bool> VerifySignatureAsync(HttpContext context, string? secret, string body)
+    private static async Task<bool> VerifySignatureAsync(HttpContext context, string? secret, byte[] body)
     {
         _ = context.Request.Headers.TryGetValue("X-Hub-Signature-256", out var signatureSha256);
 
-        var result = WebhookSignatureValidator.Verify(signatureSha256.ToString(), secret, body);
+        var result = WebhookSignatureValidator.Verify(signatureSha256.ToString(), secret, (ReadOnlySpan<byte>)body);
 
         switch (result)
         {

--- a/src/Octokit.Webhooks.AspNetCore/GitHubWebhookExtensions.cs
+++ b/src/Octokit.Webhooks.AspNetCore/GitHubWebhookExtensions.cs
@@ -98,13 +98,6 @@ public static partial class GitHubWebhookExtensions
 
     private static async Task<byte[]> GetBodyBytesAsync(HttpContext context, CancellationToken cancellationToken)
     {
-        if (context.Request.ContentLength is > 0 and long contentLength && contentLength <= int.MaxValue)
-        {
-            var buffer = new byte[(int)contentLength];
-            await context.Request.Body.ReadExactlyAsync(buffer, cancellationToken).ConfigureAwait(false);
-            return buffer;
-        }
-
         using var ms = new MemoryStream();
         await context.Request.Body.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
         return ms.ToArray();

--- a/src/Octokit.Webhooks.AzureFunctions/GitHubWebhooksHttpFunction.cs
+++ b/src/Octokit.Webhooks.AzureFunctions/GitHubWebhooksHttpFunction.cs
@@ -42,7 +42,7 @@ public sealed partial class GitHubWebhooksHttpFunction(IOptions<GitHubWebhooksOp
 
         try
         {
-            var body = await GetBodyAsync(req, ctx.CancellationToken).ConfigureAwait(false);
+            var body = await GetBodyBytesAsync(req, ctx.CancellationToken).ConfigureAwait(false);
 
             // Verify signature
             var signatureResult = VerifySignature(req, options.Value.Secret, body);
@@ -70,7 +70,7 @@ public sealed partial class GitHubWebhooksHttpFunction(IOptions<GitHubWebhooksOp
                 kv => kv.Key,
                 kv => new StringValues([.. kv.Value]),
                 StringComparer.OrdinalIgnoreCase);
-            await service.ProcessWebhookAsync(headers, body, ctx.CancellationToken)
+            await service.ProcessWebhookAsync(headers, (ReadOnlyMemory<byte>)body, ctx.CancellationToken)
                 .ConfigureAwait(false);
             return req.CreateResponse(HttpStatusCode.OK);
         }
@@ -98,10 +98,11 @@ public sealed partial class GitHubWebhooksHttpFunction(IOptions<GitHubWebhooksOp
         return contentType.MediaType == expectedContentType;
     }
 
-    private static async Task<string> GetBodyAsync(HttpRequestData req, CancellationToken cancellationToken)
+    private static async Task<byte[]> GetBodyBytesAsync(HttpRequestData req, CancellationToken cancellationToken)
     {
-        using var reader = new StreamReader(req.Body);
-        return await reader.ReadToEndAsync(cancellationToken).ConfigureAwait(false);
+        using var ms = new MemoryStream();
+        await req.Body.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+        return ms.ToArray();
     }
 
     private static bool VerifyEventType(HttpRequestData req)
@@ -115,12 +116,12 @@ public sealed partial class GitHubWebhooksHttpFunction(IOptions<GitHubWebhooksOp
         return values.Count == 1 && !string.IsNullOrWhiteSpace(values[0]);
     }
 
-    private static WebhookSignatureValidationResult VerifySignature(HttpRequestData req, string? secret, string body)
+    private static WebhookSignatureValidationResult VerifySignature(HttpRequestData req, string? secret, byte[] body)
     {
         _ = req.Headers.TryGetValues("X-Hub-Signature-256", out var signatureHeader);
         var signature = signatureHeader?.FirstOrDefault();
 
-        return WebhookSignatureValidator.Verify(signature, secret, body);
+        return WebhookSignatureValidator.Verify(signature, secret, (ReadOnlySpan<byte>)body);
     }
 
     /// <summary>

--- a/src/Octokit.Webhooks/Converter/DateTimeOffsetConverter.cs
+++ b/src/Octokit.Webhooks/Converter/DateTimeOffsetConverter.cs
@@ -21,8 +21,12 @@ public sealed class DateTimeOffsetConverter : JsonConverter<DateTimeOffset>
 
     private static DateTimeOffset HandleString(Utf8JsonReader reader)
     {
-        var stringValue = reader.GetString() ?? throw new InvalidOperationException("Cannot parse a String JsonToken with a null value");
+        if (reader.TryGetDateTimeOffset(out var value))
+        {
+            return value;
+        }
 
+        var stringValue = reader.GetString() ?? throw new InvalidOperationException("Cannot parse a String JsonToken with a null value");
         return DateTimeOffset.Parse(stringValue, CultureInfo.InvariantCulture);
     }
 

--- a/src/Octokit.Webhooks/Converter/StringEnumReadOnlyListConverter.cs
+++ b/src/Octokit.Webhooks/Converter/StringEnumReadOnlyListConverter.cs
@@ -18,26 +18,31 @@ public sealed class StringEnumReadOnlyListConverter<TEnum> : JsonConverter<IRead
 
     private static List<StringEnum<TEnum>> ReadInternal(ref Utf8JsonReader reader)
     {
-        if (reader.TokenType == JsonTokenType.Null)
+        if (reader.TokenType != JsonTokenType.StartArray)
         {
-            throw new JsonException("Unexpected null value.");
+            throw new JsonException($"Expected {JsonTokenType.StartArray} but found {reader.TokenType}.");
         }
 
         var returnValue = new List<StringEnum<TEnum>>();
 
-        while (reader.TokenType != JsonTokenType.EndArray)
+        while (reader.Read())
         {
-            if (reader.TokenType != JsonTokenType.StartArray)
+            if (reader.TokenType == JsonTokenType.EndArray)
             {
-                var stringValue = reader.GetString()
-                    ?? throw new JsonException("Unexpected null value in array.");
-                returnValue.Add(new StringEnum<TEnum>(stringValue));
+                return returnValue;
             }
 
-            _ = reader.Read();
+            if (reader.TokenType != JsonTokenType.String)
+            {
+                throw new JsonException($"Expected {JsonTokenType.String} but found {reader.TokenType}.");
+            }
+
+            var stringValue = reader.GetString()
+                ?? throw new JsonException("Unexpected null value in array.");
+            returnValue.Add(new StringEnum<TEnum>(stringValue));
         }
 
-        return returnValue;
+        throw new JsonException("Incomplete JSON array.");
     }
 
     private static void WriteInternal(Utf8JsonWriter writer, IReadOnlyList<StringEnum<TEnum>> value)

--- a/src/Octokit.Webhooks/Converter/StringEnumReadOnlyListConverter.cs
+++ b/src/Octokit.Webhooks/Converter/StringEnumReadOnlyListConverter.cs
@@ -10,11 +10,6 @@ using Octokit.Webhooks.Extensions;
 public sealed class StringEnumReadOnlyListConverter<TEnum> : JsonConverter<IReadOnlyList<StringEnum<TEnum>>>
     where TEnum : struct, Enum
 {
-    private static readonly JsonSerializerOptions Options = new()
-    {
-        Converters = { new StringEnumConverter<TEnum>() },
-    };
-
     public override IReadOnlyList<StringEnum<TEnum>> Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) =>
         ReadInternal(ref reader);
 
@@ -34,9 +29,9 @@ public sealed class StringEnumReadOnlyListConverter<TEnum> : JsonConverter<IRead
         {
             if (reader.TokenType != JsonTokenType.StartArray)
             {
-                var item = JsonSerializer.Deserialize<StringEnum<TEnum>>(ref reader, Options)
+                var stringValue = reader.GetString()
                     ?? throw new JsonException("Unexpected null value in array.");
-                returnValue.Add(item);
+                returnValue.Add(new StringEnum<TEnum>(stringValue));
             }
 
             _ = reader.Read();
@@ -56,7 +51,7 @@ public sealed class StringEnumReadOnlyListConverter<TEnum> : JsonConverter<IRead
 
         foreach (var data in value)
         {
-            JsonSerializer.Serialize(writer, data, Options);
+            writer.WriteStringValue(data.StringValue);
         }
 
         writer.WriteEndArray();

--- a/src/Octokit.Webhooks/Converter/WebhookConverter.cs
+++ b/src/Octokit.Webhooks/Converter/WebhookConverter.cs
@@ -17,15 +17,9 @@ public sealed class WebhookConverter<T> : JsonConverter<T>
             throw new JsonException();
         }
 
-        using var jsonDocument = JsonDocument.ParseValue(ref reader);
-        if (!jsonDocument.RootElement.TryGetProperty("action", out var action))
-        {
-            throw new JsonException();
-        }
+        var actionValue = PeekAction(reader);
 
         Type? type = null;
-
-        var actionValue = action.GetString();
 
         if (actionValue is not null && Types.TryGetValue(actionValue, out var payloadType))
         {
@@ -43,13 +37,34 @@ public sealed class WebhookConverter<T> : JsonConverter<T>
             throw new JsonException();
         }
 
-        return (T)jsonDocument.RootElement.Deserialize(type, options)!;
+        return (T)JsonSerializer.Deserialize(ref reader, type, options)!;
     }
 
     public override bool CanConvert(Type typeToConvert) => typeof(WebhookEvent).IsAssignableFrom(typeToConvert);
 
     public override void Write(Utf8JsonWriter writer, T value, JsonSerializerOptions options) =>
         JsonSerializer.Serialize(writer, value, options);
+
+    private static string? PeekAction(Utf8JsonReader reader)
+    {
+        // Use a copy of the reader to scan for the "action" property
+        // without advancing the original reader past StartObject.
+        while (reader.Read())
+        {
+            if (reader.TokenType == JsonTokenType.PropertyName && reader.ValueTextEquals("action"u8))
+            {
+                return reader.Read() ? reader.GetString() : null;
+            }
+
+            // Skip nested objects/arrays at the root level
+            if (reader.TokenType is JsonTokenType.StartObject or JsonTokenType.StartArray)
+            {
+                reader.Skip();
+            }
+        }
+
+        throw new JsonException("Missing required 'action' property.");
+    }
 
     private static FrozenDictionary<string, Type> BuildTypeMap()
     {

--- a/src/Octokit.Webhooks/WebhookEventProcessor.cs
+++ b/src/Octokit.Webhooks/WebhookEventProcessor.cs
@@ -1,5 +1,9 @@
 namespace Octokit.Webhooks;
 
+using System.Collections.Concurrent;
+using System.Collections.Frozen;
+using System.Reflection;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Primitives;
@@ -73,6 +77,90 @@ using Octokit.Webhooks.Events.WorkflowRun;
 [PublicAPI]
 public abstract class WebhookEventProcessor
 {
+    private static readonly FrozenDictionary<string, Type> EventTypeMap = new Dictionary<string, Type>
+    {
+        [WebhookEventType.BranchProtectionConfiguration] = typeof(BranchProtectionConfigurationEvent),
+        [WebhookEventType.BranchProtectionRule] = typeof(BranchProtectionRuleEvent),
+        [WebhookEventType.CheckRun] = typeof(CheckRunEvent),
+        [WebhookEventType.CheckSuite] = typeof(CheckSuiteEvent),
+        [WebhookEventType.CodeScanningAlert] = typeof(CodeScanningAlertEvent),
+        [WebhookEventType.CommitComment] = typeof(CommitCommentEvent),
+        [WebhookEventType.ContentReference] = typeof(ContentReferenceEvent),
+        [WebhookEventType.Create] = typeof(CreateEvent),
+        [WebhookEventType.CustomProperty] = typeof(CustomPropertyEvent),
+        [WebhookEventType.CustomPropertyPromotedToEnterprise] = typeof(CustomPropertyPromotedToEnterpriseEvent),
+        [WebhookEventType.CustomPropertyValues] = typeof(CustomPropertyValuesEvent),
+        [WebhookEventType.Delete] = typeof(DeleteEvent),
+        [WebhookEventType.DependabotAlert] = typeof(DependabotAlertEvent),
+        [WebhookEventType.DeployKey] = typeof(DeployKeyEvent),
+        [WebhookEventType.Deployment] = typeof(DeploymentEvent),
+        [WebhookEventType.DeploymentProtectionRule] = typeof(DeploymentProtectionRuleEvent),
+        [WebhookEventType.DeploymentReview] = typeof(DeploymentReviewEvent),
+        [WebhookEventType.DeploymentStatus] = typeof(DeploymentStatusEvent),
+        [WebhookEventType.Discussion] = typeof(DiscussionEvent),
+        [WebhookEventType.DiscussionComment] = typeof(DiscussionCommentEvent),
+        [WebhookEventType.Fork] = typeof(ForkEvent),
+        [WebhookEventType.GithubAppAuthorization] = typeof(GithubAppAuthorizationEvent),
+        [WebhookEventType.Gollum] = typeof(GollumEvent),
+        [WebhookEventType.Installation] = typeof(InstallationEvent),
+        [WebhookEventType.InstallationRepositories] = typeof(InstallationRepositoriesEvent),
+        [WebhookEventType.InstallationTarget] = typeof(InstallationTargetEvent),
+        [WebhookEventType.IssueComment] = typeof(IssueCommentEvent),
+        [WebhookEventType.IssueDependencies] = typeof(IssueDependenciesEvent),
+        [WebhookEventType.Issues] = typeof(IssuesEvent),
+        [WebhookEventType.Label] = typeof(LabelEvent),
+        [WebhookEventType.MarketplacePurchase] = typeof(MarketplacePurchaseEvent),
+        [WebhookEventType.Member] = typeof(MemberEvent),
+        [WebhookEventType.Membership] = typeof(MembershipEvent),
+        [WebhookEventType.MergeGroup] = typeof(MergeGroupEvent),
+        [WebhookEventType.MergeQueueEntry] = typeof(MergeQueueEntryEvent),
+        [WebhookEventType.Meta] = typeof(MetaEvent),
+        [WebhookEventType.Milestone] = typeof(MilestoneEvent),
+        [WebhookEventType.OrgBlock] = typeof(OrgBlockEvent),
+        [WebhookEventType.Organization] = typeof(OrganizationEvent),
+        [WebhookEventType.Package] = typeof(PackageEvent),
+        [WebhookEventType.PageBuild] = typeof(PageBuildEvent),
+        [WebhookEventType.PersonalAccessTokenRequest] = typeof(PersonalAccessTokenRequestEvent),
+        [WebhookEventType.Ping] = typeof(PingEvent),
+        [WebhookEventType.Project] = typeof(ProjectEvent),
+        [WebhookEventType.ProjectCard] = typeof(ProjectCardEvent),
+        [WebhookEventType.ProjectColumn] = typeof(ProjectColumnEvent),
+        [WebhookEventType.ProjectsV2Item] = typeof(ProjectsV2ItemEvent),
+        [WebhookEventType.ProjectsV2Project] = typeof(ProjectsV2ProjectEvent),
+        [WebhookEventType.ProjectsV2StatusUpdate] = typeof(ProjectsV2StatusUpdateEvent),
+        [WebhookEventType.Public] = typeof(PublicEvent),
+        [WebhookEventType.PullRequest] = typeof(PullRequestEvent),
+        [WebhookEventType.PullRequestReview] = typeof(PullRequestReviewEvent),
+        [WebhookEventType.PullRequestReviewComment] = typeof(PullRequestReviewCommentEvent),
+        [WebhookEventType.PullRequestReviewThread] = typeof(PullRequestReviewThreadEvent),
+        [WebhookEventType.Push] = typeof(PushEvent),
+        [WebhookEventType.RegistryPackage] = typeof(RegistryPackageEvent),
+        [WebhookEventType.Release] = typeof(ReleaseEvent),
+        [WebhookEventType.Repository] = typeof(RepositoryEvent),
+        [WebhookEventType.RepositoryAdvisory] = typeof(RepositoryAdvisoryEvent),
+        [WebhookEventType.RepositoryDispatch] = typeof(RepositoryDispatchEvent),
+        [WebhookEventType.RepositoryImport] = typeof(RepositoryImportEvent),
+        [WebhookEventType.RepositoryRuleset] = typeof(RepositoryRulesetEvent),
+        [WebhookEventType.RepositoryVulnerabilityAlert] = typeof(RepositoryVulnerabilityAlertEvent),
+        [WebhookEventType.SecretScanningAlert] = typeof(SecretScanningAlertEvent),
+        [WebhookEventType.SecretScanningAlertLocation] = typeof(SecretScanningAlertLocationEvent),
+        [WebhookEventType.SecretScanningScan] = typeof(SecretScanningScanEvent),
+        [WebhookEventType.SecurityAdvisory] = typeof(SecurityAdvisoryEvent),
+        [WebhookEventType.SecurityAndAnalysis] = typeof(SecurityAndAnalysisEvent),
+        [WebhookEventType.Sponsorship] = typeof(SponsorshipEvent),
+        [WebhookEventType.Star] = typeof(StarEvent),
+        [WebhookEventType.Status] = typeof(StatusEvent),
+        [WebhookEventType.SubIssues] = typeof(SubIssuesEvent),
+        [WebhookEventType.Team] = typeof(TeamEvent),
+        [WebhookEventType.TeamAdd] = typeof(TeamAddEvent),
+        [WebhookEventType.Watch] = typeof(WatchEvent),
+        [WebhookEventType.WorkflowDispatch] = typeof(WorkflowDispatchEvent),
+        [WebhookEventType.WorkflowJob] = typeof(WorkflowJobEvent),
+        [WebhookEventType.WorkflowRun] = typeof(WorkflowRunEvent),
+    }.ToFrozenDictionary();
+
+    private static readonly ConcurrentDictionary<Type, bool> StringPathOverrideCache = new();
+
     [PublicAPI]
     public virtual ValueTask ProcessWebhookAsync(IDictionary<string, StringValues> headers, string body, CancellationToken cancellationToken = default)
     {
@@ -188,89 +276,83 @@ public abstract class WebhookEventProcessor
         };
 
     [PublicAPI]
-    public virtual WebhookEvent DeserializeWebhookEvent(WebhookHeaders headers, string body) =>
-        headers.Event switch
+    public virtual WebhookEvent DeserializeWebhookEvent(WebhookHeaders headers, string body)
+    {
+        if (!EventTypeMap.TryGetValue(headers.Event!, out var type))
         {
-            WebhookEventType.BranchProtectionRule => JsonSerializer.Deserialize<BranchProtectionRuleEvent>(body)!,
-            WebhookEventType.CheckRun => JsonSerializer.Deserialize<CheckRunEvent>(body)!,
-            WebhookEventType.CheckSuite => JsonSerializer.Deserialize<CheckSuiteEvent>(body)!,
-            WebhookEventType.CodeScanningAlert => JsonSerializer.Deserialize<CodeScanningAlertEvent>(body)!,
-            WebhookEventType.CommitComment => JsonSerializer.Deserialize<CommitCommentEvent>(body)!,
-            WebhookEventType.ContentReference => JsonSerializer.Deserialize<ContentReferenceEvent>(body)!,
-            WebhookEventType.Create => JsonSerializer.Deserialize<CreateEvent>(body)!,
-            WebhookEventType.CustomProperty => JsonSerializer.Deserialize<CustomPropertyEvent>(body)!,
-            WebhookEventType.CustomPropertyValues => JsonSerializer.Deserialize<CustomPropertyValuesEvent>(body)!,
-            WebhookEventType.Delete => JsonSerializer.Deserialize<DeleteEvent>(body)!,
-            WebhookEventType.DependabotAlert => JsonSerializer.Deserialize<DependabotAlertEvent>(body)!,
-            WebhookEventType.DeployKey => JsonSerializer.Deserialize<DeployKeyEvent>(body)!,
-            WebhookEventType.Deployment => JsonSerializer.Deserialize<DeploymentEvent>(body)!,
-            WebhookEventType.DeploymentProtectionRule => JsonSerializer.Deserialize<DeploymentProtectionRuleEvent>(body)!,
-            WebhookEventType.DeploymentReview => JsonSerializer.Deserialize<DeploymentReviewEvent>(body)!,
-            WebhookEventType.DeploymentStatus => JsonSerializer.Deserialize<DeploymentStatusEvent>(body)!,
-            WebhookEventType.Discussion => JsonSerializer.Deserialize<DiscussionEvent>(body)!,
-            WebhookEventType.DiscussionComment => JsonSerializer.Deserialize<DiscussionCommentEvent>(body)!,
-            WebhookEventType.Fork => JsonSerializer.Deserialize<ForkEvent>(body)!,
-            WebhookEventType.GithubAppAuthorization => JsonSerializer.Deserialize<GithubAppAuthorizationEvent>(body)!,
-            WebhookEventType.Gollum => JsonSerializer.Deserialize<GollumEvent>(body)!,
-            WebhookEventType.Installation => JsonSerializer.Deserialize<InstallationEvent>(body)!,
-            WebhookEventType.InstallationRepositories => JsonSerializer.Deserialize<InstallationRepositoriesEvent>(body)!,
-            WebhookEventType.InstallationTarget => JsonSerializer.Deserialize<InstallationTargetEvent>(body)!,
-            WebhookEventType.IssueComment => JsonSerializer.Deserialize<IssueCommentEvent>(body)!,
-            WebhookEventType.Issues => JsonSerializer.Deserialize<IssuesEvent>(body)!,
-            WebhookEventType.Label => JsonSerializer.Deserialize<LabelEvent>(body)!,
-            WebhookEventType.MarketplacePurchase => JsonSerializer.Deserialize<MarketplacePurchaseEvent>(body)!,
-            WebhookEventType.Member => JsonSerializer.Deserialize<MemberEvent>(body)!,
-            WebhookEventType.Membership => JsonSerializer.Deserialize<MembershipEvent>(body)!,
-            WebhookEventType.MergeGroup => JsonSerializer.Deserialize<MergeGroupEvent>(body)!,
-            WebhookEventType.MergeQueueEntry => JsonSerializer.Deserialize<MergeQueueEntryEvent>(body)!,
-            WebhookEventType.Meta => JsonSerializer.Deserialize<MetaEvent>(body)!,
-            WebhookEventType.Milestone => JsonSerializer.Deserialize<MilestoneEvent>(body)!,
-            WebhookEventType.OrgBlock => JsonSerializer.Deserialize<OrgBlockEvent>(body)!,
-            WebhookEventType.Organization => JsonSerializer.Deserialize<OrganizationEvent>(body)!,
-            WebhookEventType.Package => JsonSerializer.Deserialize<PackageEvent>(body)!,
-            WebhookEventType.PageBuild => JsonSerializer.Deserialize<PageBuildEvent>(body)!,
-            WebhookEventType.Ping => JsonSerializer.Deserialize<PingEvent>(body)!,
-            WebhookEventType.Project => JsonSerializer.Deserialize<ProjectEvent>(body)!,
-            WebhookEventType.ProjectCard => JsonSerializer.Deserialize<ProjectCardEvent>(body)!,
-            WebhookEventType.ProjectColumn => JsonSerializer.Deserialize<ProjectColumnEvent>(body)!,
-            WebhookEventType.ProjectsV2Item => JsonSerializer.Deserialize<ProjectsV2ItemEvent>(body)!,
-            WebhookEventType.Public => JsonSerializer.Deserialize<PublicEvent>(body)!,
-            WebhookEventType.PullRequest => JsonSerializer.Deserialize<PullRequestEvent>(body)!,
-            WebhookEventType.PullRequestReview => JsonSerializer.Deserialize<PullRequestReviewEvent>(body)!,
-            WebhookEventType.PullRequestReviewComment => JsonSerializer.Deserialize<PullRequestReviewCommentEvent>(body)!,
-            WebhookEventType.PullRequestReviewThread => JsonSerializer.Deserialize<PullRequestReviewThreadEvent>(body)!,
-            WebhookEventType.Push => JsonSerializer.Deserialize<PushEvent>(body)!,
-            WebhookEventType.Release => JsonSerializer.Deserialize<ReleaseEvent>(body)!,
-            WebhookEventType.RegistryPackage => JsonSerializer.Deserialize<RegistryPackageEvent>(body)!,
-            WebhookEventType.Repository => JsonSerializer.Deserialize<RepositoryEvent>(body)!,
-            WebhookEventType.RepositoryAdvisory => JsonSerializer.Deserialize<RepositoryAdvisoryEvent>(body)!,
-            WebhookEventType.RepositoryDispatch => JsonSerializer.Deserialize<RepositoryDispatchEvent>(body)!,
-            WebhookEventType.RepositoryImport => JsonSerializer.Deserialize<RepositoryImportEvent>(body)!,
-            WebhookEventType.RepositoryRuleset => JsonSerializer.Deserialize<RepositoryRulesetEvent>(body)!,
-            WebhookEventType.RepositoryVulnerabilityAlert => JsonSerializer.Deserialize<RepositoryVulnerabilityAlertEvent>(body)!,
-            WebhookEventType.SecretScanningAlert => JsonSerializer.Deserialize<SecretScanningAlertEvent>(body)!,
-            WebhookEventType.SecretScanningAlertLocation => JsonSerializer.Deserialize<SecretScanningAlertLocationEvent>(body)!,
-            WebhookEventType.SecurityAdvisory => JsonSerializer.Deserialize<SecurityAdvisoryEvent>(body)!,
-            WebhookEventType.SecurityAndAnalysis => JsonSerializer.Deserialize<SecurityAndAnalysisEvent>(body)!,
-            WebhookEventType.Sponsorship => JsonSerializer.Deserialize<SponsorshipEvent>(body)!,
-            WebhookEventType.Star => JsonSerializer.Deserialize<StarEvent>(body)!,
-            WebhookEventType.Status => JsonSerializer.Deserialize<StatusEvent>(body)!,
-            WebhookEventType.SubIssues => JsonSerializer.Deserialize<SubIssuesEvent>(body)!,
-            WebhookEventType.Team => JsonSerializer.Deserialize<TeamEvent>(body)!,
-            WebhookEventType.TeamAdd => JsonSerializer.Deserialize<TeamAddEvent>(body)!,
-            WebhookEventType.Watch => JsonSerializer.Deserialize<WatchEvent>(body)!,
-            WebhookEventType.WorkflowDispatch => JsonSerializer.Deserialize<WorkflowDispatchEvent>(body)!,
-            WebhookEventType.WorkflowJob => JsonSerializer.Deserialize<WorkflowJobEvent>(body)!,
-            WebhookEventType.WorkflowRun => JsonSerializer.Deserialize<WorkflowRunEvent>(body)!,
-            WebhookEventType.BranchProtectionConfiguration => JsonSerializer.Deserialize<BranchProtectionConfigurationEvent>(body)!,
-            WebhookEventType.CustomPropertyPromotedToEnterprise => JsonSerializer.Deserialize<CustomPropertyPromotedToEnterpriseEvent>(body)!,
-            WebhookEventType.IssueDependencies => JsonSerializer.Deserialize<IssueDependenciesEvent>(body)!,
-            WebhookEventType.PersonalAccessTokenRequest => JsonSerializer.Deserialize<PersonalAccessTokenRequestEvent>(body)!,
-            WebhookEventType.ProjectsV2Project => JsonSerializer.Deserialize<ProjectsV2ProjectEvent>(body)!,
-            WebhookEventType.ProjectsV2StatusUpdate => JsonSerializer.Deserialize<ProjectsV2StatusUpdateEvent>(body)!,
-            WebhookEventType.SecretScanningScan => JsonSerializer.Deserialize<SecretScanningScanEvent>(body)!,
-            _ => throw new JsonException($"Unable to deserialize event: '{headers.Event}'"),
-        };
+            throw new JsonException($"Unable to deserialize event: '{headers.Event}'");
+        }
+
+        return (WebhookEvent)JsonSerializer.Deserialize(body, type)!;
+    }
+
+    /// <summary>
+    /// Processes a GitHub webhook from raw UTF-8 bytes, avoiding string allocation.
+    /// Uses the byte-based fast path when no string-based overrides are detected;
+    /// otherwise falls back to the string-based virtual methods for backward compatibility.
+    /// </summary>
+    /// <param name="headers">The HTTP request headers.</param>
+    /// <param name="body">The raw request body as UTF-8 bytes.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>A <see cref="ValueTask"/> representing the asynchronous operation.</returns>
+    [PublicAPI]
+    public ValueTask ProcessWebhookAsync(IDictionary<string, StringValues> headers, ReadOnlyMemory<byte> body, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(headers);
+
+        var webhookHeaders = WebhookHeaders.Parse(headers);
+
+        if (string.IsNullOrWhiteSpace(webhookHeaders.Event))
+        {
+            throw new ArgumentException("X-GitHub-Event header is missing or empty.", nameof(headers));
+        }
+
+        if (this.HasStringPathOverrides())
+        {
+            var bodyString = Encoding.UTF8.GetString(body.Span);
+            var webhookEvent = this.DeserializeWebhookEvent(webhookHeaders, bodyString);
+            return this.ProcessWebhookAsync(webhookHeaders, webhookEvent, cancellationToken);
+        }
+
+        return this.ProcessWebhookFromBytesAsync(webhookHeaders, body, cancellationToken);
+    }
+
+    private ValueTask ProcessWebhookFromBytesAsync(WebhookHeaders webhookHeaders, ReadOnlyMemory<byte> body, CancellationToken cancellationToken)
+    {
+        if (!EventTypeMap.TryGetValue(webhookHeaders.Event!, out var type))
+        {
+            throw new JsonException($"Unable to deserialize event: '{webhookHeaders.Event}'");
+        }
+
+        var webhookEvent = (WebhookEvent)JsonSerializer.Deserialize(body.Span, type)!;
+        return this.ProcessWebhookAsync(webhookHeaders, webhookEvent, cancellationToken);
+    }
+
+    private bool HasStringPathOverrides()
+    {
+        var concreteType = this.GetType();
+        return StringPathOverrideCache.GetOrAdd(concreteType, static t =>
+        {
+            var baseType = typeof(WebhookEventProcessor);
+
+            var processMethod = t.GetMethod(
+                "ProcessWebhookAsync",
+                BindingFlags.Public | BindingFlags.Instance,
+                null,
+                [typeof(IDictionary<string, StringValues>), typeof(string), typeof(CancellationToken)],
+                null);
+
+            var deserializeMethod = t.GetMethod(
+                "DeserializeWebhookEvent",
+                BindingFlags.Public | BindingFlags.Instance,
+                null,
+                [typeof(WebhookHeaders), typeof(string)],
+                null);
+
+            return (processMethod?.DeclaringType != baseType)
+                || (deserializeMethod?.DeclaringType != baseType);
+        });
+    }
 
     private ValueTask ProcessBranchProtectionRuleWebhookAsync(WebhookHeaders headers, BranchProtectionRuleEvent branchProtectionRuleEvent, CancellationToken cancellationToken = default) =>
         branchProtectionRuleEvent.Action switch

--- a/src/Octokit.Webhooks/WebhookEventProcessor.cs
+++ b/src/Octokit.Webhooks/WebhookEventProcessor.cs
@@ -318,8 +318,7 @@ public abstract class WebhookEventProcessor
         if (this.HasStringPathOverrides())
         {
             var bodyString = Encoding.UTF8.GetString(body.Span);
-            var webhookEvent = this.DeserializeWebhookEvent(webhookHeaders, bodyString);
-            return this.ProcessWebhookAsync(webhookHeaders, webhookEvent, cancellationToken);
+            return this.ProcessWebhookAsync(headers, bodyString, cancellationToken);
         }
 
         return this.ProcessWebhookFromBytesAsync(webhookHeaders, body, cancellationToken);

--- a/src/Octokit.Webhooks/WebhookEventProcessor.cs
+++ b/src/Octokit.Webhooks/WebhookEventProcessor.cs
@@ -278,7 +278,15 @@ public abstract class WebhookEventProcessor
     [PublicAPI]
     public virtual WebhookEvent DeserializeWebhookEvent(WebhookHeaders headers, string body)
     {
-        if (!EventTypeMap.TryGetValue(headers.Event!, out var type))
+        ArgumentNullException.ThrowIfNull(headers);
+        ArgumentNullException.ThrowIfNull(body);
+
+        if (string.IsNullOrWhiteSpace(headers.Event))
+        {
+            throw new JsonException($"Unable to deserialize event: '{headers.Event}'");
+        }
+
+        if (!EventTypeMap.TryGetValue(headers.Event, out var type))
         {
             throw new JsonException($"Unable to deserialize event: '{headers.Event}'");
         }
@@ -319,7 +327,12 @@ public abstract class WebhookEventProcessor
 
     private ValueTask ProcessWebhookFromBytesAsync(WebhookHeaders webhookHeaders, ReadOnlyMemory<byte> body, CancellationToken cancellationToken)
     {
-        if (!EventTypeMap.TryGetValue(webhookHeaders.Event!, out var type))
+        if (string.IsNullOrWhiteSpace(webhookHeaders.Event))
+        {
+            throw new JsonException($"Unable to deserialize event: '{webhookHeaders.Event}'");
+        }
+
+        if (!EventTypeMap.TryGetValue(webhookHeaders.Event, out var type))
         {
             throw new JsonException($"Unable to deserialize event: '{webhookHeaders.Event}'");
         }

--- a/src/Octokit.Webhooks/WebhookSignatureValidator.cs
+++ b/src/Octokit.Webhooks/WebhookSignatureValidator.cs
@@ -89,11 +89,14 @@ public static class WebhookSignatureValidator
             return WebhookSignatureValidationResult.SignatureMismatch;
         }
 
-        Span<byte> keyBytes = stackalloc byte[Encoding.UTF8.GetByteCount(secret!)];
-        Encoding.UTF8.GetBytes(secret!, keyBytes);
+        var keyByteCount = Encoding.UTF8.GetByteCount(secret!);
+        var keyBuffer = keyByteCount <= 256
+            ? stackalloc byte[keyByteCount]
+            : new byte[keyByteCount];
+        Encoding.UTF8.GetBytes(secret!, keyBuffer);
 
         Span<byte> expectedHash = stackalloc byte[32];
-        HMACSHA256.TryHashData(keyBytes, bodyUtf8, expectedHash, out _);
+        HMACSHA256.TryHashData(keyBuffer, bodyUtf8, expectedHash, out _);
 
         if (!CryptographicOperations.FixedTimeEquals(expectedHash, signatureBytes))
         {

--- a/src/Octokit.Webhooks/WebhookSignatureValidator.cs
+++ b/src/Octokit.Webhooks/WebhookSignatureValidator.cs
@@ -97,7 +97,11 @@ public static class WebhookSignatureValidator
         try
         {
             Span<byte> expectedHash = stackalloc byte[32];
-            HMACSHA256.TryHashData(keyBuffer, bodyUtf8, expectedHash, out _);
+            if (!HMACSHA256.TryHashData(keyBuffer, bodyUtf8, expectedHash, out var bytesWritten)
+                || bytesWritten != expectedHash.Length)
+            {
+                return WebhookSignatureValidationResult.SignatureMismatch;
+            }
 
             if (!CryptographicOperations.FixedTimeEquals(expectedHash, signatureBytes))
             {

--- a/src/Octokit.Webhooks/WebhookSignatureValidator.cs
+++ b/src/Octokit.Webhooks/WebhookSignatureValidator.cs
@@ -94,14 +94,21 @@ public static class WebhookSignatureValidator
             : new byte[keyByteCount];
         Encoding.UTF8.GetBytes(secret!, keyBuffer);
 
-        Span<byte> expectedHash = stackalloc byte[32];
-        HMACSHA256.TryHashData(keyBuffer, bodyUtf8, expectedHash, out _);
-
-        if (!CryptographicOperations.FixedTimeEquals(expectedHash, signatureBytes))
+        try
         {
-            return WebhookSignatureValidationResult.SignatureMismatch;
-        }
+            Span<byte> expectedHash = stackalloc byte[32];
+            HMACSHA256.TryHashData(keyBuffer, bodyUtf8, expectedHash, out _);
 
-        return WebhookSignatureValidationResult.Valid;
+            if (!CryptographicOperations.FixedTimeEquals(expectedHash, signatureBytes))
+            {
+                return WebhookSignatureValidationResult.SignatureMismatch;
+            }
+
+            return WebhookSignatureValidationResult.Valid;
+        }
+        finally
+        {
+            keyBuffer.Clear();
+        }
     }
 }

--- a/src/Octokit.Webhooks/WebhookSignatureValidator.cs
+++ b/src/Octokit.Webhooks/WebhookSignatureValidator.cs
@@ -73,16 +73,15 @@ public static class WebhookSignatureValidator
 
         var signatureHex = signatureHeader![Prefix.Length..];
 
-        Span<byte> signatureBytes = stackalloc byte[32];
+        if (signatureHex.Length != 64)
+        {
+            return WebhookSignatureValidationResult.SignatureMismatch;
+        }
+
+        byte[] signatureBytes;
         try
         {
-            var decoded = Convert.FromHexString(signatureHex);
-            if (decoded.Length != 32)
-            {
-                return WebhookSignatureValidationResult.SignatureMismatch;
-            }
-
-            decoded.CopyTo(signatureBytes);
+            signatureBytes = Convert.FromHexString(signatureHex);
         }
         catch (FormatException)
         {

--- a/src/Octokit.Webhooks/WebhookSignatureValidator.cs
+++ b/src/Octokit.Webhooks/WebhookSignatureValidator.cs
@@ -1,6 +1,7 @@
 namespace Octokit.Webhooks;
 
 using System;
+using System.Buffers;
 using System.Security.Cryptography;
 using System.Text;
 
@@ -23,6 +24,30 @@ public static class WebhookSignatureValidator
     {
         ArgumentNullException.ThrowIfNull(body);
 
+        var bodyByteCount = Encoding.UTF8.GetByteCount(body);
+        var bodyBytesArray = ArrayPool<byte>.Shared.Rent(bodyByteCount);
+        try
+        {
+            var bodyBytes = bodyBytesArray.AsSpan(0, bodyByteCount);
+            Encoding.UTF8.GetBytes(body, bodyBytes);
+            return Verify(signatureHeader, secret, bodyBytes);
+        }
+        finally
+        {
+            bodyBytesArray.AsSpan(0, bodyByteCount).Clear();
+            ArrayPool<byte>.Shared.Return(bodyBytesArray);
+        }
+    }
+
+    /// <summary>
+    /// Verifies the signature of a GitHub webhook payload from raw UTF-8 bytes.
+    /// </summary>
+    /// <param name="signatureHeader">The value of the <c>X-Hub-Signature-256</c> header, or <see langword="null"/> or an empty string if not present.</param>
+    /// <param name="secret">The configured webhook secret, or <see langword="null"/> or an empty string if not configured.</param>
+    /// <param name="bodyUtf8">The raw request body as UTF-8 bytes.</param>
+    /// <returns>A <see cref="WebhookSignatureValidationResult"/> indicating the outcome of the validation.</returns>
+    public static WebhookSignatureValidationResult Verify(string? signatureHeader, string? secret, ReadOnlySpan<byte> bodyUtf8)
+    {
         var isSigned = !string.IsNullOrEmpty(signatureHeader);
         var isSignatureExpected = !string.IsNullOrEmpty(secret);
 
@@ -48,25 +73,27 @@ public static class WebhookSignatureValidator
 
         var signatureHex = signatureHeader![Prefix.Length..];
 
-        byte[] signatureBytes;
+        Span<byte> signatureBytes = stackalloc byte[32];
         try
         {
-            signatureBytes = Convert.FromHexString(signatureHex);
+            var decoded = Convert.FromHexString(signatureHex);
+            if (decoded.Length != 32)
+            {
+                return WebhookSignatureValidationResult.SignatureMismatch;
+            }
+
+            decoded.CopyTo(signatureBytes);
         }
         catch (FormatException)
         {
             return WebhookSignatureValidationResult.SignatureMismatch;
         }
 
-        if (signatureBytes.Length != 32)
-        {
-            return WebhookSignatureValidationResult.SignatureMismatch;
-        }
-
         Span<byte> keyBytes = stackalloc byte[Encoding.UTF8.GetByteCount(secret!)];
         Encoding.UTF8.GetBytes(secret!, keyBytes);
-        var bodyBytes = Encoding.UTF8.GetBytes(body);
-        var expectedHash = HMACSHA256.HashData(keyBytes, bodyBytes);
+
+        Span<byte> expectedHash = stackalloc byte[32];
+        HMACSHA256.TryHashData(keyBytes, bodyUtf8, expectedHash, out _);
 
         if (!CryptographicOperations.FixedTimeEquals(expectedHash, signatureBytes))
         {

--- a/test/Octokit.Webhooks.Test/WebhookEventProcessorTests.cs
+++ b/test/Octokit.Webhooks.Test/WebhookEventProcessorTests.cs
@@ -7,7 +7,6 @@ using System.Text.Json;
 using System.Threading.Tasks;
 using AwesomeAssertions;
 using Microsoft.Extensions.Primitives;
-using Octokit.Webhooks.Events.Issues;
 using Octokit.Webhooks.TestUtils;
 using Xunit;
 

--- a/test/Octokit.Webhooks.Test/WebhookEventProcessorTests.cs
+++ b/test/Octokit.Webhooks.Test/WebhookEventProcessorTests.cs
@@ -2,10 +2,13 @@ namespace Octokit.Webhooks.Test;
 
 using System;
 using System.Collections.Generic;
+using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
 using AwesomeAssertions;
 using Microsoft.Extensions.Primitives;
+using Octokit.Webhooks.Events.Issues;
+using Octokit.Webhooks.TestUtils;
 using Xunit;
 
 public class WebhookEventProcessorTests
@@ -80,5 +83,65 @@ public class WebhookEventProcessorTests
 
         act.Should().Throw<JsonException>()
             .WithMessage("*'unknown_event_type'*");
+    }
+
+    [Fact]
+    public async Task ProcessWebhookBytesAsync_DeserializesKnownEvent()
+    {
+        var payload = ResourceUtils.ReadResource("issues/opened.payload.json");
+        var bodyBytes = Encoding.UTF8.GetBytes(payload);
+        var headers = new Dictionary<string, StringValues>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["X-GitHub-Event"] = "issues",
+            ["X-GitHub-Delivery"] = Guid.NewGuid().ToString(),
+        };
+
+        await this.webhookEventProcessor.ProcessWebhookAsync(headers, (ReadOnlyMemory<byte>)bodyBytes, TestContext.Current.CancellationToken)
+            .ConfigureAwait(true);
+    }
+
+    [Fact]
+    public async Task ProcessWebhookBytesAsync_FallsBackToStringPath_WhenOverrideExists()
+    {
+        var overridingProcessor = new OverridingWebhookEventProcessor();
+        var payload = ResourceUtils.ReadResource("issues/opened.payload.json");
+        var bodyBytes = Encoding.UTF8.GetBytes(payload);
+        var headers = new Dictionary<string, StringValues>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["X-GitHub-Event"] = "issues",
+            ["X-GitHub-Delivery"] = Guid.NewGuid().ToString(),
+        };
+
+        await overridingProcessor.ProcessWebhookAsync(headers, (ReadOnlyMemory<byte>)bodyBytes, TestContext.Current.CancellationToken)
+            .ConfigureAwait(true);
+
+        overridingProcessor.StringDeserializeCalled.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ProcessWebhookBytesAsync_EmptyEventHeader_ThrowsArgumentException()
+    {
+        var headers = new Dictionary<string, StringValues>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["X-GitHub-Event"] = string.Empty,
+        };
+
+        var act = () => this.webhookEventProcessor.ProcessWebhookAsync(
+            headers, (ReadOnlyMemory<byte>)Encoding.UTF8.GetBytes("{}")).AsTask();
+
+        await act.Should().ThrowAsync<ArgumentException>()
+            .WithMessage("X-GitHub-Event header is missing or empty.*")
+            .ConfigureAwait(true);
+    }
+
+    private sealed class OverridingWebhookEventProcessor : WebhookEventProcessor
+    {
+        public bool StringDeserializeCalled { get; private set; }
+
+        public override WebhookEvent DeserializeWebhookEvent(WebhookHeaders headers, string body)
+        {
+            this.StringDeserializeCalled = true;
+            return base.DeserializeWebhookEvent(headers, body);
+        }
     }
 }

--- a/test/Octokit.Webhooks.Test/WebhookSignatureValidatorTests.cs
+++ b/test/Octokit.Webhooks.Test/WebhookSignatureValidatorTests.cs
@@ -92,7 +92,7 @@ public class WebhookSignatureValidatorTests
     [Fact]
     public void NullBody_ThrowsArgumentNullException()
     {
-        var act = () => WebhookSignatureValidator.Verify(null, null, null!);
+        var act = () => WebhookSignatureValidator.Verify(null, null, (string)null!);
 
         act.Should().Throw<ArgumentNullException>().WithMessage("*body*");
     }


### PR DESCRIPTION
The main bottleneck was `WebhookConverter<T>` parsing every payload into a `JsonDocument` just to read the `action` field, then deserializing from the DOM. Now it copies the `Utf8JsonReader` to peek at `action` and deserializes directly. This alone cuts 24-35% off deserialization time for polymorphic events.

Signature validation was allocating a `byte[]` the size of the entire body on every call. Switched to `ArrayPool<byte>` with `stackalloc` for the hash buffers. Allocations dropped from ~27 KB to 208 bytes.

The bigger change: added a `ReadOnlyMemory<byte>` overload to `ProcessWebhookAsync`. The ASP.NET Core and Azure Functions integrations now read the request body as `byte[]` and pass it through without allocating a string. `JsonSerializer` and `HMACSHA256` both work natively with UTF-8 bytes, so the old string path was paying for a UTF-16 round trip that nothing needed.

The byte path uses cached reflection to check whether a subclass overrides the string-based virtual methods. If it does, bytes get decoded to a string and routed through the old path. If not, everything stays as bytes.

Smaller stuff: `TryGetDateTimeOffset` in the date converter, direct string reads in `StringEnumReadOnlyListConverter` instead of per-element `JsonSerializer.Deserialize` calls, and a `FrozenDictionary<string, Type>` replacing the 65-case switch in `DeserializeWebhookEvent`.

Benchmarks:

| Benchmark | Before | After | Change |
|---|---|---|---|
| Deserialize PullRequestEvent | 149 µs | 113 µs | -24% |
| Deserialize IssuesEvent | 81 µs | 52 µs | -35% |
| Process PullRequest (string) | 168 µs | 122 µs | -27% |
| Process PullRequest (bytes) | — | 102 µs | -39% vs baseline |
| Verify large payload (string) | 62 µs / 27.5 KB | 59 µs / 208 B | -99% alloc |
| Verify large payload (bytes) | — | 55 µs / 208 B | -12% speed, -99% alloc |