### PR TITLE
Fix `SponsorshipTier.IsCustomAmmount`

### DIFF
--- a/src/Octokit.Webhooks/Models/SponsorshipEvent/SponsorshipTier.cs
+++ b/src/Octokit.Webhooks/Models/SponsorshipEvent/SponsorshipTier.cs
@@ -27,4 +27,8 @@ public sealed record SponsorshipTier
 
     [JsonPropertyName("is_custom_amount")]
     public bool IsCustomAmount { get; init; }
+
+    [JsonPropertyName("is_custom_ammount")]
+    [Obsolete("The property name is misspelled. Use IsCustomAmount instead.")]
+    public bool IsCustomAmmount { get => this.IsCustomAmount; init => this.IsCustomAmount = value; }
 }

--- a/src/Octokit.Webhooks/Models/SponsorshipEvent/SponsorshipTier.cs
+++ b/src/Octokit.Webhooks/Models/SponsorshipEvent/SponsorshipTier.cs
@@ -25,6 +25,6 @@ public sealed record SponsorshipTier
     [JsonPropertyName("is_one_time")]
     public bool IsOneTime { get; init; }
 
-    [JsonPropertyName("is_custom_ammount")]
-    public bool IsCustomAmmount { get; init; }
+    [JsonPropertyName("is_custom_amount")]
+    public bool IsCustomAmount { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/SponsorshipEvent/SponsorshipTier.cs
+++ b/src/Octokit.Webhooks/Models/SponsorshipEvent/SponsorshipTier.cs
@@ -28,7 +28,7 @@ public sealed record SponsorshipTier
     [JsonPropertyName("is_custom_amount")]
     public bool IsCustomAmount { get; init; }
 
-    [JsonPropertyName("is_custom_ammount")]
+    [JsonIgnore]
     [Obsolete("The property name is misspelled. Use IsCustomAmount instead.")]
     public bool IsCustomAmmount { get => this.IsCustomAmount; init => this.IsCustomAmount = value; }
 }


### PR DESCRIPTION
Resolves #916

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

The json property name "is_custom_ammount" was previously correct, but now the webhook returns objects using the proper spelling, so the repository code needs changed.

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

I added a new property with the correct `JsonPropertyName` and marked the old property as obsolete.

### Pull request checklist

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

----