### PR TITLE
Fix `projects_v2_item.edited` deserialization for newer "announcement" type payloads

### DIFF
--- a/src/Octokit.Webhooks/Models/ProjectsV2ItemEvent/ChangesFieldValue.cs
+++ b/src/Octokit.Webhooks/Models/ProjectsV2ItemEvent/ChangesFieldValue.cs
@@ -17,8 +17,8 @@ public sealed record ChangesFieldValue
     public long ProjectNumber { get; init; }
 
     [JsonPropertyName("from")]
-    public required ChangesFieldValueChangeBase From { get; init; }
+    public ChangesFieldValueChangeBase? From { get; init; }
 
     [JsonPropertyName("to")]
-    public required ChangesFieldValueChangeBase To { get; init; }
+    public ChangesFieldValueChangeBase? To { get; init; }
 }

--- a/src/Octokit.Webhooks/Models/ProjectsV2ItemEvent/FieldType.cs
+++ b/src/Octokit.Webhooks/Models/ProjectsV2ItemEvent/FieldType.cs
@@ -13,4 +13,10 @@ public enum FieldType
     Text,
     [EnumMember(Value = "iteration")]
     Iteration,
+    [EnumMember(Value = "assignees")]
+    Assignees,
+    [EnumMember(Value = "reviewers")]
+    Reviewers,
+    [EnumMember(Value = "labels")]
+    Labels,
 }

--- a/test/Octokit.Webhooks.Test/Resources/projects_v2_item/edited.reviewers.payload.json
+++ b/test/Octokit.Webhooks.Test/Resources/projects_v2_item/edited.reviewers.payload.json
@@ -1,0 +1,75 @@
+{
+  "action": "edited",
+  "projects_v2_item": {
+    "id": 5678510,
+    "node_id": "PVTI_lADOAWcTxs07G84AVqWu",
+    "project_node_id": "PVT_kwDOAWcTxs07Gw",
+    "content_node_id": "DI_lADOAWcTxs07G84AIjOy",
+    "content_type": "DraftIssue",
+    "creator": {
+      "login": "wolfy1339",
+      "id": 4595477,
+      "node_id": "MDQ6VXNlcjQ1OTU0Nzc=",
+      "avatar_url": "https://avatars.githubusercontent.com/u/4595477?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/wolfy1339",
+      "html_url": "https://github.com/wolfy1339",
+      "followers_url": "https://api.github.com/users/wolfy1339/followers",
+      "following_url": "https://api.github.com/users/wolfy1339/following{/other_user}",
+      "gists_url": "https://api.github.com/users/wolfy1339/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/wolfy1339/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/wolfy1339/subscriptions",
+      "organizations_url": "https://api.github.com/users/wolfy1339/orgs",
+      "repos_url": "https://api.github.com/users/wolfy1339/repos",
+      "events_url": "https://api.github.com/users/wolfy1339/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/wolfy1339/received_events",
+      "type": "User",
+      "site_admin": false
+    },
+    "created_at": "2022-06-08T20:34:26Z",
+    "updated_at": "2022-06-08T20:34:26Z",
+    "archived_at": null
+  },
+  "changes": {
+    "field_value": {
+      "field_node_id": "PVTF_lADOAEzhac4BfZF1zhZsTpY",
+      "field_type": "reviewers",
+      "field_name": "Reviewers",
+      "project_number": 429
+    }
+  },
+  "organization": {
+    "login": "Octocoders",
+    "id": 38302899,
+    "node_id": "MDEyOk9yZ2FuaXphdGlvbjM4MzAyODk5",
+    "url": "https://api.github.com/orgs/Octocoders",
+    "repos_url": "https://api.github.com/orgs/Octocoders/repos",
+    "events_url": "https://api.github.com/orgs/Octocoders/events",
+    "hooks_url": "https://api.github.com/orgs/Octocoders/hooks",
+    "issues_url": "https://api.github.com/orgs/Octocoders/issues",
+    "members_url": "https://api.github.com/orgs/Octocoders/members{/member}",
+    "public_members_url": "https://api.github.com/orgs/Octocoders/public_members{/member}",
+    "avatar_url": "https://avatars1.githubusercontent.com/u/38302899?v=4",
+    "description": ""
+  },
+  "sender": {
+    "login": "wolfy1339",
+    "id": 4595477,
+    "node_id": "MDQ6VXNlcjQ1OTU0Nzc=",
+    "avatar_url": "https://avatars.githubusercontent.com/u/4595477?v=4",
+    "gravatar_id": "",
+    "url": "https://api.github.com/users/wolfy1339",
+    "html_url": "https://github.com/wolfy1339",
+    "followers_url": "https://api.github.com/users/wolfy1339/followers",
+    "following_url": "https://api.github.com/users/wolfy1339/following{/other_user}",
+    "gists_url": "https://api.github.com/users/wolfy1339/gists{/gist_id}",
+    "starred_url": "https://api.github.com/users/wolfy1339/starred{/owner}{/repo}",
+    "subscriptions_url": "https://api.github.com/users/wolfy1339/subscriptions",
+    "organizations_url": "https://api.github.com/users/wolfy1339/orgs",
+    "repos_url": "https://api.github.com/users/wolfy1339/repos",
+    "events_url": "https://api.github.com/users/wolfy1339/events{/privacy}",
+    "received_events_url": "https://api.github.com/users/wolfy1339/received_events",
+    "type": "User",
+    "site_admin": false
+  }
+}


### PR DESCRIPTION
Does not resolve any open bug issue but I can create one if necessary.

----

### Before the change?

There appear to be new styles of `projects_v2_item.edited` payloads that are failing to deserialize because the `From` and `To` properties of `ChangesFieldValue` are marked non-nullable required, but do not exist in these payloads:

Here are observed `changes` sections of payloads that are failing to deserialize for us:

```
// Assignees
  "changes": {
    "field_value": {
      "field_node_id": "PVTF_lADOAEzhac4BY9lUzhT_o3E",
      "field_type": "assignees",
      "field_name": "Assignees",
      "project_number": 412
    }
  },

// Reviewers
  "changes": {
    "field_value": {
      "field_node_id": "PVTF_lADOAEzhac4BfZF1zhZsTpY",
      "field_type": "reviewers",
      "field_name": "Reviewers",
      "project_number": 429
    }
  },

// Status
  "changes": {
    "field_value": {
      "field_node_id": "PVTSSF_lADOAEzhac4BCwZTzg03-OQ",
      "field_type": "single_select",
      "field_name": "Status",
      "project_number": 338
    }
  },

// Labels
  "changes": {
    "field_value": {
      "field_node_id": "PVTF_lADOAEzhac4AUKrZzgM4jL0",
      "field_type": "labels",
      "field_name": "Labels",
      "project_number": 175
    }
  },
```

These appear to be general announcements to inform project item webhook listeners that assignees/reviewers/status/labels of the attached issue/PR have changed, without making the webhook payload format even more complex by including that information that can be looked up in other ways.

### After the change?

After the change, these payloads deserialize cleanly, although the consumer must be aware the `From` and `To` properties could now potentially be null.

Also, the missing `FieldType` enum values have been added, so that the associated `StringEnum` property does not throw when accessing the `Value`.

I don't know if there are more of these types of announcement payload shapes that would include other field types, I'm only going by the webhooks that I have seen fail to deserialize in our environment.

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

