### PR TITLE
Check GetBytes return value in signature validator

### DIFF
--- a/src/Octokit.Webhooks/WebhookSignatureValidator.cs
+++ b/src/Octokit.Webhooks/WebhookSignatureValidator.cs
@@ -92,13 +92,14 @@ public static class WebhookSignatureValidator
         var keyBuffer = keyByteCount <= 256
             ? stackalloc byte[keyByteCount]
             : new byte[keyByteCount];
-        if (Encoding.UTF8.GetBytes(secret!, keyBuffer) != keyByteCount)
-        {
-            return WebhookSignatureValidationResult.SignatureMismatch;
-        }
 
         try
         {
+            if (Encoding.UTF8.GetBytes(secret!, keyBuffer) != keyByteCount)
+            {
+                return WebhookSignatureValidationResult.SignatureMismatch;
+            }
+
             Span<byte> expectedHash = stackalloc byte[32];
             if (!HMACSHA256.TryHashData(keyBuffer, bodyUtf8, expectedHash, out var bytesWritten)
                 || bytesWritten != expectedHash.Length)

--- a/src/Octokit.Webhooks/WebhookSignatureValidator.cs
+++ b/src/Octokit.Webhooks/WebhookSignatureValidator.cs
@@ -92,7 +92,10 @@ public static class WebhookSignatureValidator
         var keyBuffer = keyByteCount <= 256
             ? stackalloc byte[keyByteCount]
             : new byte[keyByteCount];
-        Encoding.UTF8.GetBytes(secret!, keyBuffer);
+        if (Encoding.UTF8.GetBytes(secret!, keyBuffer) != keyByteCount)
+        {
+            return WebhookSignatureValidationResult.SignatureMismatch;
+        }
 
         try
         {


### PR DESCRIPTION
Follow-up to #886. `Encoding.UTF8.GetBytes` returns the number of bytes written but we were not checking it. Now returns `SignatureMismatch` if the count does not match.