### PR TITLE
Allow custom webhook exception handling

### DIFF
--- a/Octokit.Webhooks.slnx
+++ b/Octokit.Webhooks.slnx
@@ -47,6 +47,7 @@
   <Folder Name="/test/">
     <File Path="test/.editorconfig" />
     <File Path="test/Directory.Build.props" />
+    <Project Path="test/Octokit.Webhooks.AspNetCore.Test/Octokit.Webhooks.AspNetCore.Test.csproj" />
     <Project Path="test/Octokit.Webhooks.AzureFunctions.Test/Octokit.Webhooks.AzureFunctions.Test.csproj" />
     <Project Path="test/Octokit.Webhooks.Test/Octokit.Webhooks.Test.csproj" />
     <Project Path="test/Octokit.Webhooks.TestUtils/Octokit.Webhooks.TestUtils.csproj" />

--- a/README.md
+++ b/README.md
@@ -50,6 +50,29 @@ Libraries to handle GitHub Webhooks in .NET applications.
 * `path`. Defaults to `/api/github/webhooks`, the URL of the endpoint to use for GitHub.
 * `secret`. The secret you have configured in GitHub, if you have set this up.
 
+By default, exceptions thrown while processing a webhook are logged and return
+HTTP 500. Configure `GitHubWebhookOptions.ExceptionHandler` to handle specific
+exceptions and control the response:
+
+```C#
+builder.Services.Configure<GitHubWebhookOptions>(options =>
+{
+    options.ExceptionHandler = (exception, context) =>
+    {
+        if (exception is JsonException)
+        {
+            context.Response.StatusCode = StatusCodes.Status400BadRequest;
+            return ValueTask.FromResult(true);
+        }
+
+        return ValueTask.FromResult(false);
+    };
+});
+```
+
+Returning `true` means the callback has completed the response. Returning
+`false` uses the default HTTP 500 behavior.
+
 ### Azure Functions
 
 **NOTE**: Support is only provided for [isolated process Azure Functions](https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide).

--- a/samples/AspNetCore/Program.cs
+++ b/samples/AspNetCore/Program.cs
@@ -1,6 +1,9 @@
 #pragma warning disable CA1852
+using System.Text.Json;
+using System.Threading.Tasks;
 using AspNetCore;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Octokit.Webhooks;
 using Octokit.Webhooks.AspNetCore;
@@ -8,6 +11,19 @@ using Octokit.Webhooks.AspNetCore;
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddSingleton<WebhookEventProcessor, MyWebhookEventProcessor>();
+builder.Services.Configure<GitHubWebhookOptions>(options =>
+{
+    options.ExceptionHandler = (exception, context) =>
+    {
+        if (exception is JsonException)
+        {
+            context.Response.StatusCode = StatusCodes.Status400BadRequest;
+            return ValueTask.FromResult(true);
+        }
+
+        return ValueTask.FromResult(false);
+    };
+});
 
 var app = builder.Build();
 

--- a/src/Octokit.Webhooks.AspNetCore/GitHubWebhookExtensions.cs
+++ b/src/Octokit.Webhooks.AspNetCore/GitHubWebhookExtensions.cs
@@ -73,6 +73,12 @@ public static partial class GitHubWebhookExtensions
                 }
                 catch (Exception ex)
                 {
+                    if (options?.CurrentValue.ExceptionHandler is { } exceptionHandler
+                        && await exceptionHandler(ex, context).ConfigureAwait(false))
+                    {
+                        return;
+                    }
+
                     Log.ProcessingFailed(logger, ex);
                     context.Response.StatusCode = 500;
                 }

--- a/src/Octokit.Webhooks.AspNetCore/GitHubWebhookOptions.cs
+++ b/src/Octokit.Webhooks.AspNetCore/GitHubWebhookOptions.cs
@@ -1,6 +1,19 @@
 namespace Octokit.Webhooks.AspNetCore;
 
+using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+
 public record GitHubWebhookOptions
 {
     public string? Secret { get; set; }
+
+    /// <summary>
+    /// Gets or sets a callback for handling exceptions thrown while processing a webhook.
+    /// </summary>
+    /// <remarks>
+    /// The callback must return <see langword="true"/> if it handled the exception and completed the HTTP response.
+    /// Returning <see langword="false"/> uses the default behavior of logging the exception and returning HTTP 500.
+    /// </remarks>
+    public Func<Exception, HttpContext, ValueTask<bool>>? ExceptionHandler { get; set; }
 }

--- a/test/Octokit.Webhooks.AspNetCore.Test/GitHubWebhookExtensionsTests.cs
+++ b/test/Octokit.Webhooks.AspNetCore.Test/GitHubWebhookExtensionsTests.cs
@@ -1,0 +1,143 @@
+namespace Octokit.Webhooks.AspNetCore.Test;
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using AwesomeAssertions;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Primitives;
+using Xunit;
+
+public class GitHubWebhookExtensionsTests
+{
+    [Fact]
+    public async Task ProcessingException_WithoutHandler_ReturnsInternalServerError()
+    {
+        var exception = new InvalidOperationException();
+
+        var context = await InvokeEndpointAsync(
+            exception,
+            cancellationToken: TestContext.Current.CancellationToken).ConfigureAwait(true);
+
+        context.Response.StatusCode.Should().Be(StatusCodes.Status500InternalServerError);
+    }
+
+    [Fact]
+    public async Task ProcessingException_HandlerReturnsFalse_ReturnsInternalServerError()
+    {
+        var exception = new InvalidOperationException();
+        Exception? actualException = null;
+        HttpContext? actualContext = null;
+
+        var context = await InvokeEndpointAsync(
+            exception,
+            (caughtException, httpContext) =>
+            {
+                actualException = caughtException;
+                actualContext = httpContext;
+                return ValueTask.FromResult(false);
+            },
+            TestContext.Current.CancellationToken).ConfigureAwait(true);
+
+        context.Response.StatusCode.Should().Be(StatusCodes.Status500InternalServerError);
+        actualException.Should().BeSameAs(exception);
+        actualContext.Should().BeSameAs(context);
+    }
+
+    [Fact]
+    public async Task ProcessingException_HandlerReturnsTrue_PreservesResponse()
+    {
+        var exception = new InvalidOperationException();
+
+        var context = await InvokeEndpointAsync(
+            exception,
+            (_, httpContext) =>
+            {
+                httpContext.Response.StatusCode = StatusCodes.Status400BadRequest;
+                return ValueTask.FromResult(true);
+            },
+            TestContext.Current.CancellationToken).ConfigureAwait(true);
+
+        context.Response.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
+    }
+
+    [Fact]
+    public async Task RequestCancelled_DoesNotInvokeHandler()
+    {
+        var handlerInvoked = false;
+        using var cancellationTokenSource = new CancellationTokenSource();
+        await cancellationTokenSource.CancelAsync().ConfigureAwait(true);
+
+        _ = await InvokeEndpointAsync(
+            new InvalidOperationException(),
+            (_, _) =>
+            {
+                handlerInvoked = true;
+                return ValueTask.FromResult(true);
+            },
+            cancellationTokenSource.Token).ConfigureAwait(true);
+
+        handlerInvoked.Should().BeFalse();
+    }
+
+    private static async Task<DefaultHttpContext> InvokeEndpointAsync(
+        Exception exception,
+        Func<Exception, HttpContext, ValueTask<bool>>? exceptionHandler = null,
+        CancellationToken cancellationToken = default)
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddRouting();
+        services.AddSingleton<WebhookEventProcessor>(new ThrowingWebhookEventProcessor(exception));
+
+        if (exceptionHandler is not null)
+        {
+            services.Configure<GitHubWebhookOptions>(options => options.ExceptionHandler = exceptionHandler);
+        }
+
+        await using var serviceProvider = services.BuildServiceProvider();
+        var routeBuilder = new TestEndpointRouteBuilder(serviceProvider);
+        routeBuilder.MapGitHubWebhooks();
+
+        var endpoint = routeBuilder.DataSources
+            .SelectMany(dataSource => dataSource.Endpoints)
+            .OfType<RouteEndpoint>()
+            .Single();
+
+        var context = new DefaultHttpContext
+        {
+            RequestServices = serviceProvider,
+        };
+        context.Request.ContentType = "application/json";
+        context.Request.Headers["X-GitHub-Event"] = "issues";
+        context.Request.Body = new MemoryStream("{}"u8.ToArray());
+        context.RequestAborted = cancellationToken;
+
+        await endpoint.RequestDelegate!(context).ConfigureAwait(true);
+        return context;
+    }
+
+    private sealed class ThrowingWebhookEventProcessor(Exception exception) : WebhookEventProcessor
+    {
+        public override ValueTask ProcessWebhookAsync(
+            IDictionary<string, StringValues> headers,
+            string body,
+            CancellationToken cancellationToken = default) =>
+            ValueTask.FromException(exception);
+    }
+
+    private sealed class TestEndpointRouteBuilder(IServiceProvider serviceProvider) : IEndpointRouteBuilder
+    {
+        public ICollection<EndpointDataSource> DataSources { get; } = [];
+
+        public IServiceProvider ServiceProvider { get; } = serviceProvider;
+
+        public IApplicationBuilder CreateApplicationBuilder() => new ApplicationBuilder(this.ServiceProvider);
+    }
+}

--- a/test/Octokit.Webhooks.AspNetCore.Test/Octokit.Webhooks.AspNetCore.Test.csproj
+++ b/test/Octokit.Webhooks.AspNetCore.Test/Octokit.Webhooks.AspNetCore.Test.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup Label="Build">
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup Label="Project References">
+    <ProjectReference Include="..\..\src\Octokit.Webhooks.AspNetCore\Octokit.Webhooks.AspNetCore.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Adds an optional async exception handler to `GitHubWebhookOptions`. A handler can set the HTTP response and return `true`. Unhandled exceptions keep the existing logged HTTP 500 response.

Fixes #962