### PR TITLE
Fix code_scanning_alert Alert model

### DIFF
--- a/src/Octokit.Webhooks/Models/CodeScanningAlertEvent/Alert.cs
+++ b/src/Octokit.Webhooks/Models/CodeScanningAlertEvent/Alert.cs
@@ -10,6 +10,10 @@ public sealed record Alert
     [JsonConverter(typeof(DateTimeOffsetConverter))]
     public DateTimeOffset CreatedAt { get; init; }
 
+    [JsonPropertyName("updated_at")]
+    [JsonConverter(typeof(NullableDateTimeOffsetConverter))]
+    public DateTimeOffset? UpdatedAt { get; init; }
+
     [JsonPropertyName("url")]
     public required string Url { get; init; }
 
@@ -17,17 +21,23 @@ public sealed record Alert
     public required string HtmlUrl { get; init; }
 
     [JsonPropertyName("instances")]
-    public required IReadOnlyList<AlertInstance> Instances { get; init; }
+    public IReadOnlyList<AlertInstance>? Instances { get; init; }
+
+    [JsonPropertyName("instances_url")]
+    public string? InstancesUrl { get; init; }
 
     [JsonPropertyName("most_recent_instance")]
     public AlertInstance? AlertInstance { get; init; }
 
     [JsonPropertyName("state")]
     [JsonConverter(typeof(StringEnumConverter<AlertState>))]
-    public required StringEnum<AlertState> State { get; init; }
+    public StringEnum<AlertState>? State { get; init; }
 
     [JsonPropertyName("dismissed_by")]
     public User? DismissedBy { get; init; }
+
+    [JsonPropertyName("dismissal_approved_by")]
+    public User? DismissalApprovedBy { get; init; }
 
     [JsonPropertyName("dismissed_at")]
     [JsonConverter(typeof(NullableDateTimeOffsetConverter))]
@@ -37,9 +47,19 @@ public sealed record Alert
     [JsonConverter(typeof(StringEnumConverter<DismissedReason>))]
     public StringEnum<DismissedReason>? DismissedReason { get; init; }
 
+    [JsonPropertyName("dismissed_comment")]
+    public string? DismissedComment { get; init; }
+
+    [JsonPropertyName("fixed_at")]
+    [JsonConverter(typeof(NullableDateTimeOffsetConverter))]
+    public DateTimeOffset? FixedAt { get; init; }
+
     [JsonPropertyName("rule")]
     public AlertRule? Rule { get; init; }
 
     [JsonPropertyName("tool")]
     public required AlertTool Tool { get; init; }
+
+    [JsonPropertyName("assignees")]
+    public IReadOnlyList<User>? Assignees { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/CodeScanningAlertEvent/AlertInstance.cs
+++ b/src/Octokit.Webhooks/Models/CodeScanningAlertEvent/AlertInstance.cs
@@ -9,6 +9,9 @@ public sealed record AlertInstance
     [JsonPropertyName("analysis_key")]
     public required string AnalysisKey { get; init; }
 
+    [JsonPropertyName("category")]
+    public string? Category { get; init; }
+
     [JsonPropertyName("environment")]
     public required string Environment { get; init; }
 

--- a/src/Octokit.Webhooks/Models/CodeScanningAlertEvent/AlertRule.cs
+++ b/src/Octokit.Webhooks/Models/CodeScanningAlertEvent/AlertRule.cs
@@ -6,9 +6,15 @@ public sealed record AlertRule
     [JsonPropertyName("id")]
     public required string Id { get; init; }
 
+    [JsonPropertyName("name")]
+    public string? Name { get; init; }
+
     [JsonPropertyName("severity")]
     [JsonConverter(typeof(StringEnumConverter<AlertRuleSeverity>))]
     public StringEnum<AlertRuleSeverity>? Severity { get; init; }
+
+    [JsonPropertyName("security_severity_level")]
+    public string? SecuritySeverityLevel { get; init; }
 
     [JsonPropertyName("description")]
     public required string Description { get; init; }
@@ -21,4 +27,7 @@ public sealed record AlertRule
 
     [JsonPropertyName("help")]
     public string? Help { get; init; }
+
+    [JsonPropertyName("help_uri")]
+    public string? HelpUri { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/CodeScanningAlertEvent/AlertRuleSeverity.cs
+++ b/src/Octokit.Webhooks/Models/CodeScanningAlertEvent/AlertRuleSeverity.cs
@@ -4,7 +4,7 @@ namespace Octokit.Webhooks.Models.CodeScanningAlertEvent;
 public enum AlertRuleSeverity
 {
     [EnumMember(Value = "none")]
-    Open,
+    None,
     [EnumMember(Value = "note")]
     Note,
     [EnumMember(Value = "warning")]

--- a/test/Octokit.Webhooks.Test/Resources/code_scanning_alert/created.with-instances-url.payload.json
+++ b/test/Octokit.Webhooks.Test/Resources/code_scanning_alert/created.with-instances-url.payload.json
@@ -1,0 +1,163 @@
+{
+  "action": "created",
+  "alert": {
+    "number": 1,
+    "created_at": "2026-06-26T03:52:44Z",
+    "updated_at": "2026-06-26T03:52:44Z",
+    "url": "https://api.github.com/repos/example-org/example-repository/code-scanning/alerts/1",
+    "html_url": "https://github.com/example-org/example-repository/security/code-scanning/1",
+    "state": null,
+    "fixed_at": null,
+    "dismissed_by": null,
+    "dismissed_at": null,
+    "dismissed_reason": null,
+    "dismissed_comment": null,
+    "rule": {
+      "id": "CVE-2026-42496",
+      "severity": "warning",
+      "description": "perl-archive-tar: perl-archive-tar: Path traversal via crafted symlinks allows arbitrary file access",
+      "name": "OsPackageVulnerability",
+      "tags": [
+        "MEDIUM",
+        "security",
+        "vulnerability"
+      ],
+      "full_description": "Archive::Tar versions before 3.08 for Perl extract symlinks with attacker controlled targets outside the extraction directory.\n\n_make_special_file() passes the tar header's linkname to symlink() without validating it against absolute paths or .. segments. The secure-extract mode check that guards regular file extraction does not cover the symlink target.\n\nA subsequent open through the extracted name reads or writes the attacker chosen path.",
+      "help": "**Vulnerability CVE-2026-42496**\n| Severity | Package | Fixed Version | Link |\n| --- | --- | --- | --- |\n|MEDIUM|perl-base|5.38.2-3.2ubuntu0.3|[CVE-2026-42496](https://avd.aquasec.com/nvd/cve-2026-42496)|\n\nArchive::Tar versions before 3.08 for Perl extract symlinks with attacker controlled targets outside the extraction directory.\n\n_make_special_file() passes the tar header's linkname to symlink() without validating it against absolute paths or .. segments. The secure-extract mode check that guards regular file extraction does not cover the symlink target.\n\nA subsequent open through the extracted name reads or writes the attacker chosen path.",
+      "help_uri": "https://avd.aquasec.com/nvd/cve-2026-42496",
+      "security_severity_level": "medium"
+    },
+    "tool": {
+      "name": "Trivy (docker)",
+      "guid": null,
+      "version": "0.71.2"
+    },
+    "most_recent_instance": {
+      "ref": "refs/pull/1/merge",
+      "analysis_key": ".github/workflows/sast.yml:analyse",
+      "environment": "{}",
+      "category": ".github/workflows/sast.yml:analyse",
+      "state": "open",
+      "commit_sha": "abc123def456789",
+      "message": {
+        "text": "Package: perl-base\nInstalled Version: 5.38.2-3.2ubuntu0.2\nVulnerability CVE-2026-42496\nSeverity: MEDIUM\nFixed Version: 5.38.2-3.2ubuntu0.3\nLink: [CVE-2026-42496](https://avd.aquasec.com/nvd/cve-2026-42496)"
+      },
+      "location": {
+        "path": "artifact/container-ExampleService.Api-0.1.0-PullRequest.1-1-merge-abc123d-0001.tar",
+        "start_line": 1,
+        "end_line": 1,
+        "start_column": 1,
+        "end_column": 1
+      },
+      "classifications": [
+        "library"
+      ]
+    },
+    "instances_url": "https://api.github.com/repos/example-org/example-repository/code-scanning/alerts/1/instances",
+    "dismissal_approved_by": null,
+    "assignees": []
+  },
+  "ref": "refs/pull/1/merge",
+  "commit_oid": "abc123def456789",
+  "repository": {
+    "id": 123456789,
+    "node_id": "R_kgDOExampleId",
+    "name": "example-repository",
+    "full_name": "example-org/example-repository",
+    "private": true,
+    "owner": {
+      "login": "example-org",
+      "id": 123456789,
+      "node_id": "O_kgDOExampleId",
+      "avatar_url": "https://avatars.githubusercontent.com/u/123456789?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/example-org",
+      "html_url": "https://github.com/example-org",
+      "type": "Organization",
+      "user_view_type": "public",
+      "site_admin": false
+    },
+    "html_url": "https://github.com/example-org/example-repository",
+    "description": "Example repository description",
+    "fork": false,
+    "url": "https://api.github.com/repos/example-org/example-repository",
+    "created_at": "2026-01-01T00:00:00Z",
+    "updated_at": "2026-06-24T23:51:03Z",
+    "pushed_at": "2026-06-26T03:21:47Z",
+    "git_url": "git://github.com/example-org/example-repository.git",
+    "ssh_url": "git@github.com:example-org/example-repository.git",
+    "clone_url": "https://github.com/example-org/example-repository.git",
+    "svn_url": "https://github.com/example-org/example-repository",
+    "homepage": "",
+    "size": 27602,
+    "stargazers_count": 1,
+    "watchers_count": 1,
+    "language": "C#",
+    "has_issues": false,
+    "has_projects": true,
+    "has_downloads": true,
+    "has_wiki": true,
+    "has_pages": false,
+    "has_discussions": false,
+    "forks_count": 0,
+    "mirror_url": null,
+    "archived": false,
+    "disabled": false,
+    "open_issues_count": 16,
+    "license": null,
+    "allow_forking": false,
+    "is_template": false,
+    "web_commit_signoff_required": false,
+    "has_pull_requests": true,
+    "pull_request_creation_policy": "all",
+    "topics": [],
+    "visibility": "internal",
+    "forks": 0,
+    "open_issues": 16,
+    "watchers": 1,
+    "default_branch": "develop",
+    "custom_properties": {
+      "Allow-Copilot-PR-reviews": "true",
+      "Automated-Permissions": "true",
+      "Conventional-Commits": "false",
+      "FileUpdater-Gitattributes-Sync": "true",
+      "FileUpdater-SAST-Sync": "true",
+      "ForcePRSquashing": "true",
+      "RepositoryType": "System",
+      "Strict-Git-Rules": "true",
+      "Strict-PR-Approvals": "false"
+    }
+  },
+  "organization": {
+    "login": "example-org",
+    "id": 123456789,
+    "node_id": "O_kgDOExampleId",
+    "url": "https://api.github.com/orgs/example-org",
+    "avatar_url": "https://avatars.githubusercontent.com/u/123456789?v=4",
+    "description": ""
+  },
+  "enterprise": {
+    "id": 1,
+    "slug": "example-enterprise",
+    "name": "Example Enterprise",
+    "node_id": "E_kgDOExampleId",
+    "avatar_url": "https://avatars.githubusercontent.com/b/1?v=4",
+    "description": "",
+    "website_url": "",
+    "html_url": "https://github.com/enterprises/example-enterprise",
+    "created_at": "2026-01-01T00:00:00Z",
+    "updated_at": "2026-06-01T00:00:00Z"
+  },
+  "sender": {
+    "login": "github",
+    "id": 1,
+    "node_id": "MDEyOk9yZ2FuaXphdGlvbjE=",
+    "avatar_url": "https://avatars.githubusercontent.com/u/1?v=4",
+    "gravatar_id": "",
+    "url": "https://api.github.com/users/github",
+    "html_url": "https://github.com/github",
+    "type": "Organization",
+    "user_view_type": "public",
+    "site_admin": false
+  }
+}


### PR DESCRIPTION
Resolves #927

----

### Before the change?

* `Alert` required `instances`, which GitHub dropped from the payload (now `instances_url`), so deserialization threw a `JsonException`. `state` is now sent as `null` too.

### After the change?

* `Instances` is optional and `State` is nullable, plus the new payload fields are added: `InstancesUrl`, `UpdatedAt`, `FixedAt`, `DismissedComment`, `DismissalApprovedBy`, `Assignees`, rule `Name`/`HelpUri`/`SecuritySeverityLevel`, and instance `Category`. Added a `created` regression fixture.

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [x] Yes
- [ ] No

----
